### PR TITLE
feat(tests): End-to-end integration for upkeep DLQ 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,27 @@ jobs:
       - name: Run upkeep retry integration test
         run: |
           make test-upkeep-retry
+  
+  upkeep-dlq-integration-test:
+    name: Upkeep DLQ integration test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+        with:
+          key: ${{ github.job }}
+
+      - name: Run upkeep DLQ integration test
+        run: |
+          make test-upkeep-dlq

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,11 @@ test-upkeep-retry: build reset-kafka ## Run the upkeep retry integration test
 	rm -r python/integration_tests/.tests_output/test_upkeep_retry
 .PHONY: test-upkeep-retry
 
-integration-test: test-rebalance test-worker-processing ## Run all integration tests
+test-upkeep-dlq: build reset-kafka ## Run the upkeep dlq integration test
+	python -m pytest python/integration_tests/test_upkeep_dlq.py -s
+.PHONY: test-upkeep-dlq
+
+integration-test: test-rebalance test-worker-processing test-upkeep-retry ## Run all integration tests
 .PHONY: integration-test
 
 # Help

--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,11 @@ test-upkeep-retry: build reset-kafka ## Run the upkeep retry integration test
 	rm -r python/integration_tests/.tests_output/test_upkeep_retry
 .PHONY: test-upkeep-retry
 
-<<<<<<< HEAD
 test-upkeep-dlq: build reset-kafka ## Run the upkeep dlq integration test
 	python -m pytest python/integration_tests/test_upkeep_dlq.py -s
+	rm -r python/integration_tests/.tests_output/test_upkeep_dlq
 .PHONY: test-upkeep-dlq
 
-=======
->>>>>>> origin
 integration-test: test-rebalance test-worker-processing test-upkeep-retry ## Run all integration tests
 .PHONY: integration-test
 

