### PR TITLE
feat(tooling) Add black and makefile target for formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,14 @@ format: ## Run autofix mode for formatting and lint
 	cargo clippy --workspace --all-targets --all-features --no-deps --fix --allow-dirty --allow-staged -- -D warnings
 .PHONY: format
 
+style-py: ## Run black --check on python code
+	python/.venv/bin/python -m black --check python/
+.PHONY: style-py
+
+format-py: ## Run autofix mode for formatting and lint
+	python/.venv/bin/python -m black python/
+.PHONY: format-py
+
 # Tests
 
 unit-test: ## Run unit tests

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -6,3 +6,4 @@ protobuf>=5.28.3
 pytest>=8.3.3
 pyyaml>=6.0.2
 sentry-protos>=0.1.52
+black==24.10.0


### PR DESCRIPTION
Add make targets for checking and applying formatting with black. I'm planning to integrate these into CI and local development tooling.