### PR TITLE
feat(tests): End-to-end integration for upkeep retry

### DIFF
--- a/.github/workflows/.vscode/settings.json
+++ b/.github/workflows/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.formatting.provider": "black",
+    "[python]": {
+        "editor.formatOnSave": true
+    }
+}

--- a/.github/workflows/.vscode/settings.json
+++ b/.github/workflows/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "python.formatting.provider": "black",
-    "[python]": {
-        "editor.formatOnSave": true
-    }
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,27 @@ jobs:
       - name: Run worker processing integration test
         run: |
           make test-worker-processing
+  
+  upkeep-retry-integration-test:
+    name: Upkeep retry integration test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+        with:
+          key: ${{ github.job }}
+
+      - name: Run upkeep retry integration test
+        run: |
+          make test-upkeep-retry

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-worker-processing: build reset-kafka ## Run the worker processing integrati
 	rm -r python/integration_tests/.tests_output/test_task_worker_processing
 .PHONY: test-worker-processing
 
-test-upkeep-retry: build reset-kafka ## Run the worker processing integration test
+test-upkeep-retry: build reset-kafka ## Run the upkeep retry integration test
 	python -m pytest python/integration_tests/test_upkeep_retry.py -s
 	rm -r python/integration_tests/.tests_output/test_upkeep_retry
 .PHONY: test-upkeep-retry

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,11 @@ test-worker-processing: build reset-kafka ## Run the worker processing integrati
 	rm -r python/integration_tests/.tests_output/test_task_worker_processing
 .PHONY: test-worker-processing
 
+test-upkeep-retry: build reset-kafka ## Run the worker processing integration test
+	python -m pytest python/integration_tests/test_upkeep_retry.py -s
+	rm -r python/integration_tests/.tests_output/test_upkeep_retry
+.PHONY: test-upkeep-retry
+
 integration-test: test-rebalance test-worker-processing ## Run all integration tests
 .PHONY: integration-test
 

--- a/python/integration_tests/helpers.py
+++ b/python/integration_tests/helpers.py
@@ -1,5 +1,6 @@
 import orjson
 import subprocess
+import sqlite3
 import time
 
 from confluent_kafka import Producer
@@ -11,6 +12,37 @@ from google.protobuf.timestamp_pb2 import Timestamp
 TASKBROKER_ROOT = Path(__file__).parent.parent.parent
 TASKBROKER_BIN = TASKBROKER_ROOT / "target/debug/taskbroker"
 TESTS_OUTPUT_ROOT = Path(__file__).parent / ".tests_output"
+
+
+class ConsumerConfig:
+    def __init__(
+        self,
+        db_name: str,
+        db_path: str,
+        max_pending_count: int,
+        kafka_topic: str,
+        kafka_consumer_group: str,
+        kafka_auto_offset_reset: str,
+        grpc_port: int
+    ):
+        self.db_name = db_name
+        self.db_path = db_path
+        self.max_pending_count = max_pending_count
+        self.kafka_topic = kafka_topic
+        self.kafka_consumer_group = kafka_consumer_group
+        self.kafka_auto_offset_reset = kafka_auto_offset_reset
+        self.grpc_port = grpc_port
+
+    def to_dict(self) -> dict:
+        return {
+            "db_name": self.db_name,
+            "db_path": self.db_path,
+            "max_pending_count": self.max_pending_count,
+            "kafka_topic": self.kafka_topic,
+            "kafka_consumer_group": self.kafka_consumer_group,
+            "kafka_auto_offset_reset": self.kafka_auto_offset_reset,
+            "grpc_port": self.grpc_port,
+        }
 
 
 def create_topic(topic_name: str, num_partitions: int) -> None:
@@ -76,3 +108,14 @@ def send_messages_to_kafka(topic_name: str, num_messages: int) -> None:
         print(f"Sent {num_messages} messages to kafka topic {topic_name}")
     except Exception as e:
         raise Exception(f"Failed to send messages to kafka: {e}")
