### PR TITLE
fix(config) Reduce the default upkeep interval

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -119,7 +119,7 @@ impl Default for Config {
             max_pending_buffer_count: 128,
             max_processing_deadline: 300,
             max_processing_attempts: 3,
-            upkeep_task_interval_ms: 200,
+            upkeep_task_interval_ms: 1000,
         }
     }
 }


### PR DESCRIPTION
With most of our time math only having second resolution there isn't much reason to run upkeep more frequently than once a second, as the only step that will apply is the completed task garbage collection.