### PR TITLE
ref(kafka): allow consumer to repoll reducers more frequently

### DIFF
--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -570,7 +570,7 @@ pub async fn reduce<T, U>(
 ) -> Result<(), Error> {
     let config = reducer.get_reduce_config();
     let mut flush_timer = config.flush_interval.map(time::interval);
-    let mut repoll_timer = time::interval(Duration::from_secs(1));
+    let mut repoll_timer = time::interval(Duration::from_millis(250));
     repoll_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let mut inflight_msgs = Vec::new();
 


### PR DESCRIPTION
The consumers reduce loop has a check to see whether or not a reducer can insert messages or be flushed. If it's not able to do either, it will wait for a set amount of time before checking again (1s). This PR lowers that time to 250ms, as we are seeing the sqlite database becoming empty.