### PR TITLE
chore(devservices): Bump devservices to 1.0.14

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,5 +1,5 @@
 confluent_kafka>=2.3.0
-devservices==1.0.5
+devservices==1.0.14
 grpcio==1.66.1
 orjson>=3.10.10
 protobuf>=5.28.3


### PR DESCRIPTION
This bumps devservices to version 1.0.14 since the version here seems to be pretty outdated. 