### PR TITLE
Replace DATETIME columns with INTEGER

### DIFF
--- a/migrations/0001_create_inflight_taskactivations.sql
+++ b/migrations/0001_create_inflight_taskactivations.sql
@@ -3,10 +3,10 @@ CREATE TABLE IF NOT EXISTS inflight_taskactivations (
     activation BLOB NOT NULL,
     partition INTEGER NOT NULL,
     offset BIGINTEGER NOT NULL,
-    added_at DATETIME NOT NULL,
-    remove_at DATETIME,
+    added_at INTEGER NOT NULL,
+    remove_at INTEGER NOT NULL,
     processing_deadline_duration INTEGER NOT NULL,
-    processing_deadline DATETIME,
+    processing_deadline INTEGER,
     status INTEGER NOT NULL,
     at_most_once BOOLEAN NOT NULL DEFAULT FALSE,
     namespace TEXT

--- a/src/consumer/deserialize_activation.rs
+++ b/src/consumer/deserialize_activation.rs
@@ -67,8 +67,8 @@ pub fn new(
             partition: msg.partition(),
             offset: msg.offset(),
             added_at: Utc::now(),
-            remove_at: Some(remove_at),
             processing_deadline: None,
+            remove_at,
             at_most_once,
             namespace,
         })
@@ -126,7 +126,7 @@ mod tests {
 
         assert!(inflight_opt.is_ok());
         let inflight = inflight_opt.unwrap();
-        let delta = inflight.remove_at.unwrap() - now;
+        let delta = inflight.remove_at - now;
         assert!(
             delta.num_seconds() >= 900,
             "Should have at least 900 seconds of delay from now"
@@ -173,7 +173,7 @@ mod tests {
 
         assert!(inflight_opt.is_ok());
         let inflight = inflight_opt.unwrap();
-        let delta = inflight.remove_at.unwrap() - the_past;
+        let delta = inflight.remove_at - the_past;
         assert!(
             delta.num_seconds() >= 99,
             "Should have ~100 seconds of delay from received_at"

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,6 +7,8 @@ use rdkafka::{
     producer::FutureProducer,
     Message,
 };
+use std::ops::Add;
+use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
@@ -50,7 +52,7 @@ pub fn make_activations(count: u32) -> Vec<InflightActivation> {
             partition: 0,
             offset: i as i64,
             added_at: Utc::now(),
-            remove_at: None,
+            remove_at: Utc::now().add(Duration::from_secs(5 * 60)),
             processing_deadline: None,
             at_most_once: false,
             namespace: "namespace".into(),

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -478,9 +478,9 @@ mod tests {
 
         let mut batch = make_activations(3);
         // Because 1 is complete and has a higher offset than 0, index 2 can be discarded
-        batch[0].remove_at = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
+        batch[0].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
         batch[1].status = InflightActivationStatus::Complete;
-        batch[2].remove_at = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
+        batch[2].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
 
         assert!(store.store(batch.clone()).await.is_ok());
         do_upkeep(config, store.clone(), producer).await;


### PR DESCRIPTION
SQlite doesn't have a specific storage type for datetime values and uses TEXT instead. This requires careful use of `datetime()` functions on value. By switching to INTEGER columns we won't get burned by future changes to datetime logic if we forget a function. It should also result in smaller database sizes. sqlx includes trait implementations to convert `DateTime<Utc>` into a timestamp already and from a timestamp into `DateTime<Utc>`.

I've also made `remove_at` required as we should not store an activation that cannot be purged in the future.

Fixes #111