### PR TITLE
fix: Improve resilience to message replays

### DIFF
--- a/src/inflight_activation_store.rs
+++ b/src/inflight_activation_store.rs
@@ -152,6 +152,7 @@ impl InflightActivationStore {
                 }
                 b.push_bind(row.status);
             })
+            .push(" ON CONFLICT(id) DO NOTHING")
             .build();
         Ok(query.execute(&self.sqlite_pool).await?.into())
     }
@@ -514,6 +515,42 @@ mod tests {
 
         let result = store.count().await;
         assert_eq!(result.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_store_duplicate_id_in_batch() {
+        let url = generate_temp_filename();
+        let store = InflightActivationStore::new(&url).await.unwrap();
+
+        let mut batch = make_activations(2);
+        // Coerce a conflict
+        batch[0].activation.id = "id_0".into();
+        batch[1].activation.id = "id_0".into();
+
+        assert!(store.store(batch).await.is_ok());
+
+        let result = store.count().await;
+        assert_eq!(result.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_store_duplicate_id_between_batches() {
+        let url = generate_temp_filename();
+        let store = InflightActivationStore::new(&url).await.unwrap();
+
+        let batch = make_activations(2);
+        assert!(store.store(batch.clone()).await.is_ok());
+        let first_count = store.count().await;
+        assert_eq!(first_count.unwrap(), 2);
+
+        let new_batch = make_activations(2);
+        // Old batch and new should have conflicts
+        assert_eq!(batch[0].activation.id, new_batch[0].activation.id);
+        assert_eq!(batch[1].activation.id, new_batch[1].activation.id);
+        assert!(store.store(new_batch).await.is_ok());
+
+        let second_count = store.count().await;
+        assert_eq!(second_count.unwrap(), 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
If we manage to get a replayed message we don't want to crash the consumer. We assume that all tasks have unique ids and that any conflicting task activations are true duplicates that can be ignored.