### PR TITLE
fix(consumer): Fix deadlock when consumer event handling and kafka client polling is scheduled onto the same POSIX thread

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -76,7 +76,7 @@ impl Default for Config {
         Self {
             sentry_dsn: None,
             sentry_env: None,
-            log_level: LogLevel::Info,
+            log_level: LogLevel::Debug,
             log_format: LogFormat::Text,
             grpc_port: 50051,
             statsd_addr: "127.0.0.1:8126".parse().unwrap(),
@@ -159,7 +159,7 @@ mod tests {
         };
         assert_eq!(config.sentry_dsn, None);
         assert_eq!(config.sentry_env, None);
-        assert_eq!(config.log_level, LogLevel::Info);
+        assert_eq!(config.log_level, LogLevel::Debug);
         assert_eq!(config.log_format, LogFormat::Text);
         assert_eq!(config.grpc_port, 50051);
         assert_eq!(config.kafka_topic, "task-worker");


### PR DESCRIPTION
### Overview

Now that the consumer event handling code is running in a dedicated green thread, it turns out that it can deadlock with the green thread that polls our rdkafka client. This change runs the rdkafka client polling in a dedicated blocking thread pool so it will never contend with our green threads.

### Details

Async rust does not rely on preemption to switch what future to execute. It is uses a cooperative model, so an underlying POSIX thread can only change what green thread to execute when the currently executing green thread hits an `.await` point in its code. Therefore, any code that runs between any `.await` point is guaranteed that it will hog that POSIX thread.

The rdkafka rust binding library provides an async client, however the rebalance callback is not async. In order to know when the rebalance event that the rebalance callback sent to the event handler is processed, it needs to use a [`sync_channel`](https://doc.rust-lang.org/std/sync/mpsc/fn.sync_channel.html) instead of something that is async like [oneshot channel](https://docs.rs/tokio/latest/tokio/sync/oneshot/fn.channel.html) to signal completion. This also means that while the rebalance callback is waiting for rendezvous, it does not yield execution.

```mermaid
sequenceDiagram
    Broker->>+pre_rebalance: Partition revocation
    pre_rebalance->>+handle_events: Write event & rendezvous sender to event sender
    handle_events->>+ActorHandles: .shutdown()
    ActorHandles->>-handle_events: .shutdown() completes
    handle_events->>pre_rebalance: Write to rendezvous sender
    deactivate handle_events
    pre_rebalance->>-Broker: Ack
```
Meanwhile, the handle_events green thread could be scheduled on the same POSIX thread as the consumer client green thread. Since the rebalance callback is waiting for rendezvous, and it does not yield execution, the handle_events green thread never gets to run. This will deadlock the consumer.

### How do we prevent future problems like this?

This problem has always existed since the consumer is merged in [here](https://github.com/getsentry/taskbroker/pull/17). We just got lucky because the consumer polling was running on a separate POSIX thread than the event handling thread. We can reproduce this problem from earlier commits if we run them with a single threaded runtime
```rust
#[tokio::main(flavor = "current_thread")]
```

Since this is the only non-async part of our codebase, now that it is on a dedicated threadpool, it should never happen again.

But to give us more confidence, when we have our integration test, we should also test our program with the `current_thread` tokio setting.