### PR TITLE
feat(devservices): Add containerized taskbroker to devservices config

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -22,6 +22,9 @@ services:
       TASKBROKER_KAFKA_CLUSTER: "kafka-kafka-1:9093"
     ports:
       - 127.0.0.1:50051:50051
+    networks:
+      - devservices
+    restart: unless-stopped
     platform: linux/amd64
 
 networks:

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -9,9 +9,20 @@ x-sentry-service-config:
         repo_name: sentry-shared-kafka
         branch: main
         repo_link: https://github.com/getsentry/sentry-shared-kafka
+    taskbroker:
+      description: Taskbroker service
   modes:
     default: [kafka]
-    containerized: [kafka]
+    containerized: [kafka, taskbroker]
+
+services:
+  taskbroker:
+    image: ghcr.io/getsentry/taskbroker:latest
+    environment:
+      TASKBROKER_KAFKA_CLUSTER: "kafka-kafka-1:9093"
+    ports:
+      - 127.0.0.1:50051:50051
+    platform: linux/amd64
 
 networks:
   devservices:


### PR DESCRIPTION
With the revamped devservices, the configurations for how to run taskbroker should live in this repo and not sentry. 

See snuba: https://github.com/getsentry/sentry/blob/ec05e95588181966ded878090b1241e3b3fb2775/devservices/config.yml#L6

This allows configurations to be defined in the appropriate repo and be used anywhere else. 