### PR TITLE
fix(upkeep): Tweak upkeep producer settings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -178,14 +178,14 @@ impl Config {
         let config = new_config
             .set("bootstrap.servers", self.kafka_cluster.clone())
             // Ensure the buffer gets flushed more frequently than upkeep runs
+            // .set(
+            //     "queue.buffering.max.ms",
+            //     (self.upkeep_task_interval_ms / 2).to_string(),
+            // )
             .set(
-                "queue.buffering.max.ms",
-                (self.upkeep_task_interval_ms / 2).to_string(),
+                "queue.buffering.max.messages",
+                self.max_rdkafka_producer_buffer.to_string(),
             );
-        // .set(
-        //     "queue.buffering.max.messages",
-        //     self.max_rdkafka_producer_buffer.to_string(),
-        // );
         config.clone()
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,11 +181,11 @@ impl Config {
             .set(
                 "queue.buffering.max.ms",
                 (self.upkeep_task_interval_ms / 2).to_string(),
-            )
-            .set(
-                "queue.buffering.max.messages",
-                self.max_rdkafka_producer_buffer.to_string(),
             );
+        // .set(
+        //     "queue.buffering.max.messages",
+        //     self.max_rdkafka_producer_buffer.to_string(),
+        // );
         config.clone()
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -178,10 +178,10 @@ impl Config {
         let config = new_config
             .set("bootstrap.servers", self.kafka_cluster.clone())
             // Ensure the buffer gets flushed more frequently than upkeep runs
-            // .set(
-            //     "queue.buffering.max.ms",
-            //     (self.upkeep_task_interval_ms / 2).to_string(),
-            // )
+            .set(
+                "queue.buffering.max.ms",
+                (self.upkeep_task_interval_ms / 2).to_string(),
+            )
             .set(
                 "queue.buffering.max.messages",
                 self.max_rdkafka_producer_buffer.to_string(),


### PR DESCRIPTION
The upkeep currently takes much much longer to run when it has to retry/deadletter messages into the
local producer. In an effort to improve that, have the local producer flush messages based on time
instead of on batch size.