### PR TITLE
feat(expires): Track task expiry explicitly

### DIFF
--- a/migrations/0001_create_inflight_taskactivations.sql
+++ b/migrations/0001_create_inflight_taskactivations.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS inflight_taskactivations (
     offset BIGINTEGER NOT NULL,
     added_at INTEGER NOT NULL,
     remove_at INTEGER NOT NULL,
+    expires_at INTEGER,
     processing_deadline_duration INTEGER NOT NULL,
     processing_deadline INTEGER,
     status INTEGER NOT NULL,

--- a/src/consumer/deserialize_activation.rs
+++ b/src/consumer/deserialize_activation.rs
@@ -45,22 +45,21 @@ pub fn new(
         let now = Utc::now();
 
         // Determine the deadletter_at time using config and activation expires time.
-        let mut remove_at = now.add(config.remove_deadline);
+        let mut expires_at = None;
         if let Some(expires) = activation.expires {
             let expires_duration = Duration::from_secs(expires);
-            if expires_duration < config.remove_deadline {
-                // Expiry times are based on the time the task was received
-                // not the time it was dequeued from Kafka.
-                let activation_received = activation.received_at.map_or(now, |ts| {
-                    match Utc.timestamp_opt(ts.seconds, ts.nanos as u32) {
-                        MappedLocalTime::Single(ts) => ts,
-                        _ => now,
-                    }
-                });
-                remove_at = activation_received + expires_duration;
-            }
+            // Expiry times are based on the time the task was received
+            // not the time it was dequeued from Kafka.
+            let activation_received = activation.received_at.map_or(now, |ts| {
+                match Utc.timestamp_opt(ts.seconds, ts.nanos as u32) {
+                    MappedLocalTime::Single(ts) => ts,
+                    _ => now,
+                }
+            });
+            expires_at = Some(activation_received + expires_duration);
         }
 
+        let remove_at = now.add(config.remove_deadline);
         Ok(InflightActivation {
             activation,
             status: InflightActivationStatus::Pending,
@@ -69,6 +68,7 @@ pub fn new(
             added_at: Utc::now(),
             processing_deadline: None,
             remove_at,
+            expires_at,
             at_most_once,
             namespace,
         })

--- a/src/inflight_activation_store.rs
+++ b/src/inflight_activation_store.rs
@@ -73,6 +73,9 @@ pub struct InflightActivation {
     /// depending on the retry policy of an activation it will either be deadlettered or discarded.
     pub remove_at: DateTime<Utc>,
 
+    // If the task has specified an expiry, this is the timestamp after which the task should be removed from inflight store
+    pub expires_at: Option<DateTime<Utc>>,
+
     /// The timestamp for when processing should be complete
     pub processing_deadline: Option<DateTime<Utc>>,
 
@@ -109,6 +112,7 @@ struct TableRow {
     offset: i64,
     added_at: DateTime<Utc>,
     remove_at: DateTime<Utc>,
+    expires_at: Option<DateTime<Utc>>,
     processing_deadline_duration: u32,
     processing_deadline: Option<DateTime<Utc>>,
     status: InflightActivationStatus,
@@ -127,6 +131,7 @@ impl TryFrom<InflightActivation> for TableRow {
             offset: value.offset,
             added_at: value.added_at,
             remove_at: value.remove_at,
+            expires_at: value.expires_at,
             processing_deadline_duration: value.activation.processing_deadline_duration as u32,
             processing_deadline: value.processing_deadline,
             status: value.status,
@@ -147,6 +152,7 @@ impl From<TableRow> for InflightActivation {
             offset: value.offset,
             added_at: value.added_at,
             remove_at: value.remove_at,
+            expires_at: value.expires_at,
             processing_deadline: value.processing_deadline,
             at_most_once: value.at_most_once,
             namespace: value.namespace,
@@ -189,7 +195,7 @@ impl InflightActivationStore {
         }
         let mut query_builder = QueryBuilder::<Sqlite>::new(
             "INSERT INTO inflight_taskactivations \
-            (id, activation, partition, offset, added_at, remove_at, processing_deadline_duration, processing_deadline, status, at_most_once, namespace)",
+            (id, activation, partition, offset, added_at, remove_at, expires_at, processing_deadline_duration, processing_deadline, status, at_most_once, namespace)",
         );
         let rows = batch
             .into_iter()
@@ -203,6 +209,7 @@ impl InflightActivationStore {
                 b.push_bind(row.offset);
                 b.push_bind(row.added_at);
                 b.push_bind(row.remove_at);
+                b.push_bind(row.expires_at);
                 b.push_bind(row.processing_deadline_duration);
                 if let Some(deadline) = row.processing_deadline {
                     b.push_bind(deadline);
@@ -237,6 +244,9 @@ impl InflightActivationStore {
             WHERE status = ",
         );
         query_builder.push_bind(InflightActivationStatus::Pending);
+        query_builder.push(" AND (expires_at IS NULL OR expires_at > ");
+        query_builder.push_bind(now);
+        query_builder.push(")");
         query_builder.push(" AND (remove_at IS NULL OR remove_at > ");
         query_builder.push_bind(now);
         query_builder.push(")");
@@ -378,6 +388,7 @@ impl InflightActivationStore {
     ///
     /// Tasks that are pending and past their remove_at deadline are updated
     /// to have status=failure so that they can be discarded/deadlettered by handle_failed_tasks
+    /// This will only happen with tasks that are older than the newest completed task
     ///
     /// The number of impacted records is returned in a Result.
     pub async fn handle_remove_at(&self) -> Result<u64, Error> {
@@ -412,6 +423,29 @@ impl InflightActivationStore {
         .await?;
 
         atomic.commit().await?;
+
+        Ok(update_result.rows_affected())
+    }
+
+    /// Perform upkeep work for tasks that are past expires_at deadlines
+    ///
+    /// Tasks that are pending and past their expires_at deadline are updated
+    /// to have status=failure so that they can be discarded/deadlettered by handle_failed_tasks
+    ///
+    /// The number of impacted records is returned in a Result.
+    pub async fn handle_expires_at(&self) -> Result<u64, Error> {
+        let now = Utc::now();
+        let update_result = sqlx::query(
+            r#"UPDATE inflight_taskactivations
+            SET status = $1
+            WHERE expires_at < $2 AND status = $3
+            "#,
+        )
+        .bind(InflightActivationStatus::Failure)
+        .bind(now)
+        .bind(InflightActivationStatus::Pending)
+        .execute(&self.sqlite_pool)
+        .await?;
 
         Ok(update_result.rows_affected())
     }
@@ -540,737 +574,4 @@ impl InflightActivationStore {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::collections::{HashMap, HashSet};
-    use std::ops::Add;
-    use std::sync::Arc;
-    use std::time::Duration;
-
-    use chrono::{TimeZone, Utc};
-    use sentry_protos::taskbroker::v1::{
-        OnAttemptsExceeded, RetryState, TaskActivation, TaskActivationStatus,
-    };
-    use tokio::sync::broadcast;
-    use tokio::task::JoinSet;
-
-    use crate::inflight_activation_store::{
-        InflightActivation, InflightActivationStatus, InflightActivationStore,
-    };
-    use crate::test_utils::{assert_count_by_status, generate_temp_filename, make_activations};
-
-    #[test]
-    fn test_inflightactivation_status_is_completion() {
-        let mut value = InflightActivationStatus::Unspecified;
-        assert!(!value.is_conclusion());
-
-        value = InflightActivationStatus::Pending;
-        assert!(!value.is_conclusion());
-
-        value = InflightActivationStatus::Processing;
-        assert!(!value.is_conclusion());
-
-        value = InflightActivationStatus::Retry;
-        assert!(value.is_conclusion());
-
-        value = InflightActivationStatus::Failure;
-        assert!(value.is_conclusion());
-
-        value = InflightActivationStatus::Complete;
-        assert!(value.is_conclusion());
-    }
-
-    #[test]
-    fn test_inflightactivation_status_from() {
-        let mut value: InflightActivationStatus = TaskActivationStatus::Pending.into();
-        assert_eq!(value, InflightActivationStatus::Pending);
-
-        value = TaskActivationStatus::Processing.into();
-        assert_eq!(value, InflightActivationStatus::Processing);
-
-        value = TaskActivationStatus::Retry.into();
-        assert_eq!(value, InflightActivationStatus::Retry);
-
-        value = TaskActivationStatus::Failure.into();
-        assert_eq!(value, InflightActivationStatus::Failure);
-
-        value = TaskActivationStatus::Complete.into();
-        assert_eq!(value, InflightActivationStatus::Complete);
-    }
-
-    #[tokio::test]
-    async fn test_create_db() {
-        assert!(InflightActivationStore::new(&generate_temp_filename())
-            .await
-            .is_ok())
-    }
-
-    #[tokio::test]
-    async fn test_store() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let batch = make_activations(2);
-        assert!(store.store(batch).await.is_ok());
-
-        let result = store.count().await;
-        assert_eq!(result.unwrap(), 2);
-    }
-
-    #[tokio::test]
-    async fn test_store_duplicate_id_in_batch() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut batch = make_activations(2);
-        // Coerce a conflict
-        batch[0].activation.id = "id_0".into();
-        batch[1].activation.id = "id_0".into();
-
-        assert!(store.store(batch).await.is_ok());
-
-        let result = store.count().await;
-        assert_eq!(result.unwrap(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_store_duplicate_id_between_batches() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let batch = make_activations(2);
-        assert!(store.store(batch.clone()).await.is_ok());
-        let first_count = store.count().await;
-        assert_eq!(first_count.unwrap(), 2);
-
-        let new_batch = make_activations(2);
-        // Old batch and new should have conflicts
-        assert_eq!(batch[0].activation.id, new_batch[0].activation.id);
-        assert_eq!(batch[1].activation.id, new_batch[1].activation.id);
-        assert!(store.store(new_batch).await.is_ok());
-
-        let second_count = store.count().await;
-        assert_eq!(second_count.unwrap(), 2);
-    }
-
-    #[tokio::test]
-    async fn test_get_pending_activation() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let batch = make_activations(2);
-        assert!(store.store(batch.clone()).await.is_ok());
-
-        let result = store.get_pending_activation(None).await.unwrap().unwrap();
-
-        assert_eq!(result.activation.id, "id_0");
-        assert_eq!(result.status, InflightActivationStatus::Processing);
-        assert!(result.processing_deadline.unwrap() > Utc::now());
-        assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 32)]
-    async fn test_get_pending_activation_with_race() {
-        let url = generate_temp_filename();
-        let store = Arc::new(InflightActivationStore::new(&url).await.unwrap());
-
-        const NUM_CONCURRENT_WRITES: u32 = 2000;
-
-        for chunk in make_activations(NUM_CONCURRENT_WRITES).chunks(1024) {
-            store.store(chunk.to_vec()).await.unwrap();
-        }
-
-        let (tx, _) = broadcast::channel::<()>(1);
-        let mut join_set = JoinSet::new();
-
-        for _ in 0..NUM_CONCURRENT_WRITES {
-            let mut rx = tx.subscribe();
-            let store = store.clone();
-            join_set.spawn(async move {
-                rx.recv().await.unwrap();
-                store
-                    .get_pending_activation(Some("namespace"))
-                    .await
-                    .unwrap()
-                    .unwrap()
-            });
-        }
-
-        tx.send(()).unwrap();
-
-        let res: HashSet<_> = join_set
-            .join_all()
-            .await
-            .iter()
-            .map(|ifa| ifa.activation.id.clone())
-            .collect();
-
-        assert_eq!(res.len(), NUM_CONCURRENT_WRITES as usize);
-    }
-
-    #[tokio::test]
-    async fn test_get_pending_activation_with_namespace() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut batch = make_activations(2);
-        batch[1].namespace = "other_namespace".into();
-        assert!(store.store(batch.clone()).await.is_ok());
-
-        // Get activation from other namespace
-        let result = store
-            .get_pending_activation(Some("other_namespace"))
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(result.activation.id, "id_1");
-        assert_eq!(result.status, InflightActivationStatus::Processing);
-        assert!(result.processing_deadline.unwrap() > Utc::now());
-        assert_eq!(result.namespace, "other_namespace");
-    }
-
-    #[tokio::test]
-    async fn test_get_pending_activation_no_deadletter() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut batch = make_activations(1);
-        batch[0].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
-        assert!(store.store(batch.clone()).await.is_ok());
-
-        let result = store.get_pending_activation(None).await;
-        assert!(result.is_ok());
-        let res_option = result.unwrap();
-        assert!(res_option.is_none());
-        assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
-    }
-
-    #[tokio::test]
-    async fn test_get_pending_activation_earliest() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut batch = make_activations(2);
-        batch[0].added_at = Utc.with_ymd_and_hms(2024, 6, 24, 0, 0, 0).unwrap();
-        batch[1].added_at = Utc.with_ymd_and_hms(1998, 6, 24, 0, 0, 0).unwrap();
-        assert!(store.store(batch.clone()).await.is_ok());
-
-        let result = store.get_pending_activation(None).await.unwrap().unwrap();
-        assert_eq!(
-            result.added_at,
-            Utc.with_ymd_and_hms(1998, 6, 24, 0, 0, 0).unwrap()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_count_pending_activations() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut batch = make_activations(3);
-        batch[0].status = InflightActivationStatus::Processing;
-        assert!(store.store(batch).await.is_ok());
-
-        assert_eq!(store.count_pending_activations().await.unwrap(), 2);
-
-        assert_count_by_status(&store, InflightActivationStatus::Pending, 2).await;
-    }
-
-    #[tokio::test]
-    async fn set_activation_status() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let batch = make_activations(2);
-        assert!(store.store(batch).await.is_ok());
-
-        assert_eq!(store.count_pending_activations().await.unwrap(), 2);
-        assert!(store
-            .set_status("id_0", InflightActivationStatus::Failure)
-            .await
-            .is_ok());
-        assert_eq!(store.count_pending_activations().await.unwrap(), 1);
-        assert!(store
-            .set_status("id_0", InflightActivationStatus::Pending)
-            .await
-            .is_ok());
-        assert_eq!(store.count_pending_activations().await.unwrap(), 2);
-        assert!(store
-            .set_status("id_0", InflightActivationStatus::Failure)
-            .await
-            .is_ok());
-        assert!(store
-            .set_status("id_1", InflightActivationStatus::Failure)
-            .await
-            .is_ok());
-        assert_eq!(store.count_pending_activations().await.unwrap(), 0);
-        assert!(store.get_pending_activation(None).await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn test_set_processing_deadline() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let batch = make_activations(1);
-        assert!(store.store(batch.clone()).await.is_ok());
-
-        let deadline = Utc::now();
-        assert!(store
-            .set_processing_deadline("id_0", Some(deadline))
-            .await
-            .is_ok());
-
-        let result = store.get_by_id("id_0").await.unwrap().unwrap();
-        assert_eq!(result.processing_deadline, Some(deadline));
-    }
-
-    #[tokio::test]
-    async fn test_delete_activation() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let batch = make_activations(2);
-        assert!(store.store(batch).await.is_ok());
-
-        let result = store.count().await;
-        assert_eq!(result.unwrap(), 2);
-
-        assert!(store.delete_activation("id_0").await.is_ok());
-        let result = store.count().await;
-        assert_eq!(result.unwrap(), 1);
-
-        assert!(store.delete_activation("id_0").await.is_ok());
-        let result = store.count().await;
-        assert_eq!(result.unwrap(), 1);
-
-        assert!(store.delete_activation("id_1").await.is_ok());
-        let result = store.count().await;
-        assert_eq!(result.unwrap(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_get_retry_activations() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let batch = make_activations(2);
-        assert!(store.store(batch.clone()).await.is_ok());
-
-        assert_count_by_status(&store, InflightActivationStatus::Pending, 2).await;
-
-        assert!(store
-            .set_status("id_0", InflightActivationStatus::Retry)
-            .await
-            .is_ok());
-        assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
-
-        assert!(store
-            .set_status("id_1", InflightActivationStatus::Retry)
-            .await
-            .is_ok());
-
-        let retries = store.get_retry_activations().await.unwrap();
-        assert_eq!(retries.len(), 2);
-        for record in retries.iter() {
-            assert_eq!(record.status, InflightActivationStatus::Retry);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_handle_processing_deadline() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut batch = make_activations(2);
-        batch[1].status = InflightActivationStatus::Processing;
-        batch[1].processing_deadline =
-            Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
-
-        assert!(store.store(batch).await.is_ok());
-
-        let past_deadline = store.handle_processing_deadline().await;
-        assert!(past_deadline.is_ok());
-        assert_eq!(past_deadline.unwrap(), 1);
-
-        assert_count_by_status(&store, InflightActivationStatus::Processing, 0).await;
-        assert_count_by_status(&store, InflightActivationStatus::Pending, 2).await;
-
-        // Run again to check early return
-        let past_deadline = store.handle_processing_deadline().await;
-        assert!(past_deadline.is_ok());
-        assert_eq!(past_deadline.unwrap(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_handle_processing_deadline_multiple_tasks() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut batch = make_activations(2);
-        batch[0].status = InflightActivationStatus::Processing;
-        batch[0].processing_deadline = Some(Utc.with_ymd_and_hms(2020, 1, 1, 1, 1, 1).unwrap());
-        batch[1].status = InflightActivationStatus::Processing;
-        batch[1].processing_deadline = Some(Utc::now() + chrono::Duration::days(30));
-        assert!(store.store(batch).await.is_ok());
-
-        let past_deadline = store.handle_processing_deadline().await;
-        assert!(past_deadline.is_ok());
-        assert_eq!(past_deadline.unwrap(), 1);
-
-        assert_count_by_status(&store, InflightActivationStatus::Processing, 1).await;
-        assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
-    }
-
-    #[tokio::test]
-    async fn test_handle_processing_at_most_once() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        // Both records are past processing deadlines
-        let mut batch = make_activations(2);
-        batch[0].status = InflightActivationStatus::Processing;
-        batch[0].processing_deadline =
-            Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
-
-        batch[1].status = InflightActivationStatus::Processing;
-        batch[1].activation.retry_state = Some(RetryState {
-            attempts: 0,
-            max_attempts: 1,
-            on_attempts_exceeded: OnAttemptsExceeded::Discard as i32,
-            at_most_once: Some(true),
-        });
-        batch[1].at_most_once = true;
-        batch[1].processing_deadline =
-            Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
-
-        assert!(store.store(batch.clone()).await.is_ok());
-
-        let past_deadline = store.handle_processing_deadline().await;
-        assert!(past_deadline.is_ok());
-        assert_eq!(past_deadline.unwrap(), 2);
-
-        assert_count_by_status(&store, InflightActivationStatus::Processing, 0).await;
-        assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
-        assert_count_by_status(&store, InflightActivationStatus::Failure, 1).await;
-
-        let task = store
-            .get_by_id(&batch[1].activation.id)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(task.status, InflightActivationStatus::Failure);
-    }
-
-    #[tokio::test]
-    async fn test_handle_processing_deadline_discard_after() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut batch = make_activations(2);
-        batch[1].status = InflightActivationStatus::Processing;
-        batch[1].processing_deadline =
-            Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
-        batch[1].activation.retry_state = Some(RetryState {
-            attempts: 0,
-            max_attempts: 1,
-            on_attempts_exceeded: OnAttemptsExceeded::Discard as i32,
-            at_most_once: None,
-        });
-
-        assert!(store.store(batch).await.is_ok());
-
-        let past_deadline = store.handle_processing_deadline().await;
-        assert!(past_deadline.is_ok());
-        assert_eq!(past_deadline.unwrap(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_handle_processing_deadline_deadletter_after() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut batch = make_activations(2);
-        batch[1].status = InflightActivationStatus::Processing;
-        batch[1].processing_deadline =
-            Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
-        batch[1].activation.retry_state = Some(RetryState {
-            attempts: 0,
-            max_attempts: 1,
-            on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
-            at_most_once: None,
-        });
-
-        assert!(store.store(batch).await.is_ok());
-
-        let past_deadline = store.handle_processing_deadline().await;
-        assert!(past_deadline.is_ok());
-        assert_eq!(past_deadline.unwrap(), 1);
-        assert_count_by_status(&store, InflightActivationStatus::Processing, 0).await;
-    }
-
-    #[tokio::test]
-    async fn test_handle_processing_deadline_no_retries_remaining() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut batch = make_activations(2);
-        batch[1].status = InflightActivationStatus::Processing;
-        batch[1].processing_deadline =
-            Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
-        batch[1].activation.retry_state = Some(RetryState {
-            attempts: 1,
-            max_attempts: 1,
-            on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
-            at_most_once: None,
-        });
-
-        assert!(store.store(batch).await.is_ok());
-
-        let past_deadline = store.handle_processing_deadline().await;
-        assert!(past_deadline.is_ok());
-        assert_eq!(past_deadline.unwrap(), 1);
-        assert_count_by_status(&store, InflightActivationStatus::Processing, 0).await;
-    }
-
-    #[tokio::test]
-    async fn test_remove_completed() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut records = make_activations(3);
-        // record 1 & 2 should not be removed.
-        records[0].status = InflightActivationStatus::Complete;
-        records[1].status = InflightActivationStatus::Pending;
-        records[2].status = InflightActivationStatus::Complete;
-
-        assert!(store.store(records.clone()).await.is_ok());
-
-        let result = store.remove_completed().await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 1);
-        assert!(store
-            .get_by_id(&records[0].activation.id)
-            .await
-            .expect("no error")
-            .is_none());
-        assert!(store
-            .get_by_id(&records[1].activation.id)
-            .await
-            .expect("no error")
-            .is_some());
-        assert!(store
-            .get_by_id(&records[2].activation.id)
-            .await
-            .expect("no error")
-            .is_some());
-
-        assert_count_by_status(&store, InflightActivationStatus::Complete, 1).await;
-        assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
-    }
-
-    #[tokio::test]
-    async fn test_remove_completed_multiple_gaps() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut records = make_activations(4);
-        // only record 1 can be removed
-        records[0].status = InflightActivationStatus::Complete;
-        records[1].status = InflightActivationStatus::Failure;
-        records[2].status = InflightActivationStatus::Complete;
-        records[3].status = InflightActivationStatus::Processing;
-
-        assert!(store.store(records.clone()).await.is_ok());
-
-        let result = store.remove_completed().await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 1);
-        assert!(store
-            .get_by_id(&records[0].activation.id)
-            .await
-            .expect("no error")
-            .is_none());
-        assert!(store
-            .get_by_id(&records[1].activation.id)
-            .await
-            .expect("no error")
-            .is_some());
-        assert!(store
-            .get_by_id(&records[2].activation.id)
-            .await
-            .expect("no error")
-            .is_some());
-        assert!(store
-            .get_by_id(&records[3].activation.id)
-            .await
-            .expect("no error")
-            .is_some());
-    }
-
-    #[tokio::test]
-    async fn test_handle_failed_tasks() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let mut records = make_activations(4);
-        // deadletter
-        records[0].status = InflightActivationStatus::Failure;
-        records[0].activation.retry_state = Some(RetryState {
-            attempts: 1,
-            max_attempts: 1,
-            on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
-            at_most_once: None,
-        });
-        // discard
-        records[1].status = InflightActivationStatus::Failure;
-        records[1].activation.retry_state = Some(RetryState {
-            attempts: 1,
-            max_attempts: 1,
-            on_attempts_exceeded: OnAttemptsExceeded::Discard as i32,
-            at_most_once: None,
-        });
-        // no retry state = discard
-        records[2].status = InflightActivationStatus::Failure;
-        assert!(records[2].activation.retry_state.is_none());
-
-        // Another deadletter
-        records[3].status = InflightActivationStatus::Failure;
-        records[3].activation.retry_state = Some(RetryState {
-            attempts: 1,
-            max_attempts: 1,
-            on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
-            at_most_once: None,
-        });
-        assert!(store.store(records.clone()).await.is_ok());
-
-        let result = store.handle_failed_tasks().await;
-        assert!(result.is_ok(), "handle_failed_tasks should be ok");
-        let fowarder = result.unwrap();
-
-        assert_eq!(
-            fowarder.to_deadletter.len(),
-            2,
-            "should have two tasks to deadletter"
-        );
-        assert!(
-            store.get_by_id(&fowarder.to_deadletter[0].id).await.is_ok(),
-            "deadletter records still in sqlite"
-        );
-        assert!(
-            store.get_by_id(&fowarder.to_deadletter[1].id).await.is_ok(),
-            "deadletter records still in sqlite"
-        );
-        assert_eq!(fowarder.to_deadletter[0].id, records[0].activation.id);
-        assert_eq!(fowarder.to_deadletter[1].id, records[3].activation.id);
-
-        assert_count_by_status(&store, InflightActivationStatus::Failure, 2).await;
-    }
-
-    #[tokio::test]
-    async fn test_mark_completed() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        let records = make_activations(3);
-        assert!(store.store(records.clone()).await.is_ok());
-        assert_count_by_status(&store, InflightActivationStatus::Pending, 3).await;
-
-        let ids: Vec<String> = records
-            .iter()
-            .map(|item| item.activation.id.clone())
-            .collect();
-        let result = store.mark_completed(ids.clone()).await;
-
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 3, "three records updated");
-
-        // No pending tasks left
-        assert_count_by_status(&store, InflightActivationStatus::Pending, 0).await;
-
-        // All tasks should be complete
-        assert_count_by_status(&store, InflightActivationStatus::Complete, 3).await;
-    }
-
-    #[tokio::test]
-    async fn test_handle_remove_at_no_complete() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-        let mut batch = make_activations(3);
-
-        // While two records are past deadlines, there are no completed tasks with higher offsets
-        // no tasks should be updated as we could have no workers available.
-        batch[0].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
-        batch[1].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
-
-        assert!(store.store(batch.clone()).await.is_ok());
-        let result = store.handle_remove_at().await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
-
-        assert_count_by_status(&store, InflightActivationStatus::Failure, 0).await;
-    }
-
-    #[tokio::test]
-    async fn test_handle_remove_at_with_complete() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-        let mut batch = make_activations(3);
-
-        // Because 1 is complete and has a higher offset than 0 1 will be moved to failure
-        batch[0].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
-        batch[1].status = InflightActivationStatus::Complete;
-        batch[2].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
-
-        assert!(store.store(batch.clone()).await.is_ok());
-
-        let result = store.handle_remove_at().await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 1, "only one record should be updated");
-
-        assert_count_by_status(&store, InflightActivationStatus::Failure, 1).await;
-
-        let failed = store.get_by_id(&batch[0].activation.id).await;
-        assert_eq!(
-            failed.unwrap().unwrap().status,
-            InflightActivationStatus::Failure
-        );
-    }
-
-    #[tokio::test]
-    async fn test_clear() {
-        let url = generate_temp_filename();
-        let store = InflightActivationStore::new(&url).await.unwrap();
-
-        #[allow(deprecated)]
-        let batch = vec![InflightActivation {
-            activation: TaskActivation {
-                id: "id_0".into(),
-                namespace: "namespace".into(),
-                taskname: "taskname".into(),
-                parameters: "{}".into(),
-                headers: HashMap::new(),
-                received_at: Some(prost_types::Timestamp {
-                    seconds: 0,
-                    nanos: 0,
-                }),
-                retry_state: None,
-                processing_deadline_duration: 0,
-                expires: Some(1),
-            },
-            status: InflightActivationStatus::Pending,
-            partition: 0,
-            offset: 0,
-            added_at: Utc::now(),
-            remove_at: Utc::now().add(Duration::from_secs(5 * 60)),
-            processing_deadline: None,
-            at_most_once: false,
-            namespace: "namespace".into(),
-        }];
-        assert!(store.store(batch).await.is_ok());
-        assert_eq!(store.count().await.unwrap(), 1);
-
-        assert!(store.clear().await.is_ok());
-
-        assert_eq!(store.count().await.unwrap(), 0);
-    }
-}
+mod store_tests;

