### PR TITLE
feat: Add incremental vacuum

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,9 @@ use taskbroker::consumer::inflight_activation_batcher::{
     ActivationBatcherConfig, InflightActivationBatcher,
 };
 use taskbroker::upkeep::upkeep;
-use tokio::select;
 use tokio::signal::unix::SignalKind;
 use tokio::task::JoinHandle;
+use tokio::{select, time};
 use tonic::transport::Server;
 use tracing::{error, info};
 
@@ -88,12 +88,36 @@ async fn runnable() -> Result<(), Error> {
         .await?;
     }
 
-    // Upkeep thread
+    // Upkeep loop
     let upkeep_task = tokio::spawn({
         let upkeep_store = store.clone();
         let upkeep_config = config.clone();
         async move {
             upkeep(upkeep_config, upkeep_store).await;
+            Ok(())
+        }
+    });
+
+    // Maintenance task loop
+    let maintenance_task = tokio::spawn({
+        let guard = elegant_departure::get_shutdown_guard().shutdown_on_drop();
+        let maintenance_store = store.clone();
+        // TODO make this configurable.
+        let mut timer = time::interval(Duration::from_secs(60));
+        timer.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+        async move {
+            loop {
+                select! {
+                    _ = timer.tick() => {
+                        info!("ran maintenance vacuum");
+                        let _ = maintenance_store.vacuum_db().await;
+                    },
+                    _ = guard.wait() => {
+                        break;
+                    }
+                }
+            }
             Ok(())
         }
     });
@@ -187,6 +211,7 @@ async fn runnable() -> Result<(), Error> {
         .on_completion(log_task_completion("consumer", consumer_task))
         .on_completion(log_task_completion("grpc_server", grpc_server_task))
         .on_completion(log_task_completion("upkeep_task", upkeep_task))
+        .on_completion(log_task_completion("maintenance_task", maintenance_task))
         .await;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,8 +110,8 @@ async fn runnable() -> Result<(), Error> {
             loop {
                 select! {
                     _ = timer.tick() => {
-                        info!("ran maintenance vacuum");
                         let _ = maintenance_store.vacuum_db().await;
+                        info!("ran maintenance vacuum");
                     },
                     _ = guard.wait() => {
                         break;

--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{str::FromStr, time::Instant};
 
 use anyhow::{Error, anyhow};
 use chrono::{DateTime, Utc};
@@ -207,9 +207,11 @@ impl InflightActivationStore {
 
     /// Trigger incremental vacuum to reclaim free pages in the database.
     pub async fn vacuum_db(&self) -> Result<(), Error> {
+        let timer = Instant::now();
         sqlx::query("PRAGMA incremental_vacuum")
             .execute(&self.sqlite_pool)
             .await?;
+        metrics::histogram!("store.vacuum").record(timer.elapsed());
         Ok(())
     }
 

--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -9,8 +9,8 @@ use sqlx::{
     migrate::MigrateDatabase,
     pool::PoolOptions,
     sqlite::{
-        SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqliteQueryResult, SqliteRow,
-        SqliteSynchronous,
+        SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqliteQueryResult,
+        SqliteRow, SqliteSynchronous,
     },
 };
 
@@ -189,6 +189,7 @@ impl InflightActivationStore {
         let conn_options = SqliteConnectOptions::from_str(url)?
             .journal_mode(SqliteJournalMode::Wal)
             .synchronous(SqliteSynchronous::Normal)
+            .auto_vacuum(SqliteAutoVacuum::Incremental)
             .disable_statement_logging();
 
         let sqlite_pool = PoolOptions::<Sqlite>::new()
@@ -202,6 +203,14 @@ impl InflightActivationStore {
             sqlite_pool,
             config,
         })
+    }
+
+    /// Trigger incremental vacuum to reclaim free pages in the database.
+    pub async fn vacuum_db(&self) -> Result<(), Error> {
+        sqlx::query("PRAGMA incremental_vacuum")
+            .execute(&self.sqlite_pool)
+            .await?;
+        Ok(())
     }
 
     /// Get an activation by id. Primarily used for testing

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -75,7 +75,7 @@ impl UpkeepResults {
     }
 }
 
-#[instrument(name = "consumer::do_upkeep", skip(store, config, producer))]
+#[instrument(name = "upkeep::do_upkeep", skip(store, config, producer))]
 pub async fn do_upkeep(
     config: Arc<Config>,
     store: Arc<InflightActivationStore>,


### PR DESCRIPTION
Doing many writes/deletes to sqlite can result in a fragmented database that may be underperforming. By running sqlite's incremental_vacuum we can reclain the empty pages and compact the database and indexes.