+
+
+def check_num_tasks_written(consumer_config: ConsumerConfig) -> int:
+    attach_db_stmt = f"ATTACH DATABASE '{consumer_config.db_path}' AS {consumer_config.db_name};\n"
+    query = f"""SELECT count(*) as count FROM {consumer_config.db_name}.inflight_taskactivations;"""
+    con = sqlite3.connect(consumer_config.db_path)
+    cur = con.cursor()
+    cur.executescript(attach_db_stmt)
+    rows = cur.execute(query).fetchall()
+    count = rows[0][0]
+    return count

--- a/python/integration_tests/test_consumer_rebalancing.py
+++ b/python/integration_tests/test_consumer_rebalancing.py
@@ -56,7 +56,7 @@ def test_tasks_written_once_during_rebalancing() -> None:
     """
     What does this test do?
     This test is responsible for ensuring that a collection of
-    taskbroker consumers only write a single task to sqlite
+    taskbroker consumers only writes a single task to sqlite
     once during a rebalancing storm.
 
     How does it accomplish this?
@@ -66,7 +66,7 @@ def test_tasks_written_once_during_rebalancing() -> None:
     from kafka and write to sqlite in parallel. At random, the test then sends
     a SIGINT to each consumer, which will trigger a rebalancing event. This
     process continues until all tasks have been written to sqlite. By using the
-    task's offset, we can validate that all tasks have been written to sqlite
+    task's offset, we validate that all tasks have been written to sqlite
     only once.
     """
     # Test configuration