--- a/src/inflight_activation_store/store_tests.rs
+++ b/src/inflight_activation_store/store_tests.rs
@@ -1,0 +1,762 @@
+use std::collections::{HashMap, HashSet};
+use std::ops::Add;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{TimeZone, Utc};
+use sentry_protos::taskbroker::v1::{
+    OnAttemptsExceeded, RetryState, TaskActivation, TaskActivationStatus,
+};
+use tokio::sync::broadcast;
+use tokio::task::JoinSet;
+
+use crate::inflight_activation_store::{
+    InflightActivation, InflightActivationStatus, InflightActivationStore,
+};
+use crate::test_utils::{assert_count_by_status, generate_temp_filename, make_activations};
+
+#[test]
+fn test_inflightactivation_status_is_completion() {
+    let mut value = InflightActivationStatus::Unspecified;
+    assert!(!value.is_conclusion());
+
+    value = InflightActivationStatus::Pending;
+    assert!(!value.is_conclusion());
+
+    value = InflightActivationStatus::Processing;
+    assert!(!value.is_conclusion());
+
+    value = InflightActivationStatus::Retry;
+    assert!(value.is_conclusion());
+
+    value = InflightActivationStatus::Failure;
+    assert!(value.is_conclusion());
+
+    value = InflightActivationStatus::Complete;
+    assert!(value.is_conclusion());
+}
+
+#[test]
+fn test_inflightactivation_status_from() {
+    let mut value: InflightActivationStatus = TaskActivationStatus::Pending.into();
+    assert_eq!(value, InflightActivationStatus::Pending);
+
+    value = TaskActivationStatus::Processing.into();
+    assert_eq!(value, InflightActivationStatus::Processing);
+
+    value = TaskActivationStatus::Retry.into();
+    assert_eq!(value, InflightActivationStatus::Retry);
+
+    value = TaskActivationStatus::Failure.into();
+    assert_eq!(value, InflightActivationStatus::Failure);
+
+    value = TaskActivationStatus::Complete.into();
+    assert_eq!(value, InflightActivationStatus::Complete);
+}
+
+#[tokio::test]
+async fn test_create_db() {
+    assert!(InflightActivationStore::new(&generate_temp_filename())
+        .await
+        .is_ok())
+}
+
+#[tokio::test]
+async fn test_store() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let batch = make_activations(2);
+    assert!(store.store(batch).await.is_ok());
+
+    let result = store.count().await;
+    assert_eq!(result.unwrap(), 2);
+}
+
+#[tokio::test]
+async fn test_store_duplicate_id_in_batch() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut batch = make_activations(2);
+    // Coerce a conflict
+    batch[0].activation.id = "id_0".into();
+    batch[1].activation.id = "id_0".into();
+
+    assert!(store.store(batch).await.is_ok());
+
+    let result = store.count().await;
+    assert_eq!(result.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn test_store_duplicate_id_between_batches() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let batch = make_activations(2);
+    assert!(store.store(batch.clone()).await.is_ok());
+    let first_count = store.count().await;
+    assert_eq!(first_count.unwrap(), 2);
+
+    let new_batch = make_activations(2);
+    // Old batch and new should have conflicts
+    assert_eq!(batch[0].activation.id, new_batch[0].activation.id);
+    assert_eq!(batch[1].activation.id, new_batch[1].activation.id);
+    assert!(store.store(new_batch).await.is_ok());
+
+    let second_count = store.count().await;
+    assert_eq!(second_count.unwrap(), 2);
+}
+
+#[tokio::test]
+async fn test_get_pending_activation() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let batch = make_activations(2);
+    assert!(store.store(batch.clone()).await.is_ok());
+
+    let result = store.get_pending_activation(None).await.unwrap().unwrap();
+
+    assert_eq!(result.activation.id, "id_0");
+    assert_eq!(result.status, InflightActivationStatus::Processing);
+    assert!(result.processing_deadline.unwrap() > Utc::now());
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 32)]
+async fn test_get_pending_activation_with_race() {
+    let url = generate_temp_filename();
+    let store = Arc::new(InflightActivationStore::new(&url).await.unwrap());
+
+    const NUM_CONCURRENT_WRITES: u32 = 2000;
+
+    for chunk in make_activations(NUM_CONCURRENT_WRITES).chunks(1024) {
+        store.store(chunk.to_vec()).await.unwrap();
+    }
+
+    let (tx, _) = broadcast::channel::<()>(1);
+    let mut join_set = JoinSet::new();
+
+    for _ in 0..NUM_CONCURRENT_WRITES {
+        let mut rx = tx.subscribe();
+        let store = store.clone();
+        join_set.spawn(async move {
+            rx.recv().await.unwrap();
+            store
+                .get_pending_activation(Some("namespace"))
+                .await
+                .unwrap()
+                .unwrap()
+        });
+    }
+
+    tx.send(()).unwrap();
+
+    let res: HashSet<_> = join_set
+        .join_all()
+        .await
+        .iter()
+        .map(|ifa| ifa.activation.id.clone())
+        .collect();
+
+    assert_eq!(res.len(), NUM_CONCURRENT_WRITES as usize);
+}
+
+#[tokio::test]
+async fn test_get_pending_activation_with_namespace() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut batch = make_activations(2);
+    batch[1].namespace = "other_namespace".into();
+    assert!(store.store(batch.clone()).await.is_ok());
+
+    // Get activation from other namespace
+    let result = store
+        .get_pending_activation(Some("other_namespace"))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.activation.id, "id_1");
+    assert_eq!(result.status, InflightActivationStatus::Processing);
+    assert!(result.processing_deadline.unwrap() > Utc::now());
+    assert_eq!(result.namespace, "other_namespace");
+}
+
+#[tokio::test]
+async fn test_get_pending_activation_no_deadletter() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut batch = make_activations(1);
+    batch[0].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
+    assert!(store.store(batch.clone()).await.is_ok());
+
+    let result = store.get_pending_activation(None).await;
+    assert!(result.is_ok());
+    let res_option = result.unwrap();
+    assert!(res_option.is_none());
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
+}
+
+#[tokio::test]
+async fn test_get_pending_activation_skip_expires() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut batch = make_activations(1);
+    batch[0].expires_at = Some(Utc::now() - Duration::from_secs(100));
+    assert!(store.store(batch.clone()).await.is_ok());
+
+    let result = store.get_pending_activation(None).await;
+    assert!(result.is_ok());
+    let res_option = result.unwrap();
+    assert!(res_option.is_none());
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
+}
+
+#[tokio::test]
+async fn test_get_pending_activation_earliest() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut batch = make_activations(2);
+    batch[0].added_at = Utc.with_ymd_and_hms(2024, 6, 24, 0, 0, 0).unwrap();
+    batch[1].added_at = Utc.with_ymd_and_hms(1998, 6, 24, 0, 0, 0).unwrap();
+    assert!(store.store(batch.clone()).await.is_ok());
+
+    let result = store.get_pending_activation(None).await.unwrap().unwrap();
+    assert_eq!(
+        result.added_at,
+        Utc.with_ymd_and_hms(1998, 6, 24, 0, 0, 0).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_count_pending_activations() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut batch = make_activations(3);
+    batch[0].status = InflightActivationStatus::Processing;
+    assert!(store.store(batch).await.is_ok());
+
+    assert_eq!(store.count_pending_activations().await.unwrap(), 2);
+
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 2).await;
+}
+
+#[tokio::test]
+async fn set_activation_status() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let batch = make_activations(2);
+    assert!(store.store(batch).await.is_ok());
+
+    assert_eq!(store.count_pending_activations().await.unwrap(), 2);
+    assert!(store
+        .set_status("id_0", InflightActivationStatus::Failure)
+        .await
+        .is_ok());
+    assert_eq!(store.count_pending_activations().await.unwrap(), 1);
+    assert!(store
+        .set_status("id_0", InflightActivationStatus::Pending)
+        .await
+        .is_ok());
+    assert_eq!(store.count_pending_activations().await.unwrap(), 2);
+    assert!(store
+        .set_status("id_0", InflightActivationStatus::Failure)
+        .await
+        .is_ok());
+    assert!(store
+        .set_status("id_1", InflightActivationStatus::Failure)
+        .await
+        .is_ok());
+    assert_eq!(store.count_pending_activations().await.unwrap(), 0);
+    assert!(store.get_pending_activation(None).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_set_processing_deadline() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let batch = make_activations(1);
+    assert!(store.store(batch.clone()).await.is_ok());
+
+    let deadline = Utc::now();
+    assert!(store
+        .set_processing_deadline("id_0", Some(deadline))
+        .await
+        .is_ok());
+
+    let result = store.get_by_id("id_0").await.unwrap().unwrap();
+    assert_eq!(result.processing_deadline, Some(deadline));
+}
+
+#[tokio::test]
+async fn test_delete_activation() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let batch = make_activations(2);
+    assert!(store.store(batch).await.is_ok());
+
+    let result = store.count().await;
+    assert_eq!(result.unwrap(), 2);
+
+    assert!(store.delete_activation("id_0").await.is_ok());
+    let result = store.count().await;
+    assert_eq!(result.unwrap(), 1);
+
+    assert!(store.delete_activation("id_0").await.is_ok());
+    let result = store.count().await;
+    assert_eq!(result.unwrap(), 1);
+
+    assert!(store.delete_activation("id_1").await.is_ok());
+    let result = store.count().await;
+    assert_eq!(result.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn test_get_retry_activations() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let batch = make_activations(2);
+    assert!(store.store(batch.clone()).await.is_ok());
+
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 2).await;
+
+    assert!(store
+        .set_status("id_0", InflightActivationStatus::Retry)
+        .await
+        .is_ok());
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
+
+    assert!(store
+        .set_status("id_1", InflightActivationStatus::Retry)
+        .await
+        .is_ok());
+
+    let retries = store.get_retry_activations().await.unwrap();
+    assert_eq!(retries.len(), 2);
+    for record in retries.iter() {
+        assert_eq!(record.status, InflightActivationStatus::Retry);
+    }
+}
+
+#[tokio::test]
+async fn test_handle_processing_deadline() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut batch = make_activations(2);
+    batch[1].status = InflightActivationStatus::Processing;
+    batch[1].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
+
+    assert!(store.store(batch).await.is_ok());
+
+    let past_deadline = store.handle_processing_deadline().await;
+    assert!(past_deadline.is_ok());
+    assert_eq!(past_deadline.unwrap(), 1);
+
+    assert_count_by_status(&store, InflightActivationStatus::Processing, 0).await;
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 2).await;
+
+    // Run again to check early return
+    let past_deadline = store.handle_processing_deadline().await;
+    assert!(past_deadline.is_ok());
+    assert_eq!(past_deadline.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn test_handle_processing_deadline_multiple_tasks() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut batch = make_activations(2);
+    batch[0].status = InflightActivationStatus::Processing;
+    batch[0].processing_deadline = Some(Utc.with_ymd_and_hms(2020, 1, 1, 1, 1, 1).unwrap());
+    batch[1].status = InflightActivationStatus::Processing;
+    batch[1].processing_deadline = Some(Utc::now() + chrono::Duration::days(30));
+    assert!(store.store(batch).await.is_ok());
+
+    let past_deadline = store.handle_processing_deadline().await;
+    assert!(past_deadline.is_ok());
+    assert_eq!(past_deadline.unwrap(), 1);
+
+    assert_count_by_status(&store, InflightActivationStatus::Processing, 1).await;
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
+}
+
+#[tokio::test]
+async fn test_handle_processing_at_most_once() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    // Both records are past processing deadlines
+    let mut batch = make_activations(2);
+    batch[0].status = InflightActivationStatus::Processing;
+    batch[0].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
+
+    batch[1].status = InflightActivationStatus::Processing;
+    batch[1].activation.retry_state = Some(RetryState {
+        attempts: 0,
+        max_attempts: 1,
+        on_attempts_exceeded: OnAttemptsExceeded::Discard as i32,
+        at_most_once: Some(true),
+    });
+    batch[1].at_most_once = true;
+    batch[1].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
+
+    assert!(store.store(batch.clone()).await.is_ok());
+
+    let past_deadline = store.handle_processing_deadline().await;
+    assert!(past_deadline.is_ok());
+    assert_eq!(past_deadline.unwrap(), 2);
+
+    assert_count_by_status(&store, InflightActivationStatus::Processing, 0).await;
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
+    assert_count_by_status(&store, InflightActivationStatus::Failure, 1).await;
+
+    let task = store
+        .get_by_id(&batch[1].activation.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(task.status, InflightActivationStatus::Failure);
+}
+
+#[tokio::test]
+async fn test_handle_processing_deadline_discard_after() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut batch = make_activations(2);
+    batch[1].status = InflightActivationStatus::Processing;
+    batch[1].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
+    batch[1].activation.retry_state = Some(RetryState {
+        attempts: 0,
+        max_attempts: 1,
+        on_attempts_exceeded: OnAttemptsExceeded::Discard as i32,
+        at_most_once: None,
+    });
+
+    assert!(store.store(batch).await.is_ok());
+
+    let past_deadline = store.handle_processing_deadline().await;
+    assert!(past_deadline.is_ok());
+    assert_eq!(past_deadline.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn test_handle_processing_deadline_deadletter_after() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut batch = make_activations(2);
+    batch[1].status = InflightActivationStatus::Processing;
+    batch[1].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
+    batch[1].activation.retry_state = Some(RetryState {
+        attempts: 0,
+        max_attempts: 1,
+        on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
+        at_most_once: None,
+    });
+
+    assert!(store.store(batch).await.is_ok());
+
+    let past_deadline = store.handle_processing_deadline().await;
+    assert!(past_deadline.is_ok());
+    assert_eq!(past_deadline.unwrap(), 1);
+    assert_count_by_status(&store, InflightActivationStatus::Processing, 0).await;
+}
+
+#[tokio::test]
+async fn test_handle_processing_deadline_no_retries_remaining() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut batch = make_activations(2);
+    batch[1].status = InflightActivationStatus::Processing;
+    batch[1].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
+    batch[1].activation.retry_state = Some(RetryState {
+        attempts: 1,
+        max_attempts: 1,
+        on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
+        at_most_once: None,
+    });
+
+    assert!(store.store(batch).await.is_ok());
+
+    let past_deadline = store.handle_processing_deadline().await;
+    assert!(past_deadline.is_ok());
+    assert_eq!(past_deadline.unwrap(), 1);
+    assert_count_by_status(&store, InflightActivationStatus::Processing, 0).await;
+}
+
+#[tokio::test]
+async fn test_remove_completed() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut records = make_activations(3);
+    // record 1 & 2 should not be removed.
+    records[0].status = InflightActivationStatus::Complete;
+    records[1].status = InflightActivationStatus::Pending;
+    records[2].status = InflightActivationStatus::Complete;
+
+    assert!(store.store(records.clone()).await.is_ok());
+
+    let result = store.remove_completed().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 1);
+    assert!(store
+        .get_by_id(&records[0].activation.id)
+        .await
+        .expect("no error")
+        .is_none());
+    assert!(store
+        .get_by_id(&records[1].activation.id)
+        .await
+        .expect("no error")
+        .is_some());
+    assert!(store
+        .get_by_id(&records[2].activation.id)
+        .await
+        .expect("no error")
+        .is_some());
+
+    assert_count_by_status(&store, InflightActivationStatus::Complete, 1).await;
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
+}
+
+#[tokio::test]
+async fn test_remove_completed_multiple_gaps() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut records = make_activations(4);
+    // only record 1 can be removed
+    records[0].status = InflightActivationStatus::Complete;
+    records[1].status = InflightActivationStatus::Failure;
+    records[2].status = InflightActivationStatus::Complete;
+    records[3].status = InflightActivationStatus::Processing;
+
+    assert!(store.store(records.clone()).await.is_ok());
+
+    let result = store.remove_completed().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 1);
+    assert!(store
+        .get_by_id(&records[0].activation.id)
+        .await
+        .expect("no error")
+        .is_none());
+    assert!(store
+        .get_by_id(&records[1].activation.id)
+        .await
+        .expect("no error")
+        .is_some());
+    assert!(store
+        .get_by_id(&records[2].activation.id)
+        .await
+        .expect("no error")
+        .is_some());
+    assert!(store
+        .get_by_id(&records[3].activation.id)
+        .await
+        .expect("no error")
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_handle_failed_tasks() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let mut records = make_activations(4);
+    // deadletter
+    records[0].status = InflightActivationStatus::Failure;
+    records[0].activation.retry_state = Some(RetryState {
+        attempts: 1,
+        max_attempts: 1,
+        on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
+        at_most_once: None,
+    });
+    // discard
+    records[1].status = InflightActivationStatus::Failure;
+    records[1].activation.retry_state = Some(RetryState {
+        attempts: 1,
+        max_attempts: 1,
+        on_attempts_exceeded: OnAttemptsExceeded::Discard as i32,
+        at_most_once: None,
+    });
+    // no retry state = discard
+    records[2].status = InflightActivationStatus::Failure;
+    assert!(records[2].activation.retry_state.is_none());
+
+    // Another deadletter
+    records[3].status = InflightActivationStatus::Failure;
+    records[3].activation.retry_state = Some(RetryState {
+        attempts: 1,
+        max_attempts: 1,
+        on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
+        at_most_once: None,
+    });
+    assert!(store.store(records.clone()).await.is_ok());
+
+    let result = store.handle_failed_tasks().await;
+    assert!(result.is_ok(), "handle_failed_tasks should be ok");
+    let fowarder = result.unwrap();
+
+    assert_eq!(
+        fowarder.to_deadletter.len(),
+        2,
+        "should have two tasks to deadletter"
+    );
+    assert!(
+        store.get_by_id(&fowarder.to_deadletter[0].id).await.is_ok(),
+        "deadletter records still in sqlite"
+    );
+    assert!(
+        store.get_by_id(&fowarder.to_deadletter[1].id).await.is_ok(),
+        "deadletter records still in sqlite"
+    );
+    assert_eq!(fowarder.to_deadletter[0].id, records[0].activation.id);
+    assert_eq!(fowarder.to_deadletter[1].id, records[3].activation.id);
+
+    assert_count_by_status(&store, InflightActivationStatus::Failure, 2).await;
+}
+
+#[tokio::test]
+async fn test_mark_completed() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    let records = make_activations(3);
+    assert!(store.store(records.clone()).await.is_ok());
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 3).await;
+
+    let ids: Vec<String> = records
+        .iter()
+        .map(|item| item.activation.id.clone())
+        .collect();
+    let result = store.mark_completed(ids.clone()).await;
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 3, "three records updated");
+
+    // No pending tasks left
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 0).await;
+
+    // All tasks should be complete
+    assert_count_by_status(&store, InflightActivationStatus::Complete, 3).await;
+}
+
+#[tokio::test]
+async fn test_handle_remove_at_no_complete() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+    let mut batch = make_activations(3);
+
+    // While two records are past deadlines, there are no completed tasks with higher offsets
+    // no tasks should be updated as we could have no workers available.
+    batch[0].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
+    batch[1].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
+
+    assert!(store.store(batch.clone()).await.is_ok());
+    let result = store.handle_remove_at().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 0);
+
+    assert_count_by_status(&store, InflightActivationStatus::Failure, 0).await;
+}
+
+#[tokio::test]
+async fn test_handle_remove_at_with_complete() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+    let mut batch = make_activations(3);
+
+    // Because 1 is complete and has a higher offset than 0 1 will be moved to failure
+    batch[0].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
+    batch[1].status = InflightActivationStatus::Complete;
+    batch[2].remove_at = Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap();
+
+    assert!(store.store(batch.clone()).await.is_ok());
+
+    let result = store.handle_remove_at().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 1, "only one record should be updated");
+
+    assert_count_by_status(&store, InflightActivationStatus::Failure, 1).await;
+
+    let failed = store.get_by_id(&batch[0].activation.id).await;
+    assert_eq!(
+        failed.unwrap().unwrap().status,
+        InflightActivationStatus::Failure
+    );
+}
+
+#[tokio::test]
+async fn test_handle_expires_at() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+    let mut batch = make_activations(3);
+
+    // All expired tasks should be removed, regardless of order or other tasks.
+    batch[0].expires_at = Some(Utc::now() - (Duration::from_secs(5 * 60)));
+    batch[1].expires_at = Some(Utc::now() + (Duration::from_secs(5 * 60)));
+    batch[2].expires_at = Some(Utc::now() - (Duration::from_secs(5 * 60)));
+
+    assert!(store.store(batch.clone()).await.is_ok());
+    let result = store.handle_expires_at().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 2);
+
+    assert_count_by_status(&store, InflightActivationStatus::Failure, 2).await;
+}
+
+#[tokio::test]
+async fn test_clear() {
+    let url = generate_temp_filename();
+    let store = InflightActivationStore::new(&url).await.unwrap();
+
+    #[allow(deprecated)]
+    let batch = vec![InflightActivation {
+        activation: TaskActivation {
+            id: "id_0".into(),
+            namespace: "namespace".into(),
+            taskname: "taskname".into(),
+            parameters: "{}".into(),
+            headers: HashMap::new(),
+            received_at: Some(prost_types::Timestamp {
+                seconds: 0,
+                nanos: 0,
+            }),
+            retry_state: None,
+            processing_deadline_duration: 0,
+            expires: Some(1),
+        },
+        status: InflightActivationStatus::Pending,
+        partition: 0,
+        offset: 0,
+        added_at: Utc::now(),
+        remove_at: Utc::now().add(Duration::from_secs(5 * 60)),
+        expires_at: None,
+        processing_deadline: None,
+        at_most_once: false,
+        namespace: "namespace".into(),
+    }];
+    assert!(store.store(batch).await.is_ok());
+    assert_eq!(store.count().await.unwrap(), 1);
+
+    assert!(store.clear().await.is_ok());
+
+    assert_eq!(store.count().await.unwrap(), 0);
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -52,6 +52,7 @@ pub fn make_activations(count: u32) -> Vec<InflightActivation> {
             offset: i as i64,
             added_at: Utc::now(),
             remove_at: Utc::now().add(Duration::from_secs(5 * 60)),
+            expires_at: None,
             processing_deadline: None,
             at_most_once: false,
             namespace: "namespace".into(),


### PR DESCRIPTION
Currently if a task has an expiry set, that expiry date is tracked through the remove_at column. However that column is also used to track tasks that aren't being processed because of worker failures.

The issue with that is that expired tasks should be handled differently from tasks that are not being processed. Expired tasks can be removed immediately as soon as the expiry has passed, regardless of any other tasks. Tasks that aren't being processed might be in that state because the workers aren't running, so they can't be removed until other tasks start being completed.

Add an explicit column for expires_at, that is only populated if the task has an expiry. Also update the upkeep thread to mark expired tasks for removal.

While in theory a check could be added to the consumer to avoid even ingesting tasks that are expired, letting the upkeep thread remove them means the tasks get properly discarded/retried/dlq.

Fixes https://github.com/getsentry/taskbroker/issues/170