### PR TITLE
fix(version): Put the version file in the same place as the executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN mkdir /opt/sqlite
 
 # Import the built binary and config file and run it
 COPY --from=build /taskbroker/.VERSION /opt/.VERSION
+COPY --from=build /taskbroker/.VERSION /opt/taskbroker/.VERSION
 COPY --from=build /taskbroker/config.yaml /opt/config.yaml
 COPY --from=build /taskbroker/target/release/taskbroker /opt/taskbroker
 ENTRYPOINT ["/opt/taskbroker"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,9 +16,6 @@ pub struct Config {
     /// The environment to report to sentry errors to.
     pub sentry_env: Option<Cow<'static, str>>,
 
-    /// The file that contains the current version of the application.
-    pub version_file: Option<String>,
-
     /// The sampling rate for tracing data.
     pub traces_sample_rate: Option<f32>,
 
@@ -103,7 +100,6 @@ impl Default for Config {
         Self {
             sentry_dsn: None,
             sentry_env: None,
-            version_file: None,
             traces_sample_rate: Some(0.0),
             log_filter: "debug,librdkafka=warn,h2=off".to_owned(),
             log_format: LogFormat::Text,


### PR DESCRIPTION
Instead of using a config string to locate the version (which isn't available in lib.rs) instead change the docker file to correctly put the version in the place that the executable expects.