### PR TITLE
test(kafka): Refactor integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,30 @@ jobs:
         with:
           key: ${{ github.job }}
 
-      - name: Run Cargo Tests
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
-        with:
-          command: test
-          args: --all
-
-      - name: Run Python Integration Tests
+      - name: Run unit tests
         run: |
-          export PYTEST_ADDOPTS=""
-          python -m pytest python/integration_tests -s -vv
+          make unit-test
+
+  rebalance-integration-test:
+    name: Rebalance integration test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+        with:
+          key: ${{ github.job }}
+
+      - name: Run Rebalance Integration Test
+        run: |
+          make test-rebalace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,4 +86,4 @@ jobs:
 
       - name: Run Rebalance Integration Test
         run: |
-          make test-rebalace
+          make test-rebalance

--- a/Makefile
+++ b/Makefile
@@ -55,12 +55,12 @@ reset-kafka: install-py-dev ## Reset kafka
 	devservices up
 .PHONY: reset-kafka
 
-test-rebalace: build reset-kafka ## Run the rebalace integration tests
+test-rebalance: build reset-kafka ## Run the rebalance integration tests
 	python -m pytest python/integration_tests/test_consumer_rebalancing.py -s
 	rm -r python/integration_tests/.tests_output/test_consumer_rebalancing
-.PHONY: test-rebalace
+.PHONY: test-rebalance
 
-integration-test test-rebalace: ## Run all integration tests
+integration-test test-rebalance: ## Run all integration tests
 .PHONY: integration-test
 
 # Help

--- a/python/integration_tests/helpers.py
+++ b/python/integration_tests/helpers.py
@@ -10,26 +10,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 
 TASKBROKER_ROOT = Path(__file__).parent.parent.parent
 TASKBROKER_BIN = TASKBROKER_ROOT / "target/debug/taskbroker"
-
-
-def delete_topic(topic_name: str) -> None:
-    print(f"Deleting topic: {topic_name}")
-    delete_topic_cmd = [
-        "docker",
-        "exec",
-        "kafka-kafka-1",
-        "kafka-topics",
-        "--bootstrap-server",
-        "localhost:9092",
-        "--delete",
-        "--topic",
-        topic_name,
-    ]
-    res = subprocess.run(delete_topic_cmd, capture_output=True, text=True)
-    if res.returncode != 0:
-        print(f"Got return code: {res.returncode}, when deleting topic")
-        print(f"Stdout: {res.stdout}")
-        print(f"Stderr: {res.stderr}")
+TESTS_OUTPUT_ROOT = Path(__file__).parent / ".tests_output"
 
 
 def create_topic(topic_name: str, num_partitions: int) -> None:
@@ -52,13 +33,6 @@ def create_topic(topic_name: str, num_partitions: int) -> None:
         print(f"Got return code: {res.returncode}, when creating topic")
         print(f"Stdout: {res.stdout}")
         print(f"Stderr: {res.stderr}")
-
-
-def recreate_topic(topic_name: str, num_partitions: int) -> None:
-    # Delete and recreate a Kafka topic to ensure a clean state.
-    delete_topic(topic_name)
-    time.sleep(3)
-    create_topic(topic_name, num_partitions)
 
 
 def serialize_task_activation(args: list, kwargs: dict) -> bytes:

--- a/python/integration_tests/test_consumer_rebalancing.py
+++ b/python/integration_tests/test_consumer_rebalancing.py
@@ -13,11 +13,12 @@ import yaml
 
 from python.integration_tests.helpers import (
     TASKBROKER_BIN,
-    recreate_topic,
+    TESTS_OUTPUT_ROOT,
+    create_topic,
     send_messages_to_kafka,
 )
 