--- a/python/integration_tests/helpers.py
+++ b/python/integration_tests/helpers.py
@@ -133,7 +133,7 @@ def send_custom_messages_to_topic(topic_name: str, custom_messages: list[TaskAct
 
         producer.poll(5)  # trigger delivery reports
         producer.flush()
-        print(f"Sent {num_messages} custom messages to kafka topic {topic_name}")
+        print(f"Sent {len(custom_messages)} custom messages to kafka topic {topic_name}")
     except Exception as e:
         raise Exception(f"Failed to send messages to kafka: {e}")
 

--- a/python/integration_tests/helpers.py
+++ b/python/integration_tests/helpers.py
@@ -20,6 +20,11 @@ TEST_PRODUCER_CONFIG = {
     "bootstrap.servers": "127.0.0.1:9092",
     "broker.address.family": "v4",
 }
+TEST_CONSUMER_CONFIG = {
+    'bootstrap.servers': "127.0.0.1:9092",
+    'group.id': 'my-group',
+    'auto.offset.reset': 'earliest',
+}
 
 
 class TaskbrokerConfig:
@@ -110,6 +115,7 @@ def send_generic_messages_to_topic(topic_name: str, num_messages: int) -> None:
 
         producer.poll(5)  # trigger delivery reports
         producer.flush()
+        print(f"Sent {num_messages} generic messages to kafka topic {topic_name}")
     except Exception as e:
         raise Exception(f"Failed to send messages to kafka: {e}")
 
@@ -127,6 +133,7 @@ def send_custom_messages_to_topic(topic_name: str, custom_messages: list[TaskAct
 
         producer.poll(5)  # trigger delivery reports
         producer.flush()
+        print(f"Sent {num_messages} custom messages to kafka topic {topic_name}")
     except Exception as e:
         raise Exception(f"Failed to send messages to kafka: {e}")
 
@@ -138,11 +145,7 @@ def get_topic_size(topic_name: str) -> int:
     """
     attempts = 30
     size = 0
-    consumer = Consumer({
-        'bootstrap.servers': "127.0.0.1:9092",
-        'group.id': 'my-group',
-        'auto.offset.reset': 'earliest',
-    })
+    consumer = Consumer(TEST_CONSUMER_CONFIG)
     consumer.subscribe([topic_name])
     while attempts > 0:
         event = consumer.poll(1.0)

--- a/python/integration_tests/helpers.py
+++ b/python/integration_tests/helpers.py
@@ -113,7 +113,7 @@ def send_generic_messages_to_topic(topic_name: str, num_messages: int) -> None:
             task_message = serialize_task_activation(i, ["foobar"], {})
             producer.produce(topic_name, task_message)
 
-        producer.poll(5)  # trigger delivery reports
+        producer.flush()
         print(f"Sent {num_messages} generic messages to kafka topic {topic_name}")
     except Exception as e:
         raise Exception(f"Failed to send messages to kafka: {e}")
@@ -130,7 +130,7 @@ def send_custom_messages_to_topic(topic_name: str, custom_messages: list[TaskAct
             task_message = message.SerializeToString()
             producer.produce(topic_name, task_message)
 
-        producer.poll(5)  # trigger delivery reports
+        producer.flush()
         print(f"Sent {len(custom_messages)} custom messages to kafka topic {topic_name}")
     except Exception as e:
         raise Exception(f"Failed to send messages to kafka: {e}")

--- a/python/integration_tests/helpers.py
+++ b/python/integration_tests/helpers.py
@@ -22,7 +22,7 @@ TEST_PRODUCER_CONFIG = {
 }
 
 
-class ConsumerConfig:
+class TaskbrokerConfig:
     def __init__(
         self,
         db_name: str,

--- a/python/integration_tests/helpers.py
+++ b/python/integration_tests/helpers.py
@@ -114,7 +114,6 @@ def send_generic_messages_to_topic(topic_name: str, num_messages: int) -> None:
             producer.produce(topic_name, task_message)
 
         producer.poll(5)  # trigger delivery reports
-        producer.flush()
         print(f"Sent {num_messages} generic messages to kafka topic {topic_name}")
     except Exception as e:
         raise Exception(f"Failed to send messages to kafka: {e}")
@@ -132,7 +131,6 @@ def send_custom_messages_to_topic(topic_name: str, custom_messages: list[TaskAct
             producer.produce(topic_name, task_message)
 
         producer.poll(5)  # trigger delivery reports
-        producer.flush()
         print(f"Sent {len(custom_messages)} custom messages to kafka topic {topic_name}")
     except Exception as e:
         raise Exception(f"Failed to send messages to kafka: {e}")

--- a/python/integration_tests/test_consumer_rebalancing.py
+++ b/python/integration_tests/test_consumer_rebalancing.py
@@ -14,7 +14,6 @@ from python.integration_tests.helpers import (
     TESTS_OUTPUT_ROOT,
     create_topic,
     send_generic_messages_to_topic,
-    send_generic_messages_to_topic,
     TaskbrokerConfig,
 )
 
@@ -81,6 +80,7 @@ def test_tasks_written_once_during_rebalancing() -> None:
     max_restart_duration = 30
     max_pending_count = 15_000
     topic_name = "task-worker"
+    kafka_deadletter_topic = "task-worker-dlq"
     curr_time = int(time.time())
 
     print(
@@ -109,13 +109,14 @@ Running test with the following configuration:
         filename = f"config_{i}.yml"
         db_name = f"db_{i}_{curr_time}"
         taskbroker_configs[filename] = TaskbrokerConfig(
-            db_name,
-            str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
-            max_pending_count,
-            topic_name,
-            topic_name,
-            "earliest",
-            50051 + i,
+            db_name=db_name,
+            db_path=str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
+            max_pending_count=max_pending_count,
+            topic_name=topic_name,
+            kafka_deadletter_topic=kafka_deadletter_topic,
+            kafka_consumer_group_id=f"task-worker-{i}",
+            kafka_consumer_offset="earliest",
+            kafka_consumer_port=50051 + i,
         )
 
     for filename, config in taskbroker_configs.items():

--- a/python/integration_tests/test_consumer_rebalancing.py
+++ b/python/integration_tests/test_consumer_rebalancing.py
@@ -112,11 +112,11 @@ Running test with the following configuration:
             db_name=db_name,
             db_path=str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
             max_pending_count=max_pending_count,
-            topic_name=topic_name,
+            kafka_topic=topic_name,
             kafka_deadletter_topic=kafka_deadletter_topic,
-            kafka_consumer_group_id=f"task-worker-{i}",
-            kafka_consumer_offset="earliest",
-            kafka_consumer_port=50051 + i,
+            kafka_consumer_group=f"task-worker-{i}",
+            kafka_auto_offset_reset="earliest",
+            grpc_port=50051 + i,
         )
 
     for filename, config in taskbroker_configs.items():

--- a/python/integration_tests/test_consumer_rebalancing.py
+++ b/python/integration_tests/test_consumer_rebalancing.py
@@ -114,7 +114,7 @@ Running test with the following configuration:
             max_pending_count=max_pending_count,
             kafka_topic=topic_name,
             kafka_deadletter_topic=kafka_deadletter_topic,
-            kafka_consumer_group=f"task-worker-{i}",
+            kafka_consumer_group=topic_name,
             kafka_auto_offset_reset="earliest",
             grpc_port=50051 + i,
         )

--- a/python/integration_tests/test_consumer_rebalancing.py
+++ b/python/integration_tests/test_consumer_rebalancing.py
@@ -15,7 +15,7 @@ from python.integration_tests.helpers import (
     TASKBROKER_BIN,
     TESTS_OUTPUT_ROOT,
     create_topic,
-    send_messages_to_kafka,
+    send_generic_messages_to_topic,
     ConsumerConfig
 )
 
@@ -114,7 +114,7 @@ Running test with the following configuration:
             yaml.safe_dump(config.to_dict(), f)
 
     try:
-        send_messages_to_kafka(topic_name, num_messages)
+        send_generic_messages_to_topic(topic_name, num_messages)
         threads: list[Thread] = []
         for i in range(num_consumers):
             thread = threading.Thread(

--- a/python/integration_tests/test_task_worker_processing.py
+++ b/python/integration_tests/test_task_worker_processing.py
@@ -202,6 +202,7 @@ def test_task_worker_processing() -> None:
         60  # the time in seconds to wait for all messages to be written to sqlite
     )
     topic_name = "task-worker"
+    kafka_deadletter_topic = "task-worker-dlq"
     curr_time = int(time.time())
 
     print(
@@ -223,13 +224,14 @@ Running test with the following configuration:
     db_name = f"db_0_{curr_time}_test_task_worker_processing"
     config_filename = "config_0_test_task_worker_processing.yml"
     taskbroker_config = TaskbrokerConfig(
-        db_name,
-        str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
-        max_pending_count,
-        topic_name,
-        topic_name,
-        "earliest",
-        50051
+        db_name=db_name,
+        db_path=str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
+        max_pending_count=max_pending_count,
+        topic_name=topic_name,
+        kafka_deadletter_topic=kafka_deadletter_topic,
+        kafka_consumer_group=topic_name,
+        kafka_consumer_offset="earliest",
+        kafka_consumer_port=50051
     )
 
     with open(str(TEST_OUTPUT_PATH / config_filename), "w") as f:

--- a/python/integration_tests/test_task_worker_processing.py
+++ b/python/integration_tests/test_task_worker_processing.py
@@ -10,9 +10,9 @@ from collections import defaultdict
 from python.integration_tests.helpers import (
     TASKBROKER_BIN,
     TESTS_OUTPUT_ROOT,
-    send_messages_to_kafka,
+    send_generic_messages_to_topic,
     create_topic,
-    check_num_tasks_written,
+    get_num_tasks_in_sqlite,
     ConsumerConfig
 )
 
@@ -101,7 +101,7 @@ def manage_consumer(
         # Let the consumer write the messages to sqlite
         end = time.time() + timeout
         while (time.time() < end) and (not tasks_written_event.is_set()):
-            written_tasks = check_num_tasks_written(consumer_config)
+            written_tasks = get_num_tasks_in_sqlite(consumer_config)
             if written_tasks == num_messages:
                 print(
                     f"[consumer_0]: Finishing writting all {num_messages} task(s) to sqlite. Sending signal to taskworker(s) to start processing"
@@ -211,7 +211,7 @@ Running test with the following configuration:
         yaml.safe_dump(consumer_config.to_dict(), f)
 
     try:
-        send_messages_to_kafka(topic_name, num_messages)
+        send_generic_messages_to_topic(topic_name, num_messages)
         tasks_written_event = threading.Event()
         shutdown_events = [threading.Event() for _ in range(num_workers)]
         consumer_thread = threading.Thread(

--- a/python/integration_tests/test_task_worker_processing.py
+++ b/python/integration_tests/test_task_worker_processing.py
@@ -227,11 +227,11 @@ Running test with the following configuration:
         db_name=db_name,
         db_path=str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
         max_pending_count=max_pending_count,
-        topic_name=topic_name,
+        kafka_topic=topic_name,
         kafka_deadletter_topic=kafka_deadletter_topic,
         kafka_consumer_group=topic_name,
-        kafka_consumer_offset="earliest",
-        kafka_consumer_port=50051
+        kafka_auto_offset_reset="earliest",
+        grpc_port=50051
     )
 
     with open(str(TEST_OUTPUT_PATH / config_filename), "w") as f:

--- a/python/integration_tests/test_upkeep_dlq.py
+++ b/python/integration_tests/test_upkeep_dlq.py
@@ -1,0 +1,163 @@
+import orjson
+import sqlite3
+import signal
+import subprocess
+import threading
+import time
+
+import yaml
+from uuid import uuid4
+from google.protobuf.timestamp_pb2 import Timestamp
+from python.integration_tests.helpers import (
+    TASKBROKER_BIN,
+    TESTS_OUTPUT_ROOT,
+    send_messages_to_kafka,
+    create_topic,
+    check_num_tasks_written,
+    ConsumerConfig,
+)
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
+    OnAttemptsExceeded,
+    RetryState,
+    TaskActivation,
+)
+
+
+TEST_OUTPUT_PATH = TESTS_OUTPUT_ROOT / "test_upkeep_dlq"
+
+
+def manage_consumer(
+    consumer_path: str,
+    config_file_path: str,
+    consumer_config: ConsumerConfig,
+    log_file_path: str,
+    timeout: int,
+    num_messages: int,
+) -> None:
+    with open(log_file_path, "a") as log_file:
+        print(f"[consumer_0] Starting consumer, writing log file to {log_file_path}")
+        process = subprocess.Popen(
+            [consumer_path, "-c", config_file_path],
+            stderr=subprocess.STDOUT,
+            stdout=log_file,
+        )
+        time.sleep(3)
+
+        # Keep gRPC consumer alive until taskworker is done processing
+        print("[consumer_0]: Waiting for upkeep to discard/deadletter tasks")
+        while True:
+            attach_db_stmt = f"ATTACH DATABASE '{consumer_config.db_path}' AS {consumer_config.db_name};\n"
+            query = f"""SELECT * FROM {consumer_config.db_name}.inflight_taskactivations;"""
+            con = sqlite3.connect(consumer_config.db_path)
+            cur = con.cursor()
+            cur.executescript(attach_db_stmt)
+            rows = cur.execute(query).fetchall()
+            print(rows)
+            time.sleep(3)
+        print("[consumer_0]: Received shutdown signal from all taskworker(s)")
+
+        # Stop the consumer
+        print("[consumer_0]: Shutting down consumer")
+        process.send_signal(signal.SIGINT)
+        try:
+            return_code = process.wait(timeout=10)
+            assert return_code == 0
+        except Exception:
+            process.kill()
+
+
+def test_upkeep_dlq() -> None:
+    """
+    Testing DLQ and discard when remove_at elapses.
+    - Produce N messages to kafka where the tasks retry policy max_attempts is 5 (does not matter) and on_attempts_exceeded is set to deadletter and expires to 0.
+
+    Testing DLQ and discard when max_attempts is reached.
+    - Produce N messages to kafka where the tasks retry policy max_attempts is 3 and set to deadletter
+    - Expect the tasks to try 3 times, then be deadlettered
+    __________________________
+    What does this test do?
+
+    How does it accomplish this?
+
+
+    Sequence diagram:
+ 
+    """
+
+    # Test configuration
+    consumer_path = str(TASKBROKER_BIN)
+    num_messages = 5000
+    num_partitions = 4
+    max_pending_count = 100_000
+    consumer_timeout = (
+        60  # the time in seconds to wait for all messages to be written to sqlite
+    )
+    topic_name = "task-worker"
+    curr_time = int(time.time())
+
+    print(
+        f"""
+Running test with the following configuration:
+        num of messages: {num_messages},
+        num of partitions: {num_partitions},
+        max pending count: {max_pending_count},
+        topic name: {topic_name}
+    """
+    )
+
+    create_topic(topic_name, num_partitions)
+
+    # Create config file for consumer
+    print("Creating config file for consumer")
+    TEST_OUTPUT_PATH.mkdir(parents=True, exist_ok=True)
+    db_name = f"db_0_{curr_time}_test_upkeep_dlq"
+    config_filename = "config_0_test_upkeep_dlq.yml"
+    consumer_config = ConsumerConfig(
+        db_name,
+        str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
+        max_pending_count,
+        topic_name,
+        topic_name,
+        "earliest",
+        50051
+    )
+
+    with open(str(TEST_OUTPUT_PATH / config_filename), "w") as f:
+        yaml.safe_dump(consumer_config.to_dict(), f)
+
+    try:
+        # Produce N messages to kafka that expires immediately
+        retry_state = RetryState(
+            attempts=0,
+            max_attempts=1,
+            on_attempts_exceeded=OnAttemptsExceeded.ON_ATTEMPTS_EXCEEDED_DISCARD,
+        )
+        custom_task_activation = TaskActivation(
+            id=uuid4().hex,
+            namespace="integration_tests",
+            taskname="integration_tests.say_hello",
+            parameters=orjson.dumps({"args": ["foobar"], "kwargs": {}}),
+            retry_state=retry_state,
+            processing_deadline_duration=3000,
+            received_at=Timestamp(seconds=int(time.time())),
+            expires=0,
+        )
+        send_messages_to_kafka(topic_name, num_messages, custom_task_activation)
+        consumer_thread = threading.Thread(
+            target=manage_consumer,
+            args=(
+                consumer_path,
+                str(TEST_OUTPUT_PATH / config_filename),
+                consumer_config,
+                str(
+                    TEST_OUTPUT_PATH
+                    / f"consumer_0_{curr_time}_test_upkeep_dlq.log"
+                ),
+                consumer_timeout,
+                num_messages,
+            ),
+        )
+        consumer_thread.start()
+        consumer_thread.join()
+    except Exception as e:
+        raise Exception(f"Error running taskbroker: {e}")

--- a/python/integration_tests/test_upkeep_dlq.py
+++ b/python/integration_tests/test_upkeep_dlq.py
@@ -338,4 +338,4 @@ Running test with the following configuration:
     dlq_size = get_topic_size(dlq_topic_name)
 
     assert num_completed_tasks == num_messages  # all tasks should be completed as a result of discard or deadlettering
-    assert dlq_size == num_messages / 2  # half of the tasks should be deadlettered
+    assert dlq_size == (num_messages - 1) / 2  # half of the tasks should be deadlettered

--- a/python/integration_tests/test_upkeep_dlq.py
+++ b/python/integration_tests/test_upkeep_dlq.py
@@ -11,19 +11,57 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from python.integration_tests.helpers import (
     TASKBROKER_BIN,
     TESTS_OUTPUT_ROOT,
-    send_messages_to_kafka,
+    send_custom_messages_to_topic,
     create_topic,
-    check_num_tasks_written,
+    get_num_tasks_in_sqlite,
+    get_num_tasks_in_sqlite_by_status,
     ConsumerConfig,
 )
+from python.integration_tests.worker import TaskWorkerClient
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     OnAttemptsExceeded,
     RetryState,
     TaskActivation,
+    TASK_ACTIVATION_STATUS_COMPLETE
 )
 
 
 TEST_OUTPUT_PATH = TESTS_OUTPUT_ROOT / "test_upkeep_dlq"
+
+
+def manage_taskworker(
+    consumer_config: ConsumerConfig,
+    tasks_written_event: threading.Event,
+    shutdown_event: threading.Event,
+    last_task_id: str,
+) -> None:
+    """
+    A special task worker that only fetches one most recent task (not the oldest) and completes it
+    """
+    worker_id = 0
+    print(f"[taskworker_{worker_id}] Starting taskworker_{worker_id}")
+    client = TaskWorkerClient(f"127.0.0.1:{consumer_config.grpc_port}")
+
+    # Wait for consumer to initialize sqlite and write tasks to it
+    print(
+        f"[taskworker_{worker_id}]: Waiting for consumer to initialize sqlite and write tasks to it..."
+    )
+    while not tasks_written_event.is_set():
+        time.sleep(1)
+
+    try:
+        client.update_task(
+            task_id=last_task_id,
+            status=TASK_ACTIVATION_STATUS_COMPLETE,
+            fetch_next_task=None,
+        )
+        print(f"[taskworker_{worker_id}]: Completed the most recent (not the oldest) task. Upkeep will now be able to discard/deadletter all the task before it")
+        print(f"[taskworker_{worker_id}]: Shutting down successfully now")
+    except Exception as e:
+        print(f"[taskworker_{worker_id}]: Worker process crashed: {e}")
+        print(f"[taskworker_{worker_id}]: Unable to complete the most recent task. Sending shutdown signal to consumer")
+        shutdown_event.set()
+        return
 
 
 def manage_consumer(
@@ -33,6 +71,8 @@ def manage_consumer(
     log_file_path: str,
     timeout: int,
     num_messages: int,
+    tasks_written_event: threading.Event,
+    shutdown_event: threading.Event,
 ) -> None:
     with open(log_file_path, "a") as log_file:
         print(f"[consumer_0] Starting consumer, writing log file to {log_file_path}")
@@ -43,20 +83,33 @@ def manage_consumer(
         )
         time.sleep(3)
 
-        # Keep gRPC consumer alive until taskworker is done processing
-        print("[consumer_0]: Waiting for upkeep to discard/deadletter tasks")
-        while True:
-            attach_db_stmt = f"ATTACH DATABASE '{consumer_config.db_path}' AS {consumer_config.db_name};\n"
-            query = f"""SELECT * FROM {consumer_config.db_name}.inflight_taskactivations;"""
-            con = sqlite3.connect(consumer_config.db_path)
-            cur = con.cursor()
-            cur.executescript(attach_db_stmt)
-            rows = cur.execute(query).fetchall()
-            print(rows)
-            time.sleep(3)
-        print("[consumer_0]: Received shutdown signal from all taskworker(s)")
+        # Let the consumer write the messages to sqlite
+        end = time.time() + timeout
+        while (time.time() < end) and (not tasks_written_event.is_set()):
+            written_tasks = get_num_tasks_in_sqlite(consumer_config)
+            if written_tasks == num_messages:
+                print(
+                    f"[consumer_0]: Finishing writting all {num_messages} task(s) to sqlite. Sending signal to taskworker to start processing"
+                )
+                tasks_written_event.set()
+            time.sleep(1)
 
-        # Stop the consumer
+        print("[consumer_0]: Waiting for upkeep to discard/deadletter tasks")
+        end = time.time() + timeout
+        cur_time = time.time()
+        num_completed_tasks = 0
+        while (not shutdown_event.is_set()) and (cur_time < end) and (num_completed_tasks < num_messages):
+            num_completed_tasks = get_num_tasks_in_sqlite_by_status(consumer_config, "Complete")
+            print(num_completed_tasks)
+            time.sleep(3)
+            cur_time = time.time()
+        if shutdown_event.is_set():
+            print("[consumer_0]: Received shutdown signal from taskworker. Consumer was unable to complete task. Shutting down taskbroker.")
+
+        if cur_time >= end:
+            print("[consumer_0]: Taskbroker (upkeep) did not finish discarding/deadlettering tasks before timeout. Shutting down taskbroker.")
+
+        # Stop the taskbroker
         print("[consumer_0]: Shutting down consumer")
         process.send_signal(signal.SIGINT)
         try:
@@ -90,7 +143,7 @@ def test_upkeep_dlq() -> None:
     num_partitions = 4
     max_pending_count = 100_000
     consumer_timeout = (
-        60  # the time in seconds to wait for all messages to be written to sqlite
+        60  # the time in seconds to wait for taskbroker to process
     )
     topic_name = "task-worker"
     curr_time = int(time.time())
@@ -127,22 +180,37 @@ Running test with the following configuration:
 
     try:
         # Produce N messages to kafka that expires immediately
-        retry_state = RetryState(
-            attempts=0,
-            max_attempts=1,
-            on_attempts_exceeded=OnAttemptsExceeded.ON_ATTEMPTS_EXCEEDED_DISCARD,
-        )
-        custom_task_activation = TaskActivation(
-            id=uuid4().hex,
-            namespace="integration_tests",
-            taskname="integration_tests.say_hello",
-            parameters=orjson.dumps({"args": ["foobar"], "kwargs": {}}),
-            retry_state=retry_state,
-            processing_deadline_duration=3000,
-            received_at=Timestamp(seconds=int(time.time())),
-            expires=0,
-        )
-        send_messages_to_kafka(topic_name, num_messages, custom_task_activation)
+        custom_messages = []
+        last_task_id = ""
+        for i in range(num_messages):
+            id = uuid4().hex
+
+            # Capture the last task id so that we can complete it later
+            if i == num_messages - 1:
+                last_task_id = id
+
+            retry_state = RetryState(
+                attempts=0,
+                max_attempts=1,
+                on_attempts_exceeded=OnAttemptsExceeded.ON_ATTEMPTS_EXCEEDED_DISCARD,
+            )
+            task_activation = TaskActivation(
+                id=id,
+                namespace="integration_tests",
+                taskname=f"integration_tests.say_hello_{i}",
+                parameters=orjson.dumps({"args": ["foobar"], "kwargs": {}}),
+                retry_state=retry_state,
+                processing_deadline_duration=3000,
+                received_at=Timestamp(seconds=int(time.time())),
+                expires=1,
+            )
+            custom_messages.append(task_activation)
+
+        send_custom_messages_to_topic(topic_name, custom_messages)
+        tasks_written_event = threading.Event()
+        shutdown_event = threading.Event()
+
+        # Create consumer thread
         consumer_thread = threading.Thread(
             target=manage_consumer,
             args=(
@@ -155,9 +223,25 @@ Running test with the following configuration:
                 ),
                 consumer_timeout,
                 num_messages,
+                tasks_written_event,
+                shutdown_event,
             ),
         )
         consumer_thread.start()
+
+        # Create worker thread
+        worker_thread = threading.Thread(
+            target=manage_taskworker,
+            args=(
+                consumer_config,
+                tasks_written_event,
+                shutdown_event,
+                last_task_id,
+            ),
+        )
+        worker_thread.start()
+
         consumer_thread.join()
+        worker_thread.join()
     except Exception as e:
         raise Exception(f"Error running taskbroker: {e}")

--- a/python/integration_tests/test_upkeep_dlq.py
+++ b/python/integration_tests/test_upkeep_dlq.py
@@ -1,5 +1,4 @@
 import orjson
-import sqlite3
 import signal
 import subprocess
 import threading
@@ -15,7 +14,7 @@ from python.integration_tests.helpers import (
     create_topic,
     get_num_tasks_in_sqlite,
     get_num_tasks_in_sqlite_by_status,
-    ConsumerConfig,
+    TaskbrokerConfig,
 )
 from python.integration_tests.worker import TaskWorkerClient
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
@@ -30,21 +29,23 @@ TEST_OUTPUT_PATH = TESTS_OUTPUT_ROOT / "test_upkeep_dlq"
 
 
 def manage_taskworker(
-    consumer_config: ConsumerConfig,
+    taskbroker_config: TaskbrokerConfig,
     tasks_written_event: threading.Event,
     shutdown_event: threading.Event,
     last_task_id: str,
 ) -> None:
     """
-    A special task worker that only fetches one most recent task (not the oldest) and completes it
+    A special task worker that only fetches one most recent task
+    (not the oldest) and completes it
     """
     worker_id = 0
     print(f"[taskworker_{worker_id}] Starting taskworker_{worker_id}")
-    client = TaskWorkerClient(f"127.0.0.1:{consumer_config.grpc_port}")
+    client = TaskWorkerClient(f"127.0.0.1:{taskbroker_config.grpc_port}")
 
-    # Wait for consumer to initialize sqlite and write tasks to it
+    # Wait for taskbroker to initialize sqlite and write tasks to it
     print(
-        f"[taskworker_{worker_id}]: Waiting for consumer to initialize sqlite and write tasks to it..."
+        f"[taskworker_{worker_id}]: Waiting for taskbroker to initialize "
+        "sqlite and write tasks to it..."
     )
     while not tasks_written_event.is_set():
         time.sleep(1)
@@ -55,19 +56,26 @@ def manage_taskworker(
             status=TASK_ACTIVATION_STATUS_COMPLETE,
             fetch_next_task=None,
         )
-        print(f"[taskworker_{worker_id}]: Completed the most recent (not the oldest) task. Upkeep will now be able to discard/deadletter all the task before it")
+        print(
+            f"[taskworker_{worker_id}]: Completed the most recent "
+            "(not the oldest) task. Upkeep will now be able to "
+            "discard/deadletter all the task before it"
+        )
         print(f"[taskworker_{worker_id}]: Shutting down successfully now")
     except Exception as e:
         print(f"[taskworker_{worker_id}]: Worker process crashed: {e}")
-        print(f"[taskworker_{worker_id}]: Unable to complete the most recent task. Sending shutdown signal to consumer")
+        print(
+            f"[taskworker_{worker_id}]: Unable to complete the most "
+            f"recent task. Sending shutdown signal to taskbroker"
+        )
         shutdown_event.set()
         return
 
 
-def manage_consumer(
-    consumer_path: str,
+def manage_taskbroker(
+    taskbroker_path: str,
     config_file_path: str,
-    consumer_config: ConsumerConfig,
+    taskbroker_config: TaskbrokerConfig,
     log_file_path: str,
     timeout: int,
     num_messages: int,
@@ -75,42 +83,62 @@ def manage_consumer(
     shutdown_event: threading.Event,
 ) -> None:
     with open(log_file_path, "a") as log_file:
-        print(f"[consumer_0] Starting consumer, writing log file to {log_file_path}")
+        print(
+            f"[taskbroker_0] Starting taskbroker, writing log file to "
+            f"{log_file_path}"
+        )
         process = subprocess.Popen(
-            [consumer_path, "-c", config_file_path],
+            [taskbroker_path, "-c", config_file_path],
             stderr=subprocess.STDOUT,
             stdout=log_file,
         )
         time.sleep(3)
 
-        # Let the consumer write the messages to sqlite
+        # Let the taskbroker write the messages to sqlite
         end = time.time() + timeout
         while (time.time() < end) and (not tasks_written_event.is_set()):
-            written_tasks = get_num_tasks_in_sqlite(consumer_config)
+            written_tasks = get_num_tasks_in_sqlite(taskbroker_config)
             if written_tasks == num_messages:
                 print(
-                    f"[consumer_0]: Finishing writting all {num_messages} task(s) to sqlite. Sending signal to taskworker to start processing"
+                    f"[taskbroker_0]: Finishing writting all {num_messages} "
+                    "task(s) to sqlite. Sending signal to taskworker to "
+                    "start processing"
                 )
                 tasks_written_event.set()
             time.sleep(1)
 
-        print("[consumer_0]: Waiting for upkeep to discard/deadletter tasks")
+        print("[taskbroker_0]: Waiting for upkeep to discard/deadletter tasks")
         end = time.time() + timeout
         cur_time = time.time()
         num_completed_tasks = 0
-        while (not shutdown_event.is_set()) and (cur_time < end) and (num_completed_tasks < num_messages):
-            num_completed_tasks = get_num_tasks_in_sqlite_by_status(consumer_config, "Complete")
+        while (
+            (not shutdown_event.is_set()) and
+            (cur_time < end) and
+            (num_completed_tasks < num_messages)
+        ):
+            num_completed_tasks = get_num_tasks_in_sqlite_by_status(
+                taskbroker_config,
+                "Complete"
+            )
             print(num_completed_tasks)
             time.sleep(3)
             cur_time = time.time()
         if shutdown_event.is_set():
-            print("[consumer_0]: Received shutdown signal from taskworker. Consumer was unable to complete task. Shutting down taskbroker.")
+            print(
+                "[taskbroker_0]: Received shutdown signal from taskworker. "
+                "Taskbroker was unable to complete task. "
+                "Shutting down taskbroker."
+            )
 
         if cur_time >= end:
-            print("[consumer_0]: Taskbroker (upkeep) did not finish discarding/deadlettering tasks before timeout. Shutting down taskbroker.")
+            print(
+                "[taskbroker_0]: Taskbroker (upkeep) did not finish "
+                "discarding/deadlettering tasks before timeout. "
+                "Shutting down taskbroker."
+            )
 
         # Stop the taskbroker
-        print("[consumer_0]: Shutting down consumer")
+        print("[taskbroker_0]: Shutting down taskbroker")
         process.send_signal(signal.SIGINT)
         try:
             return_code = process.wait(timeout=10)
@@ -138,11 +166,11 @@ def test_upkeep_dlq() -> None:
     """
 
     # Test configuration
-    consumer_path = str(TASKBROKER_BIN)
+    taskbroker_path = str(TASKBROKER_BIN)
     num_messages = 5000
     num_partitions = 4
     max_pending_count = 100_000
-    consumer_timeout = (
+    taskbroker_timeout = (
         60  # the time in seconds to wait for taskbroker to process
     )
     topic_name = "task-worker"
@@ -160,12 +188,12 @@ Running test with the following configuration:
 
     create_topic(topic_name, num_partitions)
 
-    # Create config file for consumer
-    print("Creating config file for consumer")
+    # Create config file for taskbroker
+    print("Creating config file for taskbroker")
     TEST_OUTPUT_PATH.mkdir(parents=True, exist_ok=True)
     db_name = f"db_0_{curr_time}_test_upkeep_dlq"
     config_filename = "config_0_test_upkeep_dlq.yml"
-    consumer_config = ConsumerConfig(
+    taskbroker_config = TaskbrokerConfig(
         db_name,
         str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
         max_pending_count,
@@ -176,7 +204,7 @@ Running test with the following configuration:
     )
 
     with open(str(TEST_OUTPUT_PATH / config_filename), "w") as f:
-        yaml.safe_dump(consumer_config.to_dict(), f)
+        yaml.safe_dump(taskbroker_config.to_dict(), f)
 
     try:
         # Produce N messages to kafka that expires immediately
@@ -210,30 +238,30 @@ Running test with the following configuration:
         tasks_written_event = threading.Event()
         shutdown_event = threading.Event()
 
-        # Create consumer thread
-        consumer_thread = threading.Thread(
-            target=manage_consumer,
+        # Create taskbroker thread
+        taskbroker_thread = threading.Thread(
+            target=manage_taskbroker,
             args=(
-                consumer_path,
+                taskbroker_path,
                 str(TEST_OUTPUT_PATH / config_filename),
-                consumer_config,
+                taskbroker_config,
                 str(
                     TEST_OUTPUT_PATH
-                    / f"consumer_0_{curr_time}_test_upkeep_dlq.log"
+                    / f"taskbroker_0_{curr_time}_test_upkeep_dlq.log"
                 ),
-                consumer_timeout,
+                taskbroker_timeout,
                 num_messages,
                 tasks_written_event,
                 shutdown_event,
             ),
         )
-        consumer_thread.start()
+        taskbroker_thread.start()
 
         # Create worker thread
         worker_thread = threading.Thread(
             target=manage_taskworker,
             args=(
-                consumer_config,
+                taskbroker_config,
                 tasks_written_event,
                 shutdown_event,
                 last_task_id,
@@ -241,7 +269,7 @@ Running test with the following configuration:
         )
         worker_thread.start()
 
-        consumer_thread.join()
+        taskbroker_thread.join()
         worker_thread.join()
     except Exception as e:
         raise Exception(f"Error running taskbroker: {e}")

--- a/python/integration_tests/test_upkeep_retry.py
+++ b/python/integration_tests/test_upkeep_retry.py
@@ -10,9 +10,9 @@ from collections import defaultdict
 from python.integration_tests.helpers import (
     TASKBROKER_BIN,
     TESTS_OUTPUT_ROOT,
-    send_messages_to_kafka,
+    send_generic_messages_to_topic,
     create_topic,
-    check_num_tasks_written,
+    get_num_tasks_in_sqlite,
     ConsumerConfig,
 )
 
@@ -141,7 +141,7 @@ def manage_consumer(
         # Let the consumer write the messages to sqlite
         end = time.time() + timeout
         while (time.time() < end) and (not tasks_written_event.is_set()):
-            written_tasks = check_num_tasks_written(consumer_config)
+            written_tasks = get_num_tasks_in_sqlite(consumer_config)
             if written_tasks == num_messages:
                 print(
                     f"[consumer_0]: Finishing writting all {num_messages} task(s) to sqlite. Sending signal to taskworker(s) to start processing"
@@ -260,7 +260,7 @@ Running test with the following configuration:
         yaml.safe_dump(consumer_config.to_dict(), f)
 
     try:
-        send_messages_to_kafka(topic_name, num_messages)
+        send_generic_messages_to_topic(topic_name, num_messages)
         tasks_written_event = threading.Event()
         shutdown_events = [threading.Event() for _ in range(num_workers)]
         consumer_thread = threading.Thread(

--- a/python/integration_tests/test_upkeep_retry.py
+++ b/python/integration_tests/test_upkeep_retry.py
@@ -287,11 +287,11 @@ Running test with the following configuration:
         db_name=db_name,
         db_path=str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
         max_pending_count=max_pending_count,
-        topic_name=topic_name,
+        kafka_topic=topic_name,
         kafka_deadletter_topic=kafka_deadletter_topic,
-        kafka_consumer_group_id=topic_name,
-        kafka_consumer_offset="earliest",
-        kafka_consumer_port=50051
+        kafka_consumer_group=topic_name,
+        kafka_auto_offset_reset="earliest",
+        grpc_port=50051
     )
 
     with open(str(TEST_OUTPUT_PATH / config_filename), "w") as f:

--- a/python/integration_tests/test_upkeep_retry.py
+++ b/python/integration_tests/test_upkeep_retry.py
@@ -261,6 +261,7 @@ def test_upkeep_retry() -> None:
     )
     taskworker_timeout = 600  # the time in seconds for taskworker to finish processing
     topic_name = "task-worker"
+    kafka_deadletter_topic = "task-worker-dlq"
     curr_time = int(time.time())
 
     print(
@@ -283,13 +284,14 @@ Running test with the following configuration:
     db_name = f"db_0_{curr_time}_test_upkeep_retry"
     config_filename = "config_0_test_upkeep_retry.yml"
     taskbroker_config = TaskbrokerConfig(
-        db_name,
-        str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
-        max_pending_count,
-        topic_name,
-        topic_name,
-        "earliest",
-        50051
+        db_name=db_name,
+        db_path=str(TEST_OUTPUT_PATH / f"{db_name}.sqlite"),
+        max_pending_count=max_pending_count,
+        topic_name=topic_name,
+        kafka_deadletter_topic=kafka_deadletter_topic,
+        kafka_consumer_group_id=topic_name,
+        kafka_consumer_offset="earliest",
+        kafka_consumer_port=50051
     )
 
     with open(str(TEST_OUTPUT_PATH / config_filename), "w") as f:

--- a/python/integration_tests/worker.py
+++ b/python/integration_tests/worker.py
@@ -45,7 +45,7 @@ class TaskWorkerClient:
         return None
 
     def update_task(
-        self, task_id: str, status: TaskActivationStatus.ValueType, fetch_next_task: FetchNextTask
+        self, task_id: str, status: TaskActivationStatus.ValueType, fetch_next_task: FetchNextTask | None
     ) -> TaskActivation | None:
         """
         Update the status for a given task activation.


### PR DESCRIPTION
### What does this test do?

This tests is responsible for checking the integrity of the discard and deadletter mechanism implemented in the upkeep thread of taskbroker. An initial amount of messages is produced to kafka where half of the messages' on_attempts_exceeded is set to discard and the other half to deadletter. These messages have an `expires` value of 1 second. An extra message is produced to the topic which is to be completed by a taskworker first. This allows all the previous messages to be discarded/deadlettered by upkeep. During an interval, the upkeep thread collect all tasks that have expired, sets them all to a failed status, then appropriately discards or deadletters these messages. This process continues until all tasks have have a completed status (this means all tasks have either been discarded or deadlettered).

### How does it accomplish this?

The test starts a taskworker and a taskbroker in separate threads. Synchronization events are use to instruct the taskworker when complete the last message and shutdown. Once the upkeep thread has successfully completed all messages in sqlite, taskbroker shuts down. Finally, this total number of completed messages and messages in the DLQ topic is validated.