### PR TITLE
chore: Rename taskworker -> taskbroker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "taskworker"
+name = "taskbroker"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "taskworker"
+name = "taskbroker"
 version = "0.1.0"
 edition = "2021"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN apt-get update && \
 
 EXPOSE 3000
 
-COPY --from=build /opt/src/target/release/taskworker /opt/taskworker
-CMD ["/opt/taskworker"]
+COPY --from=build /opt/src/target/release/taskbroker /opt/taskbroker
+CMD ["/opt/taskbroker"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
-# Taskworker
+# Taskbroker
 
-Taskworker is a kafka consumer + rpc application that will be the heart of asynchronous task execution at sentry.
+taskbroker provides the Kafka consumer, RPC interface, and task storage that are
+the future heart of asynchronous task execution at sentry.
+
+Task Producers and Workers can be found in `sentry.taskworker`. The sentry API
+server and taskbroker communicate using protobufs. Tasks are serialized into
+protobuf messages and appended to Kafka topics by sentry. From there, taskbroker
+consumes from the Kafka topic and stores tasks into a small SQLite database. The
+SQLite database enables workers to competitively consume from the Kafka topic
+enabling out of order message processing and per message awknowledgements.

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,7 +72,7 @@ impl Default for Config {
             kafka_cluster: vec!["127.0.0.1:9092".to_owned()],
             kafka_topic: "task-worker".to_owned(),
             kafka_deadletter_topic: "task-worker-dlq".to_owned(),
-            db_path: "./taskworker-inflight.sqlite".to_owned(),
+            db_path: "./taskbroker-inflight.sqlite".to_owned(),
             max_pending_count: 200,
             max_processing_deadline: 300,
             deadletter_deadline: 900,
@@ -82,7 +82,7 @@ impl Default for Config {
 
 impl Config {
     fn figment() -> Figment {
-        Figment::from(Config::default()).merge(Env::prefixed("TASKWORKER_"))
+        Figment::from(Config::default()).merge(Env::prefixed("TASKBROKER_"))
     }
 
     /// Build a Config instance from defaults and Env vars
@@ -122,7 +122,7 @@ mod tests {
         assert_eq!(config.log_level, Some(LogLevel::Info));
         assert_eq!(config.grpc_port, 50051);
         assert_eq!(config.kafka_topic, "task-worker");
-        assert_eq!(config.db_path, "./taskworker-inflight.sqlite");
+        assert_eq!(config.db_path, "./taskbroker-inflight.sqlite");
         assert_eq!(config.max_pending_count, 200);
     }
 
@@ -139,20 +139,20 @@ mod tests {
                 kafka_cluster: [10.0.0.1:9092, 10.0.0.2:9092]
                 kafka_topic: error-tasks
                 kafka_deadletter_topic: error-tasks-dlq
-                db_path: ./taskworker-error.sqlite
+                db_path: ./taskbroker-error.sqlite
                 max_pending_count: 512
                 max_processing_deadline: 1000
                 deadletter_deadline: 2000
             "#,
             )?;
-            jail.set_env("TASKWORKER_LOG_LEVEL", "error");
+            jail.set_env("TASKBROKER_LOG_LEVEL", "error");
 
             let config = Config::from_file(Path::new("config.yaml")).unwrap();
             assert_eq!(config.sentry_dsn, Some("fake_dsn".to_owned()));
             assert_eq!(config.log_level, Some(LogLevel::Info));
             assert_eq!(config.kafka_topic, "error-tasks".to_owned());
             assert_eq!(config.kafka_deadletter_topic, "error-tasks-dlq".to_owned());
-            assert_eq!(config.db_path, "./taskworker-error.sqlite".to_owned());
+            assert_eq!(config.db_path, "./taskbroker-error.sqlite".to_owned());
             assert_eq!(config.max_pending_count, 512);
             assert_eq!(config.max_processing_deadline, 1000);
             assert_eq!(config.deadletter_deadline, 2000);
@@ -164,8 +164,8 @@ mod tests {
     #[test]
     fn test_from_env() {
         Jail::expect_with(|jail| {
-            jail.set_env("TASKWORKER_LOG_LEVEL", "error");
-            jail.set_env("TASKWORKER_DEADLETTER_DEADLINE", "2000");
+            jail.set_env("TASKBROKER_LOG_LEVEL", "error");
+            jail.set_env("TASKBROKER_DEADLETTER_DEADLINE", "2000");
 
             let config = Config::from_env().unwrap();
             assert_eq!(config.sentry_dsn, None);
@@ -173,7 +173,7 @@ mod tests {
             assert_eq!(config.log_level, Some(LogLevel::Error));
             assert_eq!(config.kafka_topic, "task-worker".to_owned());
             assert_eq!(config.kafka_deadletter_topic, "task-worker-dlq".to_owned());
-            assert_eq!(config.db_path, "./taskworker-inflight.sqlite".to_owned());
+            assert_eq!(config.db_path, "./taskbroker-inflight.sqlite".to_owned());
             assert_eq!(config.max_pending_count, 200);
             assert_eq!(config.max_processing_deadline, 300);
             assert_eq!(config.deadletter_deadline, 2000);


### PR DESCRIPTION
It has been awkward to talk about the components of the 'taskworker' system when they had overlapping names. By renaming this consumer/rpc application to taskbroker we end up with:

- taskworker - refers to the entire system of task definitions, taskbroker and workers.
- taskbroker - this repo and application.
- workers - the worker process in sentry

If folks are happy with this, I can rename the repository and update rbac tooling.