### PR TITLE
fix(sqlite): Change id column from UUID to TEXT

### DIFF
--- a/migrations/0001_create_inflight_taskactivations.sql
+++ b/migrations/0001_create_inflight_taskactivations.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS inflight_taskactivations (
-    id UUID NOT NULL PRIMARY KEY,
+    id TEXT NOT NULL PRIMARY KEY,
     activation BLOB NOT NULL,
     partition INTEGER NOT NULL,
     offset BIGINTEGER NOT NULL,


### PR DESCRIPTION
The UUID type is a generic type in SQLite, which automatically tries to convert values into numbers where possible. Since some UUIDs are also valid numbers, SQLite was converting those values to numbers. This was generally fine except for UUIDs that had just numbers, with a lower case 'e', and then more numbers, e.g. 97033619637148748591279e7866347. SQlite would interpret the `e` as an exponent character, and end up storing +Inf.

This is all avoided by storing the key as a TEXT string, which prevents this type of interpolation.