### PR TITLE
fix: Fix processing deadlines not being reset

### DIFF
--- a/src/inflight_activation_store.rs
+++ b/src/inflight_activation_store.rs
@@ -296,7 +296,7 @@ impl InflightActivationStore {
         let result = sqlx::query(
             "UPDATE inflight_taskactivations
             SET processing_deadline = null, status = $1
-            WHERE processing_deadline < $2 AND status = $3"
+            WHERE processing_deadline < $2 AND status = $3",
         )
         .bind(InflightActivationStatus::Pending)
         .bind(now)
@@ -740,7 +740,7 @@ mod tests {
             attempts: 0,
             kind: "".into(),
             discard_after_attempt: Some(1),
-            deadletter_after_attempt: None
+            deadletter_after_attempt: None,
         });
 
         assert!(store.store(batch).await.is_ok());
@@ -763,7 +763,7 @@ mod tests {
             attempts: 0,
             kind: "".into(),
             discard_after_attempt: None,
-            deadletter_after_attempt: Some(1)
+            deadletter_after_attempt: Some(1),
         });
 
         assert!(store.store(batch).await.is_ok());
@@ -787,7 +787,7 @@ mod tests {
             attempts: 1,
             kind: "".into(),
             discard_after_attempt: None,
-            deadletter_after_attempt: Some(1)
+            deadletter_after_attempt: Some(1),
         });
 
         assert!(store.store(batch).await.is_ok());


### PR DESCRIPTION
When tasks had retry state and hadn't used all of their retries, the upkeep component would not reset the processing deadlines because of incorrect logic. When adding tests for these scenarios I realized that we don't need to treat the 'has retries' and 'no retries' scenarios differently and could simplify inflight activation logic.