### PR TITLE
chore(devservices): Bump devservices to 1.0.14

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -9,9 +9,20 @@ x-sentry-service-config:
         repo_name: sentry-shared-kafka
         branch: main
         repo_link: https://github.com/getsentry/sentry-shared-kafka
+    taskbroker:
+      description: Taskbroker service
   modes:
     default: [kafka]
-    containerized: [kafka]
+    containerized: [kafka, taskbroker]
+
+services:
+  taskbroker:
+    image: ghcr.io/getsentry/taskbroker:latest
+    environment:
+      TASKBROKER_KAFKA_CLUSTER: "kafka-kafka-1:9093"
+    ports:
+      - 127.0.0.1:50051:50051
+    platform: linux/amd64
 
 networks:
   devservices:

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,5 +1,5 @@
 confluent_kafka>=2.3.0
-devservices==1.0.5
+devservices==1.0.14
 orjson>=3.10.10
 protobuf>=5.28.3
 pytest>=8.3.3


### PR DESCRIPTION
Some various minor improvements: https://github.com/getsentry/devservices/releases/tag/1.0.14