-TEST_OUTPUT_PATH = Path(__file__).parent / ".output_from_test_consumer_rebalancing"
+TEST_OUTPUT_PATH = TESTS_OUTPUT_ROOT / "test_consumer_rebalancing"
 
 
 def manage_consumer(
@@ -56,9 +57,9 @@ def test_tasks_written_once_during_rebalancing() -> None:
     consumer_path = str(TASKBROKER_BIN)
     num_consumers = 8
     num_messages = 100_000
-    num_restarts = 2
+    num_restarts = 16
     num_partitions = 32
-    min_restart_duration = 1
+    min_restart_duration = 4
     max_restart_duration = 30
     max_pending_count = 15_000
     topic_name = "task-worker"
@@ -80,11 +81,11 @@ Running test with the following configuration:
     random.seed(42)
 
     # Ensure topic exists and has correct number of partitions
-    recreate_topic(topic_name, num_partitions)
+    create_topic(topic_name, num_partitions)
 
     # Create config files for consumers
     print("Creating config files for consumers")
-    TEST_OUTPUT_PATH.mkdir(exist_ok=True)
+    TEST_OUTPUT_PATH.mkdir(parents=True, exist_ok=True)
     consumer_configs = {}
     for i in range(num_consumers):
         db_name = f"db_{i}_{curr_time}"

--- a/python/integration_tests/test_consumer_rebalancing.py
+++ b/python/integration_tests/test_consumer_rebalancing.py
@@ -6,18 +6,18 @@ import subprocess
 import threading
 import time
 
+from pathlib import Path
 from threading import Thread
 
 import yaml
 
 from python.integration_tests.helpers import (
     TASKBROKER_BIN,
-    TESTS_OUTPUT_PATH,
-    check_topic_exists,
-    create_topic,
-    update_topic_partitions,
+    recreate_topic,
     send_messages_to_kafka,
 )
+
+TEST_OUTPUT_PATH = Path(__file__).parent / ".output_from_test_consumer_rebalancing"
 
 
 def manage_consumer(
@@ -56,7 +56,7 @@ def test_tasks_written_once_during_rebalancing() -> None:
     consumer_path = str(TASKBROKER_BIN)
     num_consumers = 8
     num_messages = 100_000
-    num_restarts = 16
+    num_restarts = 2
     num_partitions = 32
     min_restart_duration = 1
     max_restart_duration = 30
@@ -79,27 +79,18 @@ Running test with the following configuration:
     )
     random.seed(42)
 
-    # Ensure topic has correct number of partitions
-    if not check_topic_exists(topic_name):
-        print(
-            f"{topic_name} topic does not exist, creating it with {num_partitions} partitions"
-        )
-        create_topic(topic_name, num_partitions)
-    else:
-        print(
-            f"{topic_name} topic already exists, making sure it has {num_partitions} partitions"
-        )
-        update_topic_partitions(topic_name, num_partitions)
+    # Ensure topic exists and has correct number of partitions
+    recreate_topic(topic_name, num_partitions)
 
     # Create config files for consumers
-    print("\nCreating config files for consumers")
-    TESTS_OUTPUT_PATH.mkdir(exist_ok=True)
+    print("Creating config files for consumers")
+    TEST_OUTPUT_PATH.mkdir(exist_ok=True)
     consumer_configs = {}
     for i in range(num_consumers):
         db_name = f"db_{i}_{curr_time}"
         consumer_configs[f"config_{i}.yml"] = {
             "db_name": db_name,
-            "db_path": str(TESTS_OUTPUT_PATH / f"{db_name}.sqlite"),
+            "db_path": str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
             "max_pending_count": max_pending_count,
             "kafka_topic": topic_name,
             "kafka_consumer_group": topic_name,
@@ -108,7 +99,7 @@ Running test with the following configuration:
         }
 
     for filename, config in consumer_configs.items():
-        with open(str(TESTS_OUTPUT_PATH / filename), "w") as f:
+        with open(str(TEST_OUTPUT_PATH / filename), "w") as f:
             yaml.safe_dump(config, f)
 
     try:
@@ -120,11 +111,11 @@ Running test with the following configuration:
                 args=(
                     i,
                     consumer_path,
-                    str(TESTS_OUTPUT_PATH / f"config_{i}.yml"),
+                    str(TEST_OUTPUT_PATH / f"config_{i}.yml"),
                     num_restarts,
                     min_restart_duration,
                     max_restart_duration,
-                    str(TESTS_OUTPUT_PATH / f"consumer_{i}_{curr_time}.log"),
+                    str(TEST_OUTPUT_PATH / f"consumer_{i}_{curr_time}.log"),
                 ),
             )
             thread.start()
