### PR TITLE
ref(grpc): Refactor set_task_status

### DIFF
--- a/tests/grpc_server_test.rs
+++ b/tests/grpc_server_test.rs
@@ -60,6 +60,6 @@ async fn test_set_task_status_invalid() {
     assert_eq!(e.code(), Code::InvalidArgument);
     assert_eq!(
         e.message(),
-        "Invalid status, expects 3 (Failure), 4 (Retry), or 5 (Complete)"
+        "Invalid status, expects 3 (Failure), 4 (Retry), or 5 (Complete), but got: Pending"
     );
 }


### PR DESCRIPTION
I was debugging the `set_task_status` grpc code and I found it a little bit difficult to follow with the mutation and high level of nesting.

Let me know if this is actually easier to read, I am obviously biased