### PR TITLE
ref(kafka): Remove incremental rebalancing

### DIFF
--- a/src/consumer/kafka.rs
+++ b/src/consumer/kafka.rs
@@ -359,32 +359,15 @@ pub async fn handle_events(
                         unreachable!("Got partition revocation before the consumer has started")
                     }
                     (ConsumerState::Ready, Event::Shutdown) => ConsumerState::Stopped,
-                    (ConsumerState::Consuming(handles, mut tpl), Event::Assign(mut assigned)) => {
-                        assert!(
-                            tpl.is_disjoint(&assigned),
-                            "Newly assigned TPL should be disjoint from TPL we're consuming from"
-                        );
-                        tpl.append(&mut assigned);
-                        debug!(
-                            "{} additional topic partitions added after assignment",
-                            assigned.len()
-                        );
-                        handles.shutdown(CALLBACK_DURATION).await;
-                        ConsumerState::Consuming(spawn_actors(consumer.clone(), &tpl), tpl)
+                    (ConsumerState::Consuming(_, _), Event::Assign(_)) => {
+                        unreachable!("Got partition assignment after the consumer has started")
                     }
-                    (ConsumerState::Consuming(handles, mut tpl), Event::Revoke(revoked)) => {
+                    (ConsumerState::Consuming(_, tpl), Event::Revoke(revoked)) => {
                         assert!(
-                            tpl.is_subset(&revoked),
-                            "Revoked TPL should be a subset of TPL we're consuming from"
+                            tpl == revoked,
+                            "Revoked TPL should be equal to the subset of TPL we're consuming from"
                         );
-                        tpl.retain(|e| !revoked.contains(e));
-                        debug!("{} topic partitions remaining after revocation", tpl.len());
-                        handles.shutdown(CALLBACK_DURATION).await;
-                        if tpl.is_empty() {
-                            ConsumerState::Ready
-                        } else {
-                            ConsumerState::Consuming(spawn_actors(consumer.clone(), &tpl), tpl)
-                        }
+                        ConsumerState::Ready
                     }
                     (ConsumerState::Consuming(handles, _), Event::Shutdown) => {
                         handles.shutdown(CALLBACK_DURATION).await;

--- a/src/consumer/kafka.rs
+++ b/src/consumer/kafka.rs
@@ -362,11 +362,12 @@ pub async fn handle_events(
                     (ConsumerState::Consuming(_, _), Event::Assign(_)) => {
                         unreachable!("Got partition assignment after the consumer has started")
                     }
-                    (ConsumerState::Consuming(_, tpl), Event::Revoke(revoked)) => {
+                    (ConsumerState::Consuming(handles, tpl), Event::Revoke(revoked)) => {
                         assert!(
                             tpl == revoked,
                             "Revoked TPL should be equal to the subset of TPL we're consuming from"
                         );
+                        handles.shutdown(CALLBACK_DURATION).await;
                         ConsumerState::Ready
                     }
                     (ConsumerState::Consuming(handles, _), Event::Shutdown) => {


### PR DESCRIPTION
### Overview

Removes incremental rebalancing logic from the kafka consumer state machine.
We currently have a working implementation [here](https://github.com/getsentry/taskbroker/pull/99). However, taking advantage of incremental rebalancing requires a little further work:
- The rdkafka library currently has a bug with committing consumer offset manually during incremental rebalance, causing the consumer to lose its assignment when encountering an illegal generation error. We generally don't use manual offset commit and utilize the auto commit from rdkafka, but we still manually commit offset on shutdown signals. The way the PR above works around this issue is to shutdown the actors, poll the consumer for a predetermined amount of time before actually shutting down. But to use this in production we should wait for [the tracking issue](https://github.com/confluentinc/librdkafka/issues/4059) to be resolved and see what course of action the rdkfaka team decides to take before trying again.
- We currently re-create all actors even on partition assignment, we need to just increase actors without shutting down to actually reduce the time spent rebalancing. (This should be a relatively straightforward change).