@@ -205,13 +196,18 @@ Running test with the following configuration:
 
     consumer_error_logs = []
     for i in range(num_consumers):
-        with open(str(TESTS_OUTPUT_PATH / f"consumer_{i}_{curr_time}.log"), "r") as f:
+        with open(str(TEST_OUTPUT_PATH / f"consumer_{i}_{curr_time}.log"), "r") as f:
             lines = f.readlines()
             for log_line_index, line in enumerate(lines):
                 if "[31mERROR" in line:
                     # If there is an error in log file, capture 10 lines before and after the error line
-                    consumer_error_logs.append(f"Error found in consumer_{i}. Logging 10 lines before and after the error line:")
-                    for j in range(max(0, log_line_index - 10), min(len(lines) - 1, log_line_index + 10)):
+                    consumer_error_logs.append(
+                        f"Error found in consumer_{i}. Logging 10 lines before and after the error line:"
+                    )
+                    for j in range(
+                        max(0, log_line_index - 10),
+                        min(len(lines) - 1, log_line_index + 10),
+                    ):
                         consumer_error_logs.append(lines[j].strip())
                     consumer_error_logs.append("")
 


### PR DESCRIPTION
### Overview

1. Separate the unit tests and integration test into separate CI checks
2. Unify make file and CI so that the CI uses the makefile as much as possible. This way, it's much easier to reproduce CI failure locally.
3. Destroys the kafka container and volume before starting an integration test, so all integration tests can start with a clean kafka container.
4. Update the integration test output directory structure from:
```
.
└── integration_tests/
    └── .test_output/
        └── # Files all go in here
```

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;to:

```
.
└── integration_tests/
    └── .test_output/
        ├── rebalance/
        │   └── # rebalance output goes here
        └── some_other_test/
            └── # output for the other test goes here
```
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; so that finding integration tests would be easier as we add more
5. Update the makefile recipe for the integration test so that they delete the test output later. This ensures that the output only gets cleaned up after the test returns with 0 exit code.
6. Increase minimum time before a consumer startup and it recieving a shutdown signal from 1 seconds to 4 seconds. For some reason, with a fresh kafka topic created using the python integration test. If a new consumer starts up and shuts down before a partition assignment, it will print a kafka broker error when shutting down. This trips the error output check in the integration test causing it to fail but no data is lost / double processed. ~~I would like to dive deeper to why this is happening and why it only happens when a topic is created in the python integration test, but I would like to unblock us first. Also, in a real prod environment, we never shut down our consumer that fast.~~ Okay I figured it out, kafka has a setting called `group.initial.rebalance.delay.ms` (doc [here](https://cwiki.apache.org/confluence/display/KAFKA/KIP-134)), it controls how long to wait to respond to a consumer `JoinGroupRequest` when a consumer group is created. Before, the unit tests already creates the task-worker consumer group, so when the integration test runs, there are no delays from the broker when the consumers are starting. But now, because we are recreating the kafka container from scratch, the broker waits when the consumers are sending the `JoinGroupRequest`, and since our integration test can send shutdown signal in 1 second, we get the timeout error because the consumer is sending a `LeaveGroupRequest` while the broker is still not responding to the `JoinGroupRequest` from when it first starts, causing the timeout:
```
librdkafka: REQTMOUT [thrd:GroupCoordinator]: GroupCoordinator/1001: Timed out LeaveGroupRequest in flight (after 5004ms, timeout #0): possibly held back by preceeding blocking JoinGroupRequest with timeout in 297034ms
```