### PR TITLE
feat(kafka): Create the topics if they don't exist

### DIFF
--- a/config/config-dev.yaml
+++ b/config/config-dev.yaml
@@ -1,1 +1,2 @@
 upkeep_task_interval_ms: 2000
+create_missing_topics: true

--- a/config/config-sentry-dev.yaml
+++ b/config/config-sentry-dev.yaml
@@ -1,2 +1,3 @@
 upkeep_task_interval_ms: 2000
 kafka_cluster: 127.0.0.1:9092
+create_missing_topics: true

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,9 @@ pub struct Config {
     /// The kafka topic to publish dead letter messages on
     pub kafka_deadletter_topic: String,
 
+    /// The default number of partitions for a topic
+    pub default_topic_partitions: i32,
+
     /// The kafka session timeout in ms
     pub kafka_session_timeout_ms: usize,
 
@@ -101,6 +104,7 @@ impl Default for Config {
             kafka_consumer_group: "task-worker".to_owned(),
             kafka_topic: "task-worker".to_owned(),
             kafka_deadletter_topic: "task-worker-dlq".to_owned(),
+            default_topic_partitions: 1,
             kafka_session_timeout_ms: 6000,
             kafka_auto_commit_interval_ms: 5000,
             kafka_auto_offset_reset: "latest".to_owned(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,9 @@ pub struct Config {
     /// The topic to fetch task messages from.
     pub kafka_topic: String,
 
+    /// Whether to create missing topics if they don't exist.
+    pub create_missing_topics: bool,
+
     /// The kafka topic to publish dead letter messages on
     pub kafka_deadletter_topic: String,
 
@@ -103,6 +106,7 @@ impl Default for Config {
             kafka_cluster: "127.0.0.1:9092".to_owned(),
             kafka_consumer_group: "task-worker".to_owned(),
             kafka_topic: "task-worker".to_owned(),
+            create_missing_topics: false,
             kafka_deadletter_topic: "task-worker-dlq".to_owned(),
             default_topic_partitions: 1,
             kafka_session_timeout_ms: 6000,

--- a/src/consumer/admin.rs
+++ b/src/consumer/admin.rs
@@ -1,0 +1,56 @@
+use anyhow::Error;
+use rdkafka::{
+    admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
+    metadata::Metadata,
+    ClientConfig,
+};
+use std::time::Duration;
+use tracing::info;
+
+pub async fn create_missing_topics(
+    kafka_client_config: ClientConfig,
+    topics: &[&str],
+    default_topic_partitions: i32,
+) -> Result<(), Error> {
+    let admin_client: AdminClient<_> = kafka_client_config.create().unwrap();
+    let mut topics_to_create = Vec::new();
+    for topic in topics {
+        // Weirdly, this call will actually create the topic if it doesn't exist. So it needs to be overridden in the next steps.
+        let topic_metadata: Metadata = admin_client
+            .inner()
+            .fetch_metadata(Some(topic), Duration::new(5, 0))?;
+
+        if !topic_metadata.topics().is_empty() {
+            for meta_topic in topic_metadata.topics() {
+                if meta_topic.error().is_some()
+                    && meta_topic.partitions().len() as i32 != default_topic_partitions
+                {
+                    info!(
+                        "Creating topic: {} with partitions: {}",
+                        meta_topic.name(),
+                        default_topic_partitions
+                    );
+                    topics_to_create.push(NewTopic::new(
+                        topic,
+                        default_topic_partitions,
+                        TopicReplication::Fixed(1),
+                    ));
+                } else {
+                    info!(
+                        "Using topic: {}, partitions: {}, error: {:?}",
+                        meta_topic.name(),
+                        meta_topic.partitions().len(),
+                        meta_topic.error()
+                    );
+                }
+            }
+        }
+    }
+    if !topics_to_create.is_empty() {
+        admin_client
+            .create_topics(&topics_to_create, &AdminOptions::new())
+            .await?;
+    }
+
+    Ok(())
+}

--- a/src/consumer/kafka.rs
+++ b/src/consumer/kafka.rs
@@ -4,14 +4,12 @@ use futures::{
     pin_mut, Stream, StreamExt,
 };
 use rdkafka::{
-    admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
     consumer::{
         stream_consumer::StreamPartitionQueue, BaseConsumer, Consumer, ConsumerContext, Rebalance,
         StreamConsumer,
     },
     error::{KafkaError, KafkaResult},
     message::{BorrowedMessage, OwnedMessage},
-    metadata::Metadata,
     ClientConfig, ClientContext, Message, Offset, TopicPartitionList,
 };
 use std::{
@@ -71,56 +69,6 @@ pub async fn start_consumer(
         spawn_actors,
     )
     .await
-}
-
-pub async fn create_missing_topics(
-    kafka_client_config: ClientConfig,
-    topics: &[&str],
-    default_topic_partitions: i32,
-) -> Result<(), Error> {
-    let admin_client: AdminClient<_> = kafka_client_config.create().unwrap();
-    let mut topics_to_create = Vec::new();
-    for topic in topics {
-        // Weirdly, this call will actually create the topic if it doesn't exist. So it needs to be overridden in the next steps.
-        let topic_metadata: Metadata = admin_client
-            .inner()
-            .fetch_metadata(Some(topic), Duration::new(5, 0))
-            .expect("Failed to fetch metadata");
-
-        if !topic_metadata.topics().is_empty() {
-            for meta_topic in topic_metadata.topics() {
-                if meta_topic.error().is_some()
-                    && meta_topic.partitions().len() as i32 != default_topic_partitions
-                {
-                    info!(
-                        "Creating topic: {} with partitions: {}",
-                        meta_topic.name(),
-                        default_topic_partitions
-                    );
-                    topics_to_create.push(NewTopic::new(
-                        topic,
-                        default_topic_partitions,
-                        TopicReplication::Fixed(1),
-                    ));
-                } else {
-                    info!(
-                        "Using topic: {}, partitions: {}, error: {:?}",
-                        meta_topic.name(),
-                        meta_topic.partitions().len(),
-                        meta_topic.error()
-                    );
-                }
-            }
-        }
-    }
-    if !topics_to_create.is_empty() {
-        admin_client
-            .create_topics(&topics_to_create, &AdminOptions::new())
-            .await
-            .expect("Failed to create topic");
-    }
-
-    Ok(())
 }
 
 pub fn handle_os_signals(event_sender: UnboundedSender<(Event, SyncSender<()>)>) {

--- a/src/consumer/kafka.rs
+++ b/src/consumer/kafka.rs
@@ -44,20 +44,11 @@ use tracing::{debug, error, info, instrument};
 pub async fn start_consumer(
     topics: &[&str],
     kafka_client_config: &ClientConfig,
-    default_topic_partitions: i32,
     spawn_actors: impl FnMut(
         Arc<StreamConsumer<KafkaContext>>,
         &BTreeSet<(String, i32)>,
     ) -> ActorHandles,
 ) -> Result<(), Error> {
-    create_missing_topics(
-        kafka_client_config.clone(),
-        topics,
-        default_topic_partitions,
-    )
-    .await
-    .expect("Failed to find/create topics");
-
     let (client_shutdown_sender, client_shutdown_receiver) = oneshot::channel();
     let (event_sender, event_receiver) = unbounded_channel();
     let context = KafkaContext::new(event_sender.clone());
@@ -82,7 +73,7 @@ pub async fn start_consumer(
     .await
 }
 
-async fn create_missing_topics(
+pub async fn create_missing_topics(
     kafka_client_config: ClientConfig,
     topics: &[&str],
     default_topic_partitions: i32,

--- a/src/consumer/kafka.rs
+++ b/src/consumer/kafka.rs
@@ -4,12 +4,14 @@ use futures::{
     pin_mut, Stream, StreamExt,
 };
 use rdkafka::{
+    admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
     consumer::{
         stream_consumer::StreamPartitionQueue, BaseConsumer, Consumer, ConsumerContext, Rebalance,
         StreamConsumer,
     },
     error::{KafkaError, KafkaResult},
     message::{BorrowedMessage, OwnedMessage},
+    metadata::Metadata,
     ClientConfig, ClientContext, Message, Offset, TopicPartitionList,
 };
 use std::{
@@ -42,11 +44,20 @@ use tracing::{debug, error, info, instrument};
 pub async fn start_consumer(
     topics: &[&str],
     kafka_client_config: &ClientConfig,
+    default_topic_partitions: i32,
     spawn_actors: impl FnMut(
         Arc<StreamConsumer<KafkaContext>>,
         &BTreeSet<(String, i32)>,
     ) -> ActorHandles,
 ) -> Result<(), Error> {
+    create_missing_topics(
+        kafka_client_config.clone(),
+        topics,
+        default_topic_partitions,
+    )
+    .await
+    .expect("Failed to find/create topics");
+
     let (client_shutdown_sender, client_shutdown_receiver) = oneshot::channel();
     let (event_sender, event_receiver) = unbounded_channel();
     let context = KafkaContext::new(event_sender.clone());
@@ -69,6 +80,56 @@ pub async fn start_consumer(
         spawn_actors,
     )
     .await
+}
+
+async fn create_missing_topics(
+    kafka_client_config: ClientConfig,
+    topics: &[&str],
+    default_topic_partitions: i32,
+) -> Result<(), Error> {
+    let admin_client: AdminClient<_> = kafka_client_config.create().unwrap();
+    let mut topics_to_create = Vec::new();
+    for topic in topics {
+        // Weirdly, this call will actually create the topic if it doesn't exist. So it needs to be overridden in the next steps.
+        let topic_metadata: Metadata = admin_client
+            .inner()
+            .fetch_metadata(Some(topic), Duration::new(5, 0))
+            .expect("Failed to fetch metadata");
+
+        if !topic_metadata.topics().is_empty() {
+            for meta_topic in topic_metadata.topics() {
+                if meta_topic.error().is_some()
+                    && meta_topic.partitions().len() as i32 != default_topic_partitions
+                {
+                    info!(
+                        "Creating topic: {} with partitions: {}",
+                        meta_topic.name(),
+                        default_topic_partitions
+                    );
+                    topics_to_create.push(NewTopic::new(
+                        topic,
+                        default_topic_partitions,
+                        TopicReplication::Fixed(1),
+                    ));
+                } else {
+                    info!(
+                        "Using topic: {}, partitions: {}, error: {:?}",
+                        meta_topic.name(),
+                        meta_topic.partitions().len(),
+                        meta_topic.error()
+                    );
+                }
+            }
+        }
+    }
+    if !topics_to_create.is_empty() {
+        admin_client
+            .create_topics(&topics_to_create, &AdminOptions::new())
+            .await
+            .expect("Failed to create topic");
+    }
+
+    Ok(())
 }
 
 pub fn handle_os_signals(event_sender: UnboundedSender<(Event, SyncSender<()>)>) {

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod deserialize_activation;
 pub mod inflight_activation_writer;
 pub mod kafka;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ async fn main() -> Result<(), Error> {
             start_consumer(
                 &topic_list,
                 &kafka_config,
+                consumer_config.default_topic_partitions,
                 processing_strategy!({
                     map: deserialize_activation::new(DeserializeConfig::from_config(&consumer_config)),
                     reduce: InflightActivationWriter::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,10 @@ use sentry_protos::sentry::v1::consumer_service_server::ConsumerServiceServer;
 
 use taskbroker::config::Config;
 use taskbroker::consumer::{
+    admin::create_missing_topics,
     deserialize_activation::{self, DeserializeConfig},
     inflight_activation_writer::{ActivationWriterConfig, InflightActivationWriter},
-    kafka::{create_missing_topics, start_consumer},
+    kafka::start_consumer,
     os_stream_writer::{OsStream, OsStreamWriter},
 };
 use taskbroker::grpc_server::MyConsumerService;


### PR DESCRIPTION
In dev situations, it is possible for the taskbroker to be started without the necessary topics existing locally. Add a function that will create the topics if they don't exist. This function can be skipped with a config setting.

This is necessary for a couple reasons: The taskbroker runs independently of sentry itself, in the same way snuba/relay run independently. That means it should be possible to start taskbroker without needing to start the sentry monolith. These types of applications are managed using the `devservices` commands (vs. `devserver`, which starts the monolith).

However, `devservices` has no mechanism to run commands on the dependent services, which is necessary in the `taskbroker` case to initialize the kafka topics.

In order to have `taskbroker` be independent of the sentry monolith, and to not have it require extra commands to bootstrap after running `devservices up`, it was necessary to create the topics manually when the service starts.

Note that this is also what both snuba and sentry do when they start up: https://github.com/getsentry/sentry/blob/0722d000e2560bec9c097c21cf790cdcf2101197/src/sentry/runner/commands/upgrade.py

https://github.com/getsentry/snuba/blob/master/snuba/cli/bootstrap.py#L85