### PR TITLE
feat(processing-attempts): Replace remove_at with processing_attempts

### DIFF
--- a/migrations/0001_create_inflight_taskactivations.sql
+++ b/migrations/0001_create_inflight_taskactivations.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS inflight_taskactivations (
     partition INTEGER NOT NULL,
     offset BIGINTEGER NOT NULL,
     added_at INTEGER NOT NULL,
-    remove_at INTEGER NOT NULL,
+    processing_attempts INTEGER NOT NULL,
     processing_deadline_duration INTEGER NOT NULL,
     processing_deadline INTEGER,
     status INTEGER NOT NULL,

--- a/migrations/0001_create_inflight_taskactivations.sql
+++ b/migrations/0001_create_inflight_taskactivations.sql
@@ -13,4 +13,4 @@ CREATE TABLE IF NOT EXISTS inflight_taskactivations (
 );
 
 CREATE INDEX idx_pending_activation
-ON inflight_taskactivations (status, remove_at, added_at, namespace, id);
+ON inflight_taskactivations (status, added_at, namespace, id);

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,12 +83,10 @@ pub struct Config {
     /// does not have a processing deadline set, this will be used.
     pub max_processing_deadline: usize,
 
-    /// The maximum number of seconds that a TaskActivation
-    /// can be in InflightTaskStore. After this time, activations
-    /// will be removed if they are not complete. This should
-    /// be a multiple of max_processing_deadline to allow
-    /// temporary worker deaths to be resolved.
-    pub remove_deadline: usize,
+    /// The maximum number of times a task can be reset from
+    /// processing back to pending. When this limit is reached,
+    /// the activation will be discarded/deadlettered.
+    pub max_processing_attempts: usize,
 
     /// The frequency at which upkeep tasks are spawned.
     pub upkeep_task_interval_ms: u64,
@@ -120,7 +118,7 @@ impl Default for Config {
             max_pending_count: 2048,
             max_pending_buffer_count: 128,
             max_processing_deadline: 300,
-            remove_deadline: 900,
+            max_processing_attempts: 3,
             upkeep_task_interval_ms: 200,
         }
     }
@@ -223,7 +221,7 @@ mod tests {
                 db_path: ./taskbroker-error.sqlite
                 max_pending_count: 512
                 max_processing_deadline: 1000
-                remove_deadline: 2000
+                max_processing_attempts: 5
             "#,
             )?;
             // Env vars always override config file
@@ -253,7 +251,7 @@ mod tests {
             assert_eq!(config.db_path, "./taskbroker-error.sqlite".to_owned());
             assert_eq!(config.max_pending_count, 512);
             assert_eq!(config.max_processing_deadline, 1000);
-            assert_eq!(config.remove_deadline, 2000);
+            assert_eq!(config.max_processing_attempts, 5);
 
             Ok(())
         });
