### PR TITLE
feat(kafka): update reducer interface

### DIFF
--- a/src/consumer/inflight_activation_batcher.rs
+++ b/src/consumer/inflight_activation_batcher.rs
@@ -44,14 +44,14 @@ impl Reducer for InflightActivationBatcher {
         Ok(())
     }
 
-    async fn flush(&mut self) -> Result<Self::Output, anyhow::Error> {
+    async fn flush(&mut self) -> Result<Option<Self::Output>, anyhow::Error> {
         if self.buffer.is_empty() {
-            return Ok(vec![]);
+            return Ok(None);
         }
-        Ok(replace(
+        Ok(Some(replace(
             &mut self.buffer,
             Vec::with_capacity(self.config.max_buf_len),
-        ))
+        )))
     }
 
     fn reset(&mut self) {

--- a/src/consumer/os_stream_writer.rs
+++ b/src/consumer/os_stream_writer.rs
@@ -40,16 +40,16 @@ where
         Ok(())
     }
 
-    async fn flush(&mut self) -> Result<(), anyhow::Error> {
+    async fn flush(&mut self) -> Result<Option<()>, anyhow::Error> {
         let Some(data) = self.data.take() else {
-            return Ok(());
+            return Ok(None);
         };
         match self.os_stream {
             OsStream::StdOut => println!("{:?}", data),
             OsStream::StdErr => eprintln!("{:?}", data),
         }
         sleep(self.print_duration).await;
-        Ok(())
+        Ok(Some(()))
     }
 
     fn reset(&mut self) {


### PR DESCRIPTION
Reducer flush now returns
```rust
Result<Option<Self::Output>, ...>
```
instead of 
```rust
Result<Self::Output, ...>
```
So that it can signal that it yielded no value after a flush call.

This is useful for things like "the reducer is full but the db is also full", so the flush is a noop, the offsets do not get committed.