--- a/python/integration_tests/test_consumer_rebalancing.py
+++ b/python/integration_tests/test_consumer_rebalancing.py
@@ -53,6 +53,22 @@ def manage_consumer(
 
 
 def test_tasks_written_once_during_rebalancing() -> None:
+    """
+    What does this test do?
+    This test is responsible for ensuring that a collection of
+    taskbroker consumers only write a single task to sqlite
+    once during a rebalancing storm.
+
+    How does it accomplish this?
+    Firstly, the topic is created with a set number of partitions (e.g. 32).
+    After a set number of messages are sent to kafka, the test starts N number
+    of taskbroker consumers (e.g. 8). These consumers will consume messages
+    from kafka and write to sqlite in parallel. At random, the test then sends
+    a SIGINT to each consumer, which will trigger a rebalancing event. This
+    process continues until all tasks have been written to sqlite. By using the
+    task's offset, we can validate that all tasks have been written to sqlite
+    only once.
+    """
     # Test configuration
     consumer_path = str(TASKBROKER_BIN)
     num_consumers = 8

--- a/python/integration_tests/test_task_worker_processing.py
+++ b/python/integration_tests/test_task_worker_processing.py
@@ -153,14 +153,13 @@ def test_task_worker_processing() -> None:
     and completes the task (without actually running the activation).
     This process continues until all tasks have been completed only once.
 
-
     How does it accomplish this?
     To accomplish this, the test starts N number of taskworker(s) and a
     consumer in separate. threads. Synchronization events are use to
     instruct the taskworker(s) when start processing and shutdown.
-    A shared dictionary is used to collect duplicate processed tasks.
-    Finally, the total number of fetched and completed tasks are compared
-    to the number of messages sent to taskbroker.
+    A shared dictionary accessed by a mutex is used to collect duplicate
+    processed tasks. Finally, the total number of fetched and completed
+    tasks are compared to the number of messages sent to taskbroker.
 
     Sequence diagram:
     [Thread 1: Consumer]                                        [Thread 2-N: Taskworker(s)]

--- a/python/integration_tests/test_task_worker_processing.py
+++ b/python/integration_tests/test_task_worker_processing.py
@@ -146,14 +146,21 @@ def check_num_tasks_written(consumer_config: dict) -> int:
 
 def test_task_worker_processing() -> None:
     """
-    This tests is responsible for ensuring that all sent to taskbroker are
-    processed and completed by taskworker only once. To accomplish this,
-    the test starts N number of taskworker(s) and a consumer in separate.
-    threads. Synchronization events are use to instruct the taskworker(s)
-    when start processing and shutdown. A shared dictionary is used to
-    collect duplicate processed tasks. Finally, the total number of
-    fetched and completed tasks are compared to the number of messages sent
-    to taskbroker.
+    What does this test do?
+    This tests is responsible for ensuring that all tasks sent to taskbroker
+    are processed and completed by taskworker only once. An initial
+    amount of messages is produced to kafka. Then, mock taskworkers fetches
+    and completes the task (without actually running the activation).
+    This process continues until all tasks have been completed only once.
+
+
+    How does it accomplish this?
+    To accomplish this, the test starts N number of taskworker(s) and a
+    consumer in separate. threads. Synchronization events are use to
+    instruct the taskworker(s) when start processing and shutdown.
+    A shared dictionary is used to collect duplicate processed tasks.
+    Finally, the total number of fetched and completed tasks are compared
+    to the number of messages sent to taskbroker.
 
     Sequence diagram:
     [Thread 1: Consumer]                                        [Thread 2-N: Taskworker(s)]

--- a/python/integration_tests/test_upkeep_retry.py
+++ b/python/integration_tests/test_upkeep_retry.py
@@ -23,7 +23,8 @@ TEST_OUTPUT_PATH = TESTS_OUTPUT_ROOT / "test_upkeep_retry"
 
 class TaskRetriedCounter:
     """
-    A thread safe class that track of the total number of tasks that have been retried.
+    A thread safe class that track of the total number of tasks that have
+    been retried.
     """
     def __init__(self):
         self.task_retried_counter = 0
@@ -56,9 +57,6 @@ def manage_taskworker(
     num_messages: int,
     retries_per_task: int,
 ) -> None:
-    """
-    TODO: Retry consumer description.
-    """
     print(f"[taskworker_{worker_id}] Starting taskworker_{worker_id}")
     worker = SimpleTaskWorker(
         TaskWorkerClient(f"127.0.0.1:{consumer_config['grpc_port']}")
@@ -186,13 +184,12 @@ def test_upkeep_retry() -> None:
     """
     What does this test do?
     This tests is responsible for checking the integrity of the retry
-    mechanism implemented in the upkeep thread of taskbroker. This is
-    accomplished by producing an initial set amount of messages to kafka
-    with a set number of retries in its retry policy. Then, the taskworkers
-    fetches and updates the task's status to retry. During a set interval,
-    the upkeep thread will collect these tasks and re-produce the task to
-    kafka. This process continues until all tasks have been retried the
-    specified number of times.
+    mechanism implemented in the upkeep thread of taskbroker. An initial
+    amount of messages is produced to kafka with a set number of retries
+    in its retry policy. Then, the taskworkers fetches and updates the
+    task's status to retry. During an interval, the upkeep thread will
+    collect these tasks and re-produce the task to kafka. This process
+    continues until all tasks have been retried the specified number of times.
 
     How does it accomplish this?
     The test starts N number of taskworker(s) and a consumer in separate

--- a/python/integration_tests/test_upkeep_retry.py
+++ b/python/integration_tests/test_upkeep_retry.py
@@ -16,7 +16,7 @@ from python.integration_tests.helpers import (
     ConsumerConfig,
 )
 
-from python.integration_tests.worker import ConfigurableTaskWorker, SimpleTaskWorker, TaskWorkerClient
+from python.integration_tests.worker import ConfigurableTaskWorker, TaskWorkerClient
 
 
 TEST_OUTPUT_PATH = TESTS_OUTPUT_ROOT / "test_upkeep_retry"

--- a/python/integration_tests/worker.py
+++ b/python/integration_tests/worker.py
@@ -59,9 +59,10 @@ class TaskWorkerClient:
 
 class SimpleTaskWorker:
     """
-    A simple TaskWorker that is used for integration tests. This taskworker does not
-    actually execute tasks, it simply fetches tasks from the taskworker gRPC server
-    and updates their status depending on the test scenario.
+    A simple TaskWorker that is used for integration tests. This taskworker
+    does not actually execute tasks, it simply fetches tasks from the
+    taskworker gRPC serverand updates their status depending on the test
+    scenario.
     """
 
     def __init__(self, client: TaskWorkerClient, namespace: str | None = None) -> None:

--- a/python/integration_tests/worker.py
+++ b/python/integration_tests/worker.py
@@ -104,11 +104,12 @@ class ConfigurableTaskWorker:
     A taskworker that can be configured to fail/timeout while processing tasks.
     """
 
-    def __init__(self, client: TaskWorkerClient, namespace: str | None = None, failure_rate: float = 0.0, timeout_rate: float = 0.0) -> None:
+    def __init__(self, client: TaskWorkerClient, namespace: str | None = None, failure_rate: float = 0.0, timeout_rate: float = 0.0, retry_rate: float = 0.0) -> None:
         self.client = client
         self._namespace: str | None = namespace
         self._failure_rate: float = failure_rate
         self._timeout_rate: float = timeout_rate
+        self._retry_rate: float = retry_rate
 
     def fetch_task(self) -> TaskActivation | None:
         try:
@@ -125,16 +126,26 @@ class ConfigurableTaskWorker:
         return activation
 
     def process_task(self, activation: TaskActivation) -> TaskActivation | None:
+        update_status = TASK_ACTIVATION_STATUS_COMPLETE
+
         if self._timeout_rate and random.random() < self._timeout_rate:
             return None  # Pretend that the task was dropped
 
         if self._failure_rate and random.random() < self._failure_rate:
             update_status = TASK_ACTIVATION_STATUS_FAILURE
-        else:
-            update_status = TASK_ACTIVATION_STATUS_COMPLETE
+
+        if self._retry_rate and random.random() < self._retry_rate:
+            update_status = TASK_ACTIVATION_STATUS_RETRY
 
         return self.client.update_task(
             task_id=activation.id,
             status=update_status,
+            fetch_next_task=FetchNextTask(namespace=self._namespace),
+        )
+
+    def complete_task(self, activation: TaskActivation) -> TaskActivation | None:
+        return self.client.update_task(
+            task_id=activation.id,
+            status=TASK_ACTIVATION_STATUS_COMPLETE,
             fetch_next_task=FetchNextTask(namespace=self._namespace),
         )

--- a/python/integration_tests/worker.py
+++ b/python/integration_tests/worker.py
@@ -1,7 +1,7 @@
 import grpc
 import time
 
-from sentry_protos.sentry.v1.taskworker_pb2 import TaskActivation, FetchNextTask, GetTaskRequest, SetTaskStatusRequest, TaskActivationStatus, TASK_ACTIVATION_STATUS_COMPLETE
+from sentry_protos.sentry.v1.taskworker_pb2 import TaskActivation, FetchNextTask, GetTaskRequest, SetTaskStatusRequest, TaskActivationStatus, TASK_ACTIVATION_STATUS_COMPLETE, TASK_ACTIVATION_STATUS_RETRY
 from sentry_protos.sentry.v1.taskworker_pb2_grpc import ConsumerServiceStub
 
 
@@ -85,5 +85,12 @@ class SimpleTaskWorker:
         return self.client.update_task(
             task_id=activation.id,
             status=TASK_ACTIVATION_STATUS_COMPLETE,
+            fetch_next_task=FetchNextTask(namespace=self._namespace),
+        )
+
+    def process_task_with_retry(self, activation: TaskActivation) -> TaskActivation | None:
+        return self.client.update_task(
+            task_id=activation.id,
+            status=TASK_ACTIVATION_STATUS_RETRY,
             fetch_next_task=FetchNextTask(namespace=self._namespace),
         )


### PR DESCRIPTION
### What does this test do?
This tests is responsible for checking the integrity of the retry mechanism implemented in the upkeep thread of taskbroker. An initial amount of messages is produced to kafka with a set number of retries in its retry policy. Then, the taskworkers fetch and update the task's status to retry. During an interval, the upkeep thread will collect these tasks and re-produce the task to kafka. This process continues until all tasks have been retried the specified number of times.

### How does it accomplish this?
The test starts N number of taskworker(s) and a consumer in separate
threads. Synchronization events are use to instruct the taskworker(s) when start processing and shutdown. A shared data structured access by a mutex called TaskRetriedCounter is used to globally keep track of every task retried. Finally, this total number is validated alongside the number of times each individual task was retried.