### PR TITLE
chore(makefile): Use docker commands to reset kafka

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ install-py-dev: ## Install python dependencies
 
 reset-kafka: install-py-dev ## Reset kafka
 	devservices down
-	devservices purge
+	-docker container rm kafka-kafka-1
+	-docker volume rm kafka_kafka-data
 	devservices up
 .PHONY: reset-kafka
 


### PR DESCRIPTION
We shouldn't be using `devservices purge` for this command as it resets all devservices containers, impacting development environments in sentry/snuba/relay if used. 