### PR TITLE
fix(index): Add indexes for the upkeep queries that run

### DIFF
--- a/migrations/0001_create_inflight_taskactivations.sql
+++ b/migrations/0001_create_inflight_taskactivations.sql
@@ -15,3 +15,12 @@ CREATE TABLE IF NOT EXISTS inflight_taskactivations (
 
 CREATE INDEX idx_pending_activation
 ON inflight_taskactivations (status, added_at, namespace, id);
+
+CREATE INDEX idx_processing_deadline
+ON inflight_taskactivations (status, processing_deadline);
+
+CREATE INDEX idx_processing_attempts
+ON inflight_taskactivations (status, processing_attempts);
+
+CREATE INDEX idx_expires_at
+ON inflight_taskactivations (status, expires_at);


### PR DESCRIPTION
The queries that the upkeep thread uses have different indexes from the get pending activation query. Add more indexes to account for those queries as well.

These were tested locally, just to ensure that they get used as expected.

```
sqlite> EXPLAIN QUERY PLAN UPDATE inflight_taskactivations SET processing_deadline = null, status = "Failure" WHERE processing_deadline < now() and at_most_once = TRUE AND status = "Processing";
QUERY PLAN
`--SEARCH inflight_taskactivations USING INDEX idx_processing_deadline (status=? AND processing_deadline<?)

sqlite> EXPLAIN QUERY PLAN UPDATE inflight_taskactivations SET status = "FAILURE" WHERE processing_attempts >= 10 AND status = "PROCESSING";
QUERY PLAN
`--SEARCH inflight_taskactivations USING INDEX idx_processing_attempts (status=? AND processing_attempts>?)

sqlite> EXPLAIN QUERY PLAN UPDATE inflight_taskactivations SET status = "FAILURE" WHERE expires_at IS NOT NULL AND expires_at < 1713686400 AND status = "PROCESSING";
QUERY PLAN
`--SEARCH inflight_taskactivations USING INDEX idx_expires_at (status=? AND expires_at>? AND expires_at<?)
```