### PR TITLE
feat(upkeep): Separate processing deadline attempts

### DIFF
--- a/python/integration_tests/test_upkeep_expiry.py
+++ b/python/integration_tests/test_upkeep_expiry.py
@@ -231,11 +231,11 @@ Running test with the following configuration:
         for i in range(num_messages):
             if i % 2 == 0:
                 task_activation = generate_task_activation(
-                    OnAttemptsExceeded.ON_ATTEMPTS_EXCEEDED_DISCARD, 3
+                    OnAttemptsExceeded.ON_ATTEMPTS_EXCEEDED_DISCARD, 15
                 )
             else:
                 task_activation = generate_task_activation(
-                    OnAttemptsExceeded.ON_ATTEMPTS_EXCEEDED_DEADLETTER, 3
+                    OnAttemptsExceeded.ON_ATTEMPTS_EXCEEDED_DEADLETTER, 15
                 )
             custom_messages.append(task_activation)
 

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -143,16 +143,24 @@ pub async fn do_upkeep(
     }
 
     // 4. Handle processing deadlines
-    if let Ok(counts) = store
+    if let Ok(processing_deadline_reset) = store
         .handle_processing_deadline()
         .instrument(info_span!("handle_processing_deadline"))
         .await
     {
-        result_context.processing_deadline_reset = counts.0;
-        result_context.processing_attempts_exceeded = counts.1;
+        result_context.processing_deadline_reset = processing_deadline_reset;
     }
 
-    // 5. Handle tasks that are past their expires_at deadline
+    // 5. Handle processing attempts exceeded
+    if let Ok(processing_attempts_exceeded) = store
+        .handle_processing_attempts()
+        .instrument(info_span!("handle_processing_attempts"))
+        .await
+    {
+        result_context.processing_attempts_exceeded = processing_attempts_exceeded;
+    }
+
+    // 6. Handle tasks that are past their expires_at deadline
     if let Ok(expired_count) = store
         .handle_expires_at()
         .instrument(info_span!("handle_expires_at"))
@@ -161,7 +169,7 @@ pub async fn do_upkeep(
         result_context.expired = expired_count;
     }
 
-    // 6. Handle failure state tasks
+    // 7. Handle failure state tasks
     if let Ok(failed_tasks_forwarder) = store
         .handle_failed_tasks()
         .instrument(info_span!("handle_failed_tasks"))
@@ -206,13 +214,13 @@ pub async fn do_upkeep(
             })
             .collect();
 
-        // 7. Update deadlettered tasks to complete
+        // 8. Update deadlettered tasks to complete
         if let Ok(deadletter_count) = store.mark_completed(ids).await {
             result_context.deadlettered = deadletter_count;
         }
     }
 
-    // 8. Cleanup completed tasks
+    // 9. Cleanup completed tasks
     if let Ok(count) = store
         .remove_completed()
         .instrument(info_span!("remove_completed"))


### PR DESCRIPTION
When upkeep needs to handle a large number of deadlines and discards at once, this locks up sqlite for quite a bit. As a result, this is causing a significant decrease in throughput in our sandbox testing. This PR splits out the processing attempts work out of the processing deadline call to sqlite in hopes to reduce the total time sqlite is blocked for when we see a large influx of tasks that need to be discarded after a restart.