### PR TITLE
fix: Rename variables used to build images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ COPY ./config/${config_file} ./config.yaml
 COPY ./benches ./benches
 
 # This is set by the cloudbuild.yaml file
-ARG TASKWORKER_GIT_REVISION=""
-ENV TASKWORKER_GIT_REVISION=${TASKWORKER_GIT_REVISION}
+ARG TASKBROKER_GIT_REVISION=""
+ENV TASKBROKER_GIT_REVISION=${TASKBROKER_GIT_REVISION}
 
 # Build dependencies in a way they can be cached
 RUN cargo build --release
@@ -33,7 +33,7 @@ COPY ./src ./src
 RUN rm ./target/release/deps/taskbroker*
 RUN cargo build --release
 
-RUN echo "${TASKWORKER_GIT_REVISION}" > ./VERSION
+RUN echo "${TASKBROKER_GIT_REVISION}" > ./VERSION
 
 # Runtime image
 FROM rust:1-bookworm

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
         "--cache=true",
         "--use-new-run",
         "--build-arg",
-        "TASKWORKER_GIT_REVISION=$COMMIT_SHA",
+        "TASKBROKER_GIT_REVISION=$COMMIT_SHA",
         "--destination=us-central1-docker.pkg.dev/$PROJECT_ID/taskbroker/image:$COMMIT_SHA",
         "-f",
         "./Dockerfile",


### PR DESCRIPTION
Rename these values as they were using the old project name.