### PR TITLE
ref(tele): Use counters for now

### DIFF
--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -210,8 +210,8 @@ pub async fn do_upkeep(
     metrics::counter!("upkeep.remove_at_expired").increment(result_context.remove_at_expired);
     metrics::counter!("upkeep.retried").increment(result_context.retried);
 
-    metrics::gauge!("upkeep.pending_count").increment(result_context.pending);
-    metrics::gauge!("upkeep.processing_count").increment(result_context.processing);
+    metrics::counter!("upkeep.pending_count").increment(result_context.pending.into());
+    metrics::counter!("upkeep.processing_count").increment(result_context.processing.into());
 
     result_context
 }


### PR DESCRIPTION
For some reason gauges does not work with the metrics library we're using. What we can do is to emit counters and set those values to gauges on datadog.

I think for now this is an acceptable solution because I don't think we should waste too much time debugging the datadog agent in the sandbox, as the metrics configuration would be quite different between the sandbox and production anyway.