### PR TITLE
feat(kafka): Add a setting to control auto offset reset

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,9 @@ pub struct Config {
     /// The amount of ms that the consumer will commit at.
     pub kafka_auto_commit_interval_ms: usize,
 
+    /// The amount of ms that the consumer will commit at.
+    pub kafka_auto_offset_reset: String,
+
     /// The path to the sqlite database
     pub db_path: String,
 
@@ -86,6 +89,7 @@ impl Default for Config {
             kafka_deadletter_topic: "task-worker-dlq".to_owned(),
             kafka_session_timeout_ms: 6000,
             kafka_auto_commit_interval_ms: 5000,
+            kafka_auto_offset_reset: "latest".to_owned(),
             db_path: "./taskbroker-inflight.sqlite".to_owned(),
             max_pending_count: 2048,
             max_pending_buffer_count: 1,
@@ -124,6 +128,10 @@ impl Config {
             .set(
                 "auto.commit.interval.ms",
                 self.kafka_auto_commit_interval_ms.to_string(),
+            )
+            .set(
+                "auto.offset.reset",
+                self.kafka_auto_offset_reset.to_string(),
             )
             .set("enable.auto.offset.store", "false")
             .set_log_level(self.log_level.kafka_level());
@@ -181,6 +189,7 @@ mod tests {
                 kafka_cluster: 10.0.0.1:9092,10.0.0.2:9092
                 kafka_topic: error-tasks
                 kafka_deadletter_topic: error-tasks-dlq
+                kafka_auto_offset_reset: earliest
                 db_path: ./taskbroker-error.sqlite
                 max_pending_count: 512
                 max_processing_deadline: 1000
@@ -204,6 +213,7 @@ mod tests {
                 "10.0.0.1:9092,10.0.0.2:9092".to_owned()
             );
             assert_eq!(config.kafka_consumer_group, "task-worker".to_owned());
+            assert_eq!(config.kafka_auto_offset_reset, "earliest".to_owned());
             assert_eq!(config.kafka_session_timeout_ms, 6000.to_owned());
             assert_eq!(config.kafka_topic, "error-tasks".to_owned());
             assert_eq!(config.kafka_deadletter_topic, "error-tasks-dlq".to_owned());


### PR DESCRIPTION
### Overview

The auto offset reset setting controls what the consumer group starts at when it is first created.
Let's say our topic has 3 messages (message 0, message 1, and message 2), and we create a new consumer group.
The `"earliest"` setting make it so the consumer group consumes message 0 to 2 and then all messages onward
The `"latest"` setting make it so the consumer group only consumes message onward after 2.

I think the setting for production should be `"latest"`, but for integration tests where we build a backlog and start the consumer to burn it down, we should use `"earliest"`.