### PR TITLE
feat(telemetry): A single place to configure log filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,8 +1932,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1935,8 +1953,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3036,12 +3060,16 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,11 @@ figment = { version = "0.10.19", features = ["env", "yaml", "test"] }
 clap = { version = "4.5.20", features = ["derive"] }
 sentry = { version = "0.34.0", features = ["tracing"] }
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["json"] }
+tracing-subscriber = { version = "0.3.18", features = [
+    "std",
+    "env-filter",
+    "json",
+] }
 metrics-exporter-statsd = "0.9.0"
 metrics = "0.24.0"
 elegant-departure = { version = "0.3.1", features = ["tokio"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,12 @@
 use figment::{
-    providers::{Env, Format, Serialized, Yaml},
+    providers::{Env, Format, Yaml},
     Figment, Metadata, Profile, Provider,
 };
 use rdkafka::ClientConfig;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
-use crate::{
-    logging::{LogFormat, LogLevel},
-    Args,
-};
+use crate::{logging::LogFormat, Args};
 
 #[derive(PartialEq, Debug, Deserialize, Serialize)]
 pub struct Config {
@@ -22,11 +19,8 @@ pub struct Config {
     /// The sampling rate for tracing data.
     pub traces_sample_rate: Option<f32>,
 
-    /// The log level to filter application logging to.
-    pub log_level: LogLevel,
-
-    /// The log level to filter rdkafka logging to.
-    pub rdkafka_log_level: LogLevel,
+    /// The log filter to apply application logging to.
+    pub log_filter: String,
 
     /// The log format to use
     pub log_format: LogFormat,
@@ -102,8 +96,7 @@ impl Default for Config {
             sentry_dsn: None,
             sentry_env: None,
             traces_sample_rate: Some(0.0),
-            log_level: LogLevel::Debug,
-            rdkafka_log_level: LogLevel::Warn,
+            log_filter: "debug,librdkafka=warn,h2=off".to_owned(),
             log_format: LogFormat::Text,
             grpc_addr: "0.0.0.0".to_owned(),
             grpc_port: 50051,
@@ -135,9 +128,6 @@ impl Config {
         if let Some(path) = &args.config {
             builder = builder.merge(Yaml::file(path));
         }
-        if let Some(log_level) = &args.log_level {
-            builder = builder.merge(Serialized::default("log_level", log_level));
-        }
         builder = builder.merge(Env::prefixed("TASKBROKER_"));
         let config = builder.extract()?;
         Ok(config)
@@ -163,17 +153,14 @@ impl Config {
                 "auto.offset.reset",
                 self.kafka_auto_offset_reset.to_string(),
             )
-            .set("enable.auto.offset.store", "false")
-            .set_log_level(self.rdkafka_log_level.kafka_level());
+            .set("enable.auto.offset.store", "false");
         config.clone()
     }
 
     /// Convert the application Config into rdkafka::ClientConfig
     pub fn kafka_producer_config(&self) -> ClientConfig {
         let mut new_config = ClientConfig::new();
-        let config = new_config
-            .set("bootstrap.servers", self.kafka_cluster.clone())
-            .set_log_level(self.log_level.kafka_level());
+        let config = new_config.set("bootstrap.servers", self.kafka_cluster.clone());
         config.clone()
     }
 }
@@ -193,10 +180,7 @@ mod tests {
     use std::borrow::Cow;
 
     use super::Config;
-    use crate::{
-        logging::{LogFormat, LogLevel},
-        Args,
-    };
+    use crate::{logging::LogFormat, Args};
     use figment::Jail;
 
     #[test]
@@ -206,7 +190,7 @@ mod tests {
         };
         assert_eq!(config.sentry_dsn, None);
         assert_eq!(config.sentry_env, None);
-        assert_eq!(config.log_level, LogLevel::Debug);
+        assert_eq!(config.log_filter, "debug,librdkafka=warn,h2=off");
         assert_eq!(config.log_format, LogFormat::Text);
         assert_eq!(config.grpc_port, 50051);
         assert_eq!(config.kafka_topic, "task-worker");
@@ -222,7 +206,7 @@ mod tests {
                 r#"
                 sentry_dsn: fake_dsn
                 sentry_env: prod
-                log_level: info
+                log_filter: debug,rdkafka=off
                 log_format: json
                 statsd_addr: 127.0.0.1:8126
                 kafka_cluster: 10.0.0.1:9092,10.0.0.2:9092
@@ -236,16 +220,15 @@ mod tests {
             "#,
             )?;
             // Env vars always override config file
-            jail.set_env("TASKBROKER_LOG_LEVEL", "error");
+            jail.set_env("TASKBROKER_LOG_FILTER", "error");
 
             let args = Args {
                 config: Some("config.yaml".to_owned()),
-                log_level: None,
             };
             let config = Config::from_args(&args).unwrap();
             assert_eq!(config.sentry_dsn, Some("fake_dsn".to_owned()));
             assert_eq!(config.sentry_env, Some(Cow::Borrowed("prod")));
-            assert_eq!(config.log_level, LogLevel::Error);
+            assert_eq!(config.log_filter, "error");
             assert_eq!(config.log_format, LogFormat::Json);
             assert_eq!(
                 config.kafka_cluster,
@@ -268,15 +251,12 @@ mod tests {
     #[test]
     fn test_from_args_env_and_args() {
         Jail::expect_with(|jail| {
-            jail.set_env("TASKBROKER_LOG_LEVEL", "error");
+            jail.set_env("TASKBROKER_LOG_FILTER", "error");
             jail.set_env("TASKBROKER_REMOVE_DEADLINE", "2000");
 
-            let args = Args {
-                config: None,
-                log_level: Some("debug".to_owned()),
-            };
+            let args = Args { config: None };
             let config = Config::from_args(&args).unwrap();
-            assert_eq!(config.log_level, LogLevel::Error);
+            assert_eq!(config.log_filter, "error");
             assert_eq!(config.remove_deadline, 2000);
 
             Ok(())
@@ -286,17 +266,14 @@ mod tests {
     #[test]
     fn test_from_args_env_test() {
         Jail::expect_with(|jail| {
-            jail.set_env("TASKBROKER_LOG_LEVEL", "error");
+            jail.set_env("TASKBROKER_LOG_FILTER", "error");
             jail.set_env("TASKBROKER_REMOVE_DEADLINE", "2000");
 
-            let args = Args {
-                config: None,
-                log_level: None,
-            };
+            let args = Args { config: None };
             let config = Config::from_args(&args).unwrap();
             assert_eq!(config.sentry_dsn, None);
             assert_eq!(config.sentry_env, None);
-            assert_eq!(config.log_level, LogLevel::Error);
+            assert_eq!(config.log_filter, "error");
             assert_eq!(config.kafka_topic, "task-worker".to_owned());
             assert_eq!(config.kafka_deadletter_topic, "task-worker-dlq".to_owned());
             assert_eq!(config.db_path, "./taskbroker-inflight.sqlite".to_owned());
@@ -310,10 +287,7 @@ mod tests {
 
     #[test]
     fn test_kafka_consumer_config() {
-        let args = Args {
-            config: None,
-            log_level: None,
-        };
+        let args = Args { config: None };
         let config = Config::from_args(&args).unwrap();
         let consumer_config = config.kafka_consumer_config();
 
@@ -327,10 +301,7 @@ mod tests {
 
     #[test]
     fn test_kafka_producer_config() {
-        let args = Args {
-            config: None,
-            log_level: None,
-        };
+        let args = Args { config: None };
         let config = Config::from_args(&args).unwrap();
         let producer_config = config.kafka_producer_config();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub struct Config {
     pub traces_sample_rate: Option<f32>,
 
     /// The log filter to apply application logging to.
+    /// See https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
     pub log_filter: String,
 
     /// The log format to use

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,4 @@ pub struct Args {
     /// Path to the configuration file
     #[arg(short, long, help = "The path to a config file")]
     pub config: Option<String>,
-
-    #[arg(short, long, help = "Set the logging level filter")]
-    pub log_level: Option<String>,
 }


### PR DESCRIPTION
I was trying to figure out how to get rid of the annoying h2 logs
```
2025-01-30T07:17:43.333156Z DEBUG Connection: h2::codec::framed_read: received frame=Headers { stream_id: StreamId(7), flags: (0x4: END_HEADERS) } peer=Server
2025-01-30T07:17:43.333259Z DEBUG Connection: h2::codec::framed_read: received frame=WindowUpdate { stream_id: StreamId(7), size_increment: 5 } peer=Server
2025-01-30T07:17:43.333311Z DEBUG Connection: h2::codec::framed_read: received frame=Data { stream_id: StreamId(7), flags: (0x1: END_STREAM) } peer=Server
2025-01-30T07:17:43.334691Z DEBUG Connection: h2::codec::framed_write: send frame=Headers { stream_id: StreamId(7), flags: (0x5: END_HEADERS | END_STREAM) } peer=Server
```

After figuring it out I realize I'll need to create yet another thing in the config struct / file / envar to adjust the h2 logs, similar to what we do with rdkafka. This can quickly get confusing when trying to find the right filter for different parts of our codebase.

I learned that we can just control everything with a single config field / envar like
```
log_filter: debug,librdkafka=warn,h2=off
```
Which sets our log level to debug (or above), set the rdkafka log level to warning (or above) and turns off logs from h2.
This feels a lot more readable and maintainable to me. This also has the benefit of not needing to muck around with settings when we adopt another really verbose library in the future.

What do we think?