### PR TITLE
fix(metrics): Update metrics on processing and execution times

### DIFF
--- a/src/grpc_server.rs
+++ b/src/grpc_server.rs
@@ -91,14 +91,14 @@ impl ConsumerService for MyConsumerService {
             // Record the time taken from when the task started processing to when it finished
             // Use the processing deadline to calculate the time taken
             if let Some(processing_deadline) = inflight_activation.processing_deadline {
-                let mut execution_remaining =
+                let execution_remaining =
                     processing_deadline.timestamp_millis() - Utc::now().timestamp_millis();
-                if execution_remaining < 0 {
-                    execution_remaining = 0;
-                }
-                let execution_time = (inflight_activation.activation.processing_deadline_duration
-                    * 1000)
-                    - execution_remaining as u64;
+
+                // If the task has passed the processing deadline, then execution_remaining will be negative
+                // This then gets added to the processing deadline duration to get the execution time
+                let execution_time =
+                    (inflight_activation.activation.processing_deadline_duration as i64 * 1000)
+                        - execution_remaining;
                 metrics::histogram!("task_execution.completion_time", "namespace" => inflight_activation.activation.namespace.clone(),
                     "taskname" => inflight_activation.activation.taskname.clone()).record(execution_time as f64);
             }

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -255,6 +255,8 @@ pub async fn do_upkeep(
     metrics::counter!("upkeep.discarded").increment(result_context.discarded);
     metrics::counter!("upkeep.processing_attempts_exceeded")
         .increment(result_context.processing_attempts_exceeded);
+    metrics::counter!("upkeep.processing_deadline_reset")
+        .increment(result_context.processing_deadline_reset);
     metrics::counter!("upkeep.retried").increment(result_context.retried);
     metrics::counter!("upkeep.expired").increment(result_context.expired);
 


### PR DESCRIPTION
This is related to the bugs around task processing deadlines. The metric to track task execution time was not accurate since it was ignoring the case when the processing deadline had passed.

This also tracks how often a task had its processing count incremented, not just the times the task was discarded after exceeding the increment.