### PR TITLE
feat: Allow fetching multiple tasks at once

### DIFF
--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -25,11 +25,8 @@ impl ConsumerService for TaskbrokerServer {
         request: Request<GetTaskRequest>,
     ) -> Result<Response<GetTaskResponse>, Status> {
         let start_time = Instant::now();
-        let namespace = &request.get_ref().namespace;
-        let inflight = self
-            .store
-            .get_pending_activation(namespace.as_deref())
-            .await;
+        let namespace = request.get_ref().namespace.as_deref();
+        let inflight = self.store.get_pending_activation(namespace).await;
 
         match inflight {
             Ok(Some(inflight)) => {
@@ -123,7 +120,6 @@ impl ConsumerService for TaskbrokerServer {
         };
 
         let start_time = Instant::now();
-
         let res = match self
             .store
             .get_pending_activation(namespace.as_deref())

--- a/src/grpc/server_tests.rs
+++ b/src/grpc/server_tests.rs
@@ -92,7 +92,9 @@ async fn test_set_task_status_success() {
     let request = SetTaskStatusRequest {
         id: "id_0".to_string(),
         status: 5, // Complete
-        fetch_next_task: Some(FetchNextTask { namespace: None }),
+        fetch_next_task: Some(FetchNextTask {
+            namespace: Some("namespace".to_string()),
+        }),
     };
     let response = service.set_task_status(Request::new(request)).await;
     assert!(response.is_ok());

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -49,7 +49,7 @@ pub fn make_activations(count: u32) -> Vec<InflightActivation> {
             status: InflightActivationStatus::Pending,
             partition: 0,
             offset: i as i64,
-            added_at: Utc::now(),
+            added_at: Utc::now() + chrono::Duration::seconds(i as i64),
             processing_attempts: 0,
             expires_at: None,
             processing_deadline: None,


### PR DESCRIPTION
Change the store to allow fetching multiple pending tasks at once. This is the first step towards being able to batch fetch tasks from the worker.

This adds a `get_pending_activations` function, and points the existing function to call that function with a limit of 1. In the future new endpoints can leverage the pending activations function directly. That function accepts the namespaces that are being requested, and the number of pending tasks that can be returned.