### PR TITLE
fix(dlq-test): bump consumer timeout to 10 min

### DIFF
--- a/python/integration_tests/test_upkeep_dlq.py
+++ b/python/integration_tests/test_upkeep_dlq.py
@@ -243,7 +243,7 @@ def test_upkeep_dlq() -> None:
     num_messages = 10_000
     num_partitions = 4
     max_pending_count = 100_000
-    taskbroker_timeout = 120  # the time in seconds to wait for taskbroker to process
+    taskbroker_timeout = 600  # the time in seconds to wait for taskbroker to process
     topic_name = "task-worker"
     dlq_topic_name = "task-worker-dlq"
     curr_time = int(time.time())


### PR DESCRIPTION
Two minutes for the consumer to completely DLQ/discarding 10,000 tasks might have been over ambitious. Let's bump it to 10 minutes and see if it fixes flaky test.