### PR TITLE
chore(devservices): Bump devservices to 1.0.18

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,5 +1,5 @@
 confluent_kafka>=2.3.0
-devservices==1.0.17
+devservices==1.0.18
 grpcio==1.66.1
 orjson>=3.10.10
 protobuf>=5.28.3


### PR DESCRIPTION
This picks up better observability in sentry for CI runs that use devservices and adds additional information on what devservices is doing behind the scenes for `devservices up`

https://github.com/getsentry/devservices/releases/tag/1.0.18