### PR TITLE
feat(consumer): Improve consumer write throughput

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -118,7 +118,7 @@ impl Default for Config {
             kafka_send_timeout_ms: 500,
             db_path: "./taskbroker-inflight.sqlite".to_owned(),
             max_pending_count: 2048,
-            max_pending_buffer_count: 1,
+            max_pending_buffer_count: 128,
             max_processing_deadline: 300,
             remove_deadline: 900,
             upkeep_task_interval_ms: 200,

--- a/src/consumer/inflight_activation_batcher.rs
+++ b/src/consumer/inflight_activation_batcher.rs
@@ -1,0 +1,73 @@
+use std::{mem::replace, time::Duration};
+
+use crate::{config::Config, inflight_activation_store::InflightActivation};
+
+use super::kafka::{
+    ReduceConfig, ReduceShutdownBehaviour, ReduceShutdownCondition, Reducer,
+    ReducerWhenFullBehaviour,
+};
+
+pub struct ActivationBatcherConfig {
+    pub max_buf_len: usize,
+}
+
+impl ActivationBatcherConfig {
+    /// Convert from application configuration into ActivationBatcher config.
+    pub fn from_config(config: &Config) -> Self {
+        Self {
+            max_buf_len: config.max_pending_buffer_count,
+        }
+    }
+}
+
+pub struct InflightActivationBatcher {
+    buffer: Vec<InflightActivation>,
+    config: ActivationBatcherConfig,
+}
+
+impl InflightActivationBatcher {
+    pub fn new(config: ActivationBatcherConfig) -> Self {
+        Self {
+            buffer: Vec::with_capacity(config.max_buf_len),
+            config,
+        }
+    }
+}
+
+impl Reducer for InflightActivationBatcher {
+    type Input = InflightActivation;
+
+    type Output = Vec<InflightActivation>;
+
+    async fn reduce(&mut self, t: Self::Input) -> Result<(), anyhow::Error> {
+        self.buffer.push(t);
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<Self::Output, anyhow::Error> {
+        if self.buffer.is_empty() {
+            return Ok(vec![]);
+        }
+        Ok(replace(
+            &mut self.buffer,
+            Vec::with_capacity(self.config.max_buf_len),
+        ))
+    }
+
+    fn reset(&mut self) {
+        self.buffer.clear();
+    }
+
+    async fn is_full(&self) -> bool {
+        self.buffer.len() >= self.config.max_buf_len
+    }
+
+    fn get_reduce_config(&self) -> ReduceConfig {
+        ReduceConfig {
+            shutdown_condition: ReduceShutdownCondition::Signal,
+            shutdown_behaviour: ReduceShutdownBehaviour::Drop,
+            when_full_behaviour: ReducerWhenFullBehaviour::Flush,
+            flush_interval: Some(Duration::from_secs(1)),
+        }
+    }
+}

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod deserialize_activation;
+pub mod inflight_activation_batcher;
 pub mod inflight_activation_writer;
 pub mod kafka;
 pub mod os_stream_writer;


### PR DESCRIPTION
Adds a batching step in front of the db write step.

The current Sqlite write step works like so:
1. When a message come in from the previou step, it queries to see if size(db) + size(buffer) is smaller than max pending tasks, if it is, add the message to the buffer.
2. When size(db) + size(buffer) is equal to the max pending tasks, or every 4 seconds, flush the buffer to the db

This worked reasonably well but it requires us to make a query each time we see a message. By separating the batching step before the writer, we only need to query the DB every `max_pending_buffer_count` messages.