### PR TITLE
fix(sqlite): Remove upkeep indexes

### DIFF
--- a/migrations/0001_create_inflight_taskactivations.sql
+++ b/migrations/0001_create_inflight_taskactivations.sql
@@ -15,12 +15,3 @@ CREATE TABLE IF NOT EXISTS inflight_taskactivations (
 
 CREATE INDEX idx_pending_activation
 ON inflight_taskactivations (status, added_at, namespace, id);
-
-CREATE INDEX idx_processing_deadline
-ON inflight_taskactivations (status, processing_deadline);
-
-CREATE INDEX idx_processing_attempts
-ON inflight_taskactivations (status, processing_attempts);
-
-CREATE INDEX idx_expires_at
-ON inflight_taskactivations (status, expires_at);


### PR DESCRIPTION
After testing these indexes in production, they have shown to actually slow down the throughput of the servers.

Before adding the indexes: https://app.datadoghq.com/s/FH6-Y3/4ay-hjm-jc4
After adding the indexes: https://app.datadoghq.com/s/FH6-Y3/pgc-nrd-sb2