### PR TITLE
fix(main): Change to allow passing parameters to the tokio runtime

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -86,6 +86,9 @@ pub struct Config {
 
     /// The frequency at which upkeep tasks are spawned.
     pub upkeep_task_interval_ms: u64,
+
+    /// The number of worker threads for tokio runtime. Use the tokio default if 0.
+    pub worker_threads: usize,
 }
 
 impl Default for Config {
@@ -115,6 +118,7 @@ impl Default for Config {
             max_pending_buffer_count: 128,
             max_processing_attempts: 3,
             upkeep_task_interval_ms: 1000,
+            worker_threads: 0,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,24 @@ async fn log_task_completion(name: &str, task: JoinHandle<Result<(), Error>>) {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
+    let args = Args::parse();
+    let config = Arc::new(Config::from_args(&args)?);
+
+    let mut basic = tokio::runtime::Builder::new_multi_thread();
+    let mut runtime = basic.enable_all();
+    if config.worker_threads > 0 {
+        runtime = runtime.worker_threads(config.worker_threads);
+    }
+
+    runtime
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async { runnable().await })
+}
+
+async fn runnable() -> Result<(), Error> {
     let args = Args::parse();
     let config = Arc::new(Config::from_args(&args)?);
 


### PR DESCRIPTION
Using the tokio::main macro meant that it wasn't easy to configure the runtime itself using the configuration.

Change the main to not use the macro, and add an option to set the worker threads.

There is also the TOKIO_WORKER_THREADS environment variable, but this felt like a more consistent way of configuring things.