### PR TITLE
fix: flush WAL on each commit to the store

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,9 @@ pub struct Config {
     /// The synchronization mode for the sqlite database
     pub db_sync_mode: String,
 
+    /// The checkpoint mode to use when storing activations
+    pub db_checkpoint_mode: String,
+
     /// The maximum number of pending records that can be
     /// in the InflightTaskStore (sqlite)
     pub max_pending_count: usize,
@@ -119,6 +122,7 @@ impl Default for Config {
             kafka_send_timeout_ms: 500,
             db_path: "./taskbroker-inflight.sqlite".to_owned(),
             db_sync_mode: "normal".to_owned(),
+            db_checkpoint_mode: "PASSIVE".to_owned(),
             max_pending_count: 2048,
             max_pending_buffer_count: 128,
             max_processing_deadline: 300,


### PR DESCRIPTION
With sync=normal we *could* lose entries in the WAL if the machine were to die abruptly. By forcing a sync on each batch write we can ensure that we won't lose tasks between kafka and sqlite.