### PR TITLE
fix: Use STRICT when building SQLite table

### DIFF
--- a/migrations/0001_create_inflight_taskactivations.sql
+++ b/migrations/0001_create_inflight_taskactivations.sql
@@ -2,15 +2,15 @@ CREATE TABLE IF NOT EXISTS inflight_taskactivations (
     id TEXT NOT NULL PRIMARY KEY,
     activation BLOB NOT NULL,
     partition INTEGER NOT NULL,
-    offset BIGINTEGER NOT NULL,
+    offset INTEGER NOT NULL,
     added_at INTEGER NOT NULL,
     remove_at INTEGER NOT NULL,
     processing_deadline_duration INTEGER NOT NULL,
     processing_deadline INTEGER,
-    status INTEGER NOT NULL,
-    at_most_once BOOLEAN NOT NULL DEFAULT FALSE,
+    status TEXT NOT NULL,
+    at_most_once INTEGER NOT NULL DEFAULT 0,
     namespace TEXT
-);
+) STRICT;
 
 CREATE INDEX idx_pending_activation
 ON inflight_taskactivations (status, remove_at, added_at, namespace, id);

--- a/src/inflight_activation_store.rs
+++ b/src/inflight_activation_store.rs
@@ -297,7 +297,7 @@ impl InflightActivationStore {
         deadline: Option<DateTime<Utc>>,
     ) -> Result<(), Error> {
         sqlx::query("UPDATE inflight_taskactivations SET processing_deadline = $1 WHERE id = $2")
-            .bind(deadline)
+            .bind(deadline.unwrap().timestamp())
             .bind(id)
             .execute(&self.sqlite_pool)
             .await?;

--- a/src/inflight_activation_store/store_tests.rs
+++ b/src/inflight_activation_store/store_tests.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::{TimeZone, Utc};
+use chrono::{SubsecRound, TimeZone, Utc};
 use sentry_protos::taskbroker::v1::{
     OnAttemptsExceeded, RetryState, TaskActivation, TaskActivationStatus,
 };
@@ -277,7 +277,7 @@ async fn test_set_processing_deadline() {
         .is_ok());
 
     let result = store.get_by_id("id_0").await.unwrap().unwrap();
-    assert_eq!(result.processing_deadline, Some(deadline));
+    assert_eq!(result.processing_deadline, Some(deadline.round_subsecs(0)));
 }
 
 #[tokio::test]


### PR DESCRIPTION
This makes SQLite enforce that the types of the columns are restricted just to the ones that are
explicitly supported, and does validation on the values being inserted to ensure they are the
correct type.
