### PR TITLE
feat(killswitch): Drop task due to killswitch in batcher

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,8 @@ async fn log_task_completion(name: &str, task: JoinHandle<Result<(), Error>>) {
 async fn main() -> Result<(), Error> {
     let args = Args::parse();
     let config = Arc::new(Config::from_args(&args)?);
-    let _ = Arc::new(RuntimeConfigManager::new(config.runtime_config_path.clone()).await);
+    let runtime_config_manager =
+        Arc::new(RuntimeConfigManager::new(config.runtime_config_path.clone()).await);
 
     println!("taskbroker starting");
     println!("version: {}", get_version().trim());
@@ -127,7 +128,8 @@ async fn main() -> Result<(), Error> {
 
                     reduce:
                         InflightActivationBatcher::new(
-                            ActivationBatcherConfig::from_config(&consumer_config)
+                            ActivationBatcherConfig::from_config(&consumer_config),
+                            runtime_config_manager.clone()
                         )
                         => InflightActivationWriter::new(
                             consumer_store.clone(),


### PR DESCRIPTION
This is simpler implementation of dropping tasks without the processing strategy change described in: https://github.com/getsentry/taskbroker/pull/258. Instead, this change is made on the reduce step specifically in the `InflightActivationBatcher`. If the task name is found in the runtime config, then do not push into the buffer and emit a metric. 