### PR TITLE
feat(k8s): Add basic k8s config files

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,20 @@
+gcloud container clusters get-credentials gke --region=<region> --project=<project>
+
+gcloud compute ssh gke--bastion --tunnel-through-iap --project=<project> --zone=<zone> --billing-project=<project> --ssh-flag="-4 -L8888:localhost:8888 -N -q -f"
+
+kubectl get ns
+
+
+kubectl apply -f k8s/k8s_storage_class.yaml
+kubectl apply -f k8s/k8s_stateful_set.yaml
+
+The topic needs to be created manually in kafka.
+
+If kafka is running in a container on a compute instance:
+SSH into the Compute Instance.
+
+`docker ps` to get the container id.
+
+`docker exec -it <container_id> /bin/bash` to get into the container.
+
+`/bin/kafka-topics --bootstrap-server 127.0.0.1:9093 --topic task-worker --create --partitions 4 --replication-factor 1` to create the topic.

--- a/k8s/k8s_stateful_set.yaml
+++ b/k8s/k8s_stateful_set.yaml
@@ -11,6 +11,10 @@ spec:
   clusterIP: None
   selector:
     app: taskbroker
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 86400 # default is 10800
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/k8s/k8s_stateful_set.yaml
+++ b/k8s/k8s_stateful_set.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: taskbroker-service
+  labels:
+    app: taskbroker-service
+spec:
+  ports:
+  - port: 50051
+    name: grpc
+  clusterIP: None
+  selector:
+    app: taskbroker
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: taskbroker
+spec:
+  selector:
+    matchLabels:
+      app: taskbroker # has to match .spec.template.metadata.labels
+  serviceName: "taskbroker"
+  replicas: 1 # by default is 1
+  minReadySeconds: 10 # by default is 0
+  template:
+    metadata:
+      labels:
+        app: taskbroker # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: taskbroker
+        image: us-central1-docker.pkg.dev/sentryio/taskbroker/image:ab1f14a7701cddf3113bab70d4367f1172be68cd
+        env:
+          - name: TASKBROKER_KAFKA_CLUSTER
+            value: "kafka-001:9092"
+        ports:
+        - containerPort: 50051
+          name: grpc
+        volumeMounts:
+        - name: sqlite
+          mountPath: /opt/sqlite
+  volumeClaimTemplates:
+  - metadata:
+      name: sqlite
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: taskbroker-sqlite
+      resources:
+        requests:
+          storage: 100Mi

--- a/k8s/k8s_storage_class.yaml
+++ b/k8s/k8s_storage_class.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: taskbroker-sqlite
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+reclaimPolicy: Retain # default value is Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
This adds two k8s config files: one to create the storage class used for sqlite, and another to run the taskbroker service itself.

The service currently uses a specific cloud image. This should be fixed in the future to be locked to the latest build of the image, instead of a specific commit.

There are some rough instructions in the README on how to apply this k8s config to a sandbox for testing.