### PR TITLE
ref(config): Remove tokio worker_threads config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -90,9 +90,6 @@ pub struct Config {
 
     /// The frequency at which upkeep tasks are spawned.
     pub upkeep_task_interval_ms: u64,
-
-    /// The number of worker threads for tokio runtime. Use the tokio default if 0.
-    pub worker_threads: usize,
 }
 
 impl Default for Config {
@@ -123,7 +120,6 @@ impl Default for Config {
             max_pending_buffer_count: 128,
             max_processing_attempts: 5,
             upkeep_task_interval_ms: 1000,
-            worker_threads: 0,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,30 +46,13 @@ async fn log_task_completion(name: &str, task: JoinHandle<Result<(), Error>>) {
     }
 }
 
-fn main() -> Result<(), Error> {
+#[tokio::main]
+async fn main() -> Result<(), Error> {
     let args = Args::parse();
     let config = Arc::new(Config::from_args(&args)?);
 
     println!("taskbroker starting");
     println!("version: {}", get_version().trim());
-
-    let mut basic = tokio::runtime::Builder::new_multi_thread();
-    let mut runtime = basic.enable_all();
-    if config.worker_threads > 0 {
-        println!("Starting with {:?} threads", config.worker_threads);
-        runtime = runtime.worker_threads(config.worker_threads);
-    }
-
-    runtime
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(async { runnable().await })
-}
-
-async fn runnable() -> Result<(), Error> {
-    let args = Args::parse();
-    let config = Arc::new(Config::from_args(&args)?);
 
     logging::init(logging::LoggingConfig::from_config(&config));
     metrics::init(metrics::MetricsConfig::from_config(&config));


### PR DESCRIPTION
Removes the config that allows us to specify how many tokio workers we would like, as it does not change our throughput