@@ -263,12 +261,12 @@ mod tests {
     fn test_from_args_env_and_args() {
         Jail::expect_with(|jail| {
             jail.set_env("TASKBROKER_LOG_FILTER", "error");
-            jail.set_env("TASKBROKER_REMOVE_DEADLINE", "2000");
+            jail.set_env("TASKBROKER_MAX_PROCESSING_ATTEMPTS", "5");
 
             let args = Args { config: None };
             let config = Config::from_args(&args).unwrap();
             assert_eq!(config.log_filter, "error");
-            assert_eq!(config.remove_deadline, 2000);
+            assert_eq!(config.max_processing_attempts, 5);
 
             Ok(())
         });
@@ -278,7 +276,7 @@ mod tests {
     fn test_from_args_env_test() {
         Jail::expect_with(|jail| {
             jail.set_env("TASKBROKER_LOG_FILTER", "error");
-            jail.set_env("TASKBROKER_REMOVE_DEADLINE", "2000");
+            jail.set_env("TASKBROKER_MAX_PROCESSING_ATTEMPTS", "5");
             jail.set_env("TASKBROKER_DEFAULT_METRICS_TAGS", "{key=value}");
 
             let args = Args { config: None };
@@ -291,7 +289,7 @@ mod tests {
             assert_eq!(config.db_path, "./taskbroker-inflight.sqlite".to_owned());
             assert_eq!(config.max_pending_count, 2048);
             assert_eq!(config.max_processing_deadline, 300);
-            assert_eq!(config.remove_deadline, 2000);
+            assert_eq!(config.max_processing_attempts, 5);
             assert_eq!(
                 config.default_metrics_tags,
                 BTreeMap::from([("key".to_owned(), "value".to_owned())])

--- a/src/consumer/deserialize_activation.rs
+++ b/src/consumer/deserialize_activation.rs
@@ -42,24 +42,7 @@ pub fn new(
                 .or(Some(false))
                 .expect("could not access at_most_once");
         }
-        let now = Utc::now();
-
-        // Determine the deadletter_at time using config and activation expires time.
-        let mut remove_at = now.add(config.remove_deadline);
-        if let Some(expires) = activation.expires {
-            let expires_duration = Duration::from_secs(expires);
-            if expires_duration < config.remove_deadline {
-                // Expiry times are based on the time the task was received
-                // not the time it was dequeued from Kafka.
-                let activation_received = activation.received_at.map_or(now, |ts| {
-                    match Utc.timestamp_opt(ts.seconds, ts.nanos as u32) {
-                        MappedLocalTime::Single(ts) => ts,
-                        _ => now,
-                    }
-                });
-                remove_at = activation_received + expires_duration;
-            }
-        }
+        let processing_attempts = 0;
 
         Ok(InflightActivation {
             activation,
@@ -68,7 +51,7 @@ pub fn new(
             offset: msg.offset(),
             added_at: Utc::now(),
             processing_deadline: None,
-            remove_at,
+            processing_attempts,
             at_most_once,
             namespace,
         })

--- a/src/inflight_activation_store.rs
+++ b/src/inflight_activation_store.rs
@@ -374,7 +374,7 @@ impl InflightActivationStore {
         // Update non-idempotent tasks
         let result = sqlx::query(
             "UPDATE inflight_taskactivations
-            SET processing_deadline = null, status = $1
+            SET processing_deadline = null, status = $1, processing_attempts = processing_attempts + 1
             WHERE processing_deadline < $2 AND status = $3",
         )
         .bind(InflightActivationStatus::Pending)

--- a/src/inflight_activation_store/store_tests.rs
+++ b/src/inflight_activation_store/store_tests.rs
@@ -608,7 +608,7 @@ async fn test_remove_completed() {
 
     let result = store.remove_completed().await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), 1);
+    assert_eq!(result.unwrap(), 2);
     assert!(store
         .get_by_id(&records[0].activation.id)
         .await
@@ -623,9 +623,9 @@ async fn test_remove_completed() {
         .get_by_id(&records[2].activation.id)
         .await
         .expect("no error")
-        .is_some());
+        .is_none());
 
-    assert_count_by_status(&store, InflightActivationStatus::Complete, 1).await;
+    assert_count_by_status(&store, InflightActivationStatus::Complete, 0).await;
     assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
 }
 
@@ -655,7 +655,7 @@ async fn test_remove_completed_multiple_gaps() {
 
     let result = store.remove_completed().await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), 1);
+    assert_eq!(result.unwrap(), 2);
     assert!(store
         .get_by_id(&records[0].activation.id)
         .await
@@ -670,7 +670,7 @@ async fn test_remove_completed_multiple_gaps() {
         .get_by_id(&records[2].activation.id)
         .await
         .expect("no error")
-        .is_some());
+        .is_none());
     assert!(store
         .get_by_id(&records[3].activation.id)
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use sentry_protos::taskbroker::v1::consumer_service_server::ConsumerServiceServe
 use taskbroker::config::Config;
 use taskbroker::consumer::{
     admin::create_missing_topics,
-    deserialize_activation::{self, DeserializeConfig},
+    deserialize_activation::{self},
     inflight_activation_writer::{ActivationWriterConfig, InflightActivationWriter},
     kafka::start_consumer,
     os_stream_writer::{OsStream, OsStreamWriter},
@@ -93,9 +93,7 @@ async fn main() -> Result<(), Error> {
                 &consumer_config.kafka_consumer_config(),
                 processing_strategy!({
                     map:
-                        deserialize_activation::new(
-                            DeserializeConfig::from_config(&consumer_config)
-                        ),
+                        deserialize_activation::new(),
 
                     reduce:
                         InflightActivationBatcher::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,9 @@ use taskbroker::consumer::{
     os_stream_writer::{OsStream, OsStreamWriter},
 };
 use taskbroker::grpc_server::MyConsumerService;
-use taskbroker::inflight_activation_store::InflightActivationStore;
+use taskbroker::inflight_activation_store::{
+    InflightActivationStore, InflightActivationStoreConfig,
+};
 use taskbroker::logging;
 use taskbroker::metrics;
 use taskbroker::processing_strategy;
@@ -50,7 +52,13 @@ async fn main() -> Result<(), Error> {
 
     logging::init(logging::LoggingConfig::from_config(&config));
     metrics::init(metrics::MetricsConfig::from_config(&config));
-    let store = Arc::new(InflightActivationStore::new(&config.db_path).await?);
+    let store = Arc::new(
+        InflightActivationStore::new(
+            &config.db_path,
+            InflightActivationStoreConfig::from_config(&config),
+        )
+        .await?,
+    );
 
     // If this is an environment where the topics might not exist, check and create them.
     if config.create_missing_topics {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,8 +7,6 @@ use rdkafka::{
     producer::FutureProducer,
     Message,
 };
-use std::ops::Add;
-use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
@@ -51,7 +49,7 @@ pub fn make_activations(count: u32) -> Vec<InflightActivation> {
             partition: 0,
             offset: i as i64,
             added_at: Utc::now(),
-            remove_at: Utc::now().add(Duration::from_secs(5 * 60)),
+            processing_attempts: 0,
             processing_deadline: None,
             at_most_once: false,
             namespace: "namespace".into(),

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -13,6 +13,7 @@ use crate::{
     config::Config,
     inflight_activation_store::{
         InflightActivation, InflightActivationStatus, InflightActivationStore,
+        InflightActivationStoreConfig,
     },
 };
 use chrono::{Timelike, Utc};
@@ -76,6 +77,18 @@ pub async fn assert_count_by_status(
 /// Create a basic default [`Config`]
 pub fn create_config() -> Arc<Config> {
     Arc::new(Config::default())
+}
+
+/// Create an InflightActivationStore instance
+pub async fn create_test_store() -> InflightActivationStore {
+    let url = generate_temp_filename();
+
+    InflightActivationStore::new(
+        &url,
+        InflightActivationStoreConfig::from_config(&create_integration_config()),
+    )
+    .await
+    .unwrap()
 }
 
 /// Create a Config instance that uses a testing topic

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -125,12 +125,13 @@ pub async fn do_upkeep(
     }
 
     // 4. Handle processing deadlines
-    if let Ok(processing_count) = store
+    if let Ok(counts) = store
         .handle_processing_deadline()
         .instrument(info_span!("handle_processing_deadline"))
         .await
     {
-        result_context.processing_deadline_reset = processing_count;
+        result_context.processing_deadline_reset = counts.0;
+        result_context.processing_attempts_exceeded = counts.1;
     }
 
     // 5.Handle tasks whos processing_attempts have exceeded max_processing_attempts
@@ -139,7 +140,7 @@ pub async fn do_upkeep(
         .instrument(info_span!("handle_processing_attempts"))
         .await
     {
-        result_context.processing_attempts_exceeded = processing_attempts_exceeded;
+        result_context.processing_attempts_exceeded += processing_attempts_exceeded;
     }
 
     // 6. Handle tasks that are past their expires_at deadline

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -134,16 +134,7 @@ pub async fn do_upkeep(
         result_context.processing_attempts_exceeded = counts.1;
     }
 
-    // 5.Handle tasks whos processing_attempts have exceeded max_processing_attempts
-    if let Ok(processing_attempts_exceeded) = store
-        .handle_processing_attempts()
-        .instrument(info_span!("handle_processing_attempts"))
-        .await
-    {
-        result_context.processing_attempts_exceeded += processing_attempts_exceeded;
-    }
-
-    // 6. Handle tasks that are past their expires_at deadline
+    // 5. Handle tasks that are past their expires_at deadline
     if let Ok(expired_count) = store
         .handle_expires_at()
         .instrument(info_span!("handle_expires_at"))
@@ -152,7 +143,7 @@ pub async fn do_upkeep(
         result_context.expired = expired_count;
     }
 
-    // 7.. Handle failure state tasks
+    // 6. Handle failure state tasks
     if let Ok(failed_tasks_forwarder) = store
         .handle_failed_tasks()
         .instrument(info_span!("handle_failed_tasks"))
@@ -178,13 +169,13 @@ pub async fn do_upkeep(
             ids.push(activation.id);
         }
 
-        // 8. Update deadlettered tasks to complete
+        // 7. Update deadlettered tasks to complete
         if let Ok(deadletter_count) = store.mark_completed(ids).await {
             result_context.deadlettered = deadletter_count;
         }
     }
 
-    // 9. Cleanup completed tasks
+    // 8. Cleanup completed tasks
     if let Ok(count) = store
         .remove_completed()
         .instrument(info_span!("remove_completed"))

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -245,7 +245,9 @@ mod tests {
     use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, RetryState};
 
     use crate::{
-        inflight_activation_store::{InflightActivationStatus, InflightActivationStore},
+        inflight_activation_store::{
+            InflightActivationStatus, InflightActivationStore, InflightActivationStoreConfig,
+        },
         test_utils::{
             consume_topic, create_config, create_integration_config, create_producer,
             generate_temp_filename, make_activations, reset_topic,
@@ -255,8 +257,13 @@ mod tests {
 
     async fn create_inflight_store() -> Arc<InflightActivationStore> {
         let url = generate_temp_filename();
+        let config = create_integration_config();
 
-        Arc::new(InflightActivationStore::new(&url).await.unwrap())
+        Arc::new(
+            InflightActivationStore::new(&url, InflightActivationStoreConfig::from_config(&config))
+                .await
+                .unwrap(),
+        )
     }
 
     #[tokio::test]


### PR DESCRIPTION
There is an edge case with the `remove_at` mechanism which can cause taskbroker to halt. This column is not enough for the taskbroker to differentiate activations that are stuck in sqlite because workers are unable to process them, and activations that are stuck due to workers not being available. 

This PR is responsible for replacing the `remove_at` column with `processing_attempts` which counts the number of times an activation has been reset back from `processing` to `pending` due to processing_deadline exceeding. When `processing_attempts` >= `max_processing_attempts` (defined in configuration), the new `handle_processing_attempts` function in upkeep will move the task to `failed`. Finally, the `handle_failed_tasks` cleans them up.

In this implementation, the `processing_attempts` is reset for a task is retried (reproduced into the topic). This means there is a scenario where a task with a `max_processing_attempts=3` and `retry=5` could be attempted 15 times assuming the worker dies every time.