### PR TITLE
chore(test): Fixup consumer rebalance test

### DIFF
--- a/python/integration_tests/test_consumer_rebalancing.py
+++ b/python/integration_tests/test_consumer_rebalancing.py
@@ -208,7 +208,7 @@ Running test with the following configuration:
             f"{str(count).rjust(16)}"
         )
 
-    taskbrokers_have_data = True
+    total_row_count = 0
     print("\n======== Number of rows in each taskbroker ========")
     for i, config in enumerate(taskbroker_configs.values()):
         query = (
@@ -220,7 +220,9 @@ Running test with the following configuration:
             f"Consumer {i}: {res}, "
             f"{str(int(res / max_pending_count * 100))}% of capacity"
         )
-        taskbrokers_have_data = taskbrokers_have_data and res >= max_pending_count // 3
+        total_row_count += res
+
+    taskbrokers_have_data = total_row_count > num_messages // 3
 
     taskbroker_error_logs = []
     for i in range(num_consumers):
@@ -245,9 +247,7 @@ Running test with the following configuration:
         print("\nTest failed! Got duplicate/missing kafka messages in sqlite")
 
     if not taskbrokers_have_data:
-        print(
-            "\nTest failed! Lower than expected amount of kafka messages " "in sqlite"
-        )
+        print("\nTest failed! Lower than expected amount of kafka messages in sqlite")
 
     if taskbroker_error_logs:
         print("\nTest failed! Errors in taskbroker logs")


### PR DESCRIPTION
There're certain runs of the rebalance integration test where the number of messages are distributed unevenly amongst the partitions and thus distributed unevenly amongst the consumers

For example [this run](https://github.com/getsentry/taskbroker/actions/runs/13152142746/job/36702863955?pr=166)
```
======== Number of rows in each taskbroker ========
Consumer 0: 3539, 23% of capacity
Consumer 1: 14994, 99% of capacity
Consumer 2: 14976, 99% of capacity
Consumer 3: 14975, 99% of capacity
Consumer 4: 13188, 87% of capacity
Consumer 5: 14964, 99% of capacity
Consumer 6: 13824, 92% of capacity
Consumer 7: 9540, 63% of capacity

Test failed! Lower than expected amount of kafka messages in sqlite
F
```

The consumers actually wrote all 100000 messages, but Consumer 0 just happened to get less of it, so the test ended up failing.

This pr changes the test to apply the expected amount of kafka messages check to the sum of the number of rows, instead of checking each individual ones.