### PR TITLE
fix(config) Make env variables the final override

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -123,7 +123,6 @@ impl Config {
         }
         builder = builder.merge(Env::prefixed("TASKBROKER_"));
         let config = builder.extract()?;
-        println!("config: {:?}", config);
         Ok(config)
     }
 


### PR DESCRIPTION
In most cases with how applications are deployed, it's helpful to have env variables be the last level of overrides, since most other config files are compiled/bundled into the application itself.