### PR TITLE
feat(inflight-store): Add checkpointing log

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,9 @@ pub struct Config {
 
     /// The number of worker threads for tokio runtime. Use the tokio default if 0.
     pub worker_threads: usize,
+
+    /// Whether to enable the WAL checkpoint log.
+    pub enable_wal_checkpoint_log: bool,
 }
 
 impl Default for Config {
@@ -124,6 +127,7 @@ impl Default for Config {
             max_processing_attempts: 5,
             upkeep_task_interval_ms: 1000,
             worker_threads: 0,
+            enable_wal_checkpoint_log: false,
         }
     }
 }


### PR DESCRIPTION
In our sandbox testing, we are currently seeing performance issues when taskbroker is running for more than 10-15mins. I have a theory that this is due to how checkpoint is being executed. Pulling sqlite from the sandbox during the degraded state, I observed that the WAL file is almost the same size as the database file. When we explicitly call `wal_checkpoint` in passive mode, there is no guarantee that WAL is actually flushed, instead sqlite just checkpoints as many frames as possible without waiting for readers or writers to finish. At each call, we should be able to verify how many pages are written to the WAL file and how many have moved into the database. The wal_checkpoint pragma returns a single row with three integer columns that tells us this. See https://www.sqlite.org/pragma.html#pragma_wal_checkpoint.