### PR TITLE
perf(store): Add covering index for get_pending_activation

### DIFF
--- a/migrations/0001_create_inflight_taskactivations.sql
+++ b/migrations/0001_create_inflight_taskactivations.sql
@@ -11,3 +11,6 @@ CREATE TABLE IF NOT EXISTS inflight_taskactivations (
     at_most_once BOOLEAN NOT NULL DEFAULT FALSE,
     namespace TEXT
 );
+
+CREATE INDEX idx_pending_activation
+ON inflight_taskactivations (status, remove_at, added_at, namespace, id);


### PR DESCRIPTION
I see almost a 2x performance when running this locally. I promise I will stop working on perf optimization after this.