### PR TITLE
chore: Rename team in codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,1 @@
-* @getsentry/taskworker
-
-src/         @getsentry/taskworker
-migrations/  @getsentry/taskworker
+* @getsentry/taskbroker


### PR DESCRIPTION
Refs getsentry/security-as-code#1329