### PR TITLE
fix(ci): Add default token to avoid protoc rate limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install protoc
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust Toolchain
         run: rustup toolchain install stable --profile minimal --component clippy --component rustfmt --no-self-update


### PR DESCRIPTION
Looks like providing an access token gets us a higher Github API request allocation to avoid rate limiting: https://github.com/arduino/setup-protoc#:~:text=to%20avoid%20rate%20limiting