### PR TITLE
ref(main): Use elegant_departure to cleanly shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "elegant-departure"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259261d0b72dc618a177af380b2944fa44e22fedbdabb920f7b47edffb1df337"
+dependencies = [
+ "futures",
+ "lazy_static",
+ "pin-project-lite",
+ "tokio-util",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2679,9 +2691,9 @@ name = "taskbroker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-stream",
  "chrono",
  "clap",
+ "elegant-departure",
  "figment",
  "futures",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ prost-types = "0.13.3"
 tokio = { version = "1.41.0", features = ["full"] }
 tokio-util = "0.7.12"
 tokio-stream = { version = "0.1.16", features = ["full"] }
-async-stream = "0.3.5"
 futures = "0.3.31"
 rdkafka = { version = "0.36.2", features = ["cmake-build"] }
 serde = "1.0.214"
@@ -29,6 +28,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json"] }
 metrics-exporter-statsd = "0.9.0"
 metrics = "0.24.0"
+elegant-departure = "0.3.1"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use anyhow::Error;
 use clap::Parser;
 use std::{sync::Arc, time::Duration};
-use tokio::{select, signal, time};
+use tokio::signal::unix::{signal, SignalKind};
+use tokio::task::JoinHandle;
+use tokio::{select, time};
 use tonic::transport::Server;
 use tonic_health::server::health_reporter;
-use tracing::info;
+use tracing::{error, info};
 
 use sentry_protos::sentry::v1::consumer_service_server::ConsumerServiceServer;
 
@@ -22,6 +24,40 @@ use taskbroker::metrics;
 use taskbroker::processing_strategy;
 use taskbroker::Args;
 
+async fn check_for_shutdown() {
+    let (mut hangup, mut interrupt, mut terminate, mut quit) = (
+        signal(SignalKind::hangup()).expect("error creating signal stream for hangup"),
+        signal(SignalKind::interrupt()).expect("error creating signal stream for hangup"),
+        signal(SignalKind::terminate()).expect("error creating signal stream for hangup"),
+        signal(SignalKind::quit()).expect("error creating signal stream for hangup"),
+    );
+    select! {
+        _ = hangup.recv() => {
+            info!("Hangup received, shutting down");
+        }
+        _ = interrupt.recv() => {
+            info!("Interrupt received, shutting down");
+        }
+        _ = terminate.recv() => {
+            info!("Terminate received, shutting down");
+        }
+        _ = quit.recv() => {
+            info!("Quit received, shutting down");
+        }
+    }
+}
+
+async fn log_task_completion(name: &str, task: JoinHandle<()>) {
+    match task.await {
+        Ok(()) => {
+            info!("Task {} completed", name);
+        }
+        Err(e) => {
+            error!("Task {} failed: {:?}", name, e);
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     let args = Args::parse();
@@ -35,19 +71,21 @@ async fn main() -> Result<(), Error> {
     let upkeep_task = tokio::spawn({
         let upkeep_store = store.clone();
         async move {
+            let guard = elegant_departure::get_shutdown_guard().shutdown_on_drop();
             let mut timer = time::interval(Duration::from_millis(200));
             loop {
                 select! {
-                _ = signal::ctrl_c() => {
-                    break;
-                }
-                _ = timer.tick() => {
-                    let _ = upkeep_store.get_pending_activation().await;
-                    info!(
-                        "Pending activation in store: {}",
-                        upkeep_store.count_pending_activations().await.unwrap()
-                    );
-                }
+                    _ = timer.tick() => {
+                        let _ = upkeep_store.get_pending_activation().await;
+                        info!(
+                            "Pending activation in store: {}",
+                            upkeep_store.count_pending_activations().await.unwrap()
+                        );
+                    }
+                    _ = guard.wait() => {
+                        info!("Cancellation token received, shutting down upkeep");
+                        break;
+                    }
                 }
             }
         }
@@ -58,10 +96,13 @@ async fn main() -> Result<(), Error> {
         let consumer_store = store.clone();
         let consumer_config = config.clone();
         async move {
+            let kafka_topic = consumer_config.kafka_topic.clone();
+            let topic_list = [kafka_topic.as_str()];
             let kafka_config = consumer_config.kafka_client_config();
-
+            // The consumer has an internal thread that listens for cancellations, so it doesn't need
+            // an outer select here like the other tasks.
             start_consumer(
-                [&consumer_config.kafka_topic as &str].as_ref(),
+                &topic_list,
                 &kafka_config,
                 processing_strategy!({
                     map: deserialize_activation::new(DeserializeConfig::from_config(&consumer_config)),
@@ -75,7 +116,7 @@ async fn main() -> Result<(), Error> {
                         OsStream::StdErr,
                     ),
                 }),
-            ).await
+            ).await.expect("Failed to start consumer");
         }
     });
 
@@ -84,6 +125,7 @@ async fn main() -> Result<(), Error> {
         let grpc_store = store.clone();
         let grpc_config = config.clone();
         async move {
+            let guard = elegant_departure::get_shutdown_guard().shutdown_on_drop();
             let (mut health_reporter_fn, health_service) = health_reporter();
             health_reporter_fn
                 .set_serving::<ConsumerServiceServer<MyConsumerService>>()
@@ -99,25 +141,46 @@ async fn main() -> Result<(), Error> {
                 .serve(addr);
 
             select! {
-                _ = signal::ctrl_c() => {
-                    info!("Cancel received, shutting down GRPC server");
-                    health_reporter_fn.set_not_serving::<ConsumerServiceServer<MyConsumerService>>().await;
-                    Ok(())
-                }
+                biased;
+
                 _ = server => {
                     info!("GRPC server task failed, shutting down");
                     health_reporter_fn.set_not_serving::<ConsumerServiceServer<MyConsumerService>>().await;
-                    Err(anyhow::anyhow!("GRPC server task failed"))
+
+                    // Wait for any running requests to drain
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                }
+                _ = guard.wait() => {
+                    info!("Cancellation token received, shutting down GRPC server");
+                    health_reporter_fn.set_not_serving::<ConsumerServiceServer<MyConsumerService>>().await;
+
+                    // Wait for any running requests to drain
+                    tokio::time::sleep(Duration::from_secs(5)).await;
                 }
             }
         }
     });
 
-    let (consumer_result, grpc_server_result, upkeep_result) =
-        tokio::join!(consumer_task, grpc_server_task, upkeep_task);
+    /*
+    This select is waiting for either:
+    - A shutdown signal, in which case it signals the tasks to shutdown
+    - A task completion, in which case it logs the completion (including if its an error)
 
-    let _ = consumer_result.expect("Consumer task failed");
-    let _ = grpc_server_result.expect("GRPC server task failed");
-    upkeep_result.expect("Upkeep task failed");
+    Each of the tasks is also using an elegant_departure guard, so if one of them shuts down,
+    it will automatically trigger the shutdown of the other tasks as well. Then the code awaits
+    the shutdown of all the remaining tasks to ensure everything has shut down cleanly.
+    */
+    select! {
+        _ = check_for_shutdown() => {
+            info!("Received shutdown signal, shutting down");
+            // Wait for the tasks to finish
+            elegant_departure::shutdown().await;
+        }
+        _ = log_task_completion("consumer", consumer_task) => { }
+        _ = log_task_completion("grpc_server", grpc_server_task) => { }
+        _ = log_task_completion("upkeep_task", upkeep_task) => { }
+    }
+
+    elegant_departure::wait_for_shutdown_complete().await;
     Ok(())
 }


### PR DESCRIPTION
The taskbroker has two shutdown cases currently:
1. A signal is received of some kind (SIGINT etc.)
2. One of the components panics/shuts down

In the first case, shut down the guard that all the components are awaiting, which will cause them to execute.

In the second case, when the tokio task finishes, the guard being dropped will trigger a shutdown on the other guards. Log the error/completion of the original component and then wait for all the other components to shut down.