### PR TITLE
fix: Fix broken SSL in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN cargo build --release
 RUN echo "${TASKWORKER_GIT_REVISION}" > ./VERSION
 
 # Runtime image
-FROM debian:bookworm-slim
+FROM rust:1-bookworm
 
 # Necessary for libssl bindings
 RUN apt-get update && apt-get upgrade -y && apt-get install -y libssl-dev


### PR DESCRIPTION
- Use the same operating system base image.
- Install all of openssl in the runtime image.