### PR TITLE
chore(devservices): Bumping the version of devservices to latest

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,5 +1,5 @@
 confluent_kafka>=2.3.0
-devservices==1.0.16
+devservices==1.0.17
 grpcio==1.66.1
 orjson>=3.10.10
 protobuf>=5.28.3


### PR DESCRIPTION
Updating devservices to 1.0.17: https://github.com/getsentry/devservices/releases/tag/1.0.17