### PR TITLE
feat: Start gocd pipeline for taskbroker

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[env]
+# Workaround for https://github.com/confluentinc/librdkafka/pull/5012
+CMAKE_POLICY_VERSION_MINIMUM = "3.10"

--- a/gocd/templates/bash/check-cloudbuild.sh
+++ b/gocd/templates/bash/check-cloudbuild.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
+	"${GO_REVISION_TASKBROKER_REPO}" \
+	"sentryio" \
+	"us-central1-docker.pkg.dev/sentryio/taskbroker/image"

--- a/gocd/templates/bash/check-github-runs.sh
+++ b/gocd/templates/bash/check-github-runs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/devinfra/scripts/checks/githubactions/checkruns.py \
+	"getsentry/taskbroker" \
+	"${GO_REVISION_TASKBROKER_REPO}" \
+    "Tests (ubuntu)"

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+/devinfra/scripts/k8s/k8stunnel &&
+	/devinfra/scripts/k8s/k8s-deploy.py \
+		--label-selector="${LABEL_SELECTOR}" \
+		--image="us-central1-docker.pkg.dev/sentryio/taskbroker/image:${GO_REVISION_TASKBROKER_REPO}" \
+		--container-name="taskbroker"

--- a/gocd/templates/bash/wait-canary.sh
+++ b/gocd/templates/bash/wait-canary.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sleep 300

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "libs"
+        }
+      },
+      "version": "v2.10.0"
+    }
+  ],
+  "legacyImports": true
+}

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "libs"
+        }
+      },
+      "version": "74ae5728e2d7ed39fdd43cf3b2d28dde7e4567a1",
+      "sum": "AKMGYALLyaVVVjTNnZy64PoCDA8QjxTbHBe5dCnE4tE="
+    }
+  ],
+  "legacyImports": false
+}

--- a/gocd/templates/pipelines/taskbroker.libsonnet
+++ b/gocd/templates/pipelines/taskbroker.libsonnet
@@ -1,0 +1,78 @@
+local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libsonnet';
+
+local checks_stage = {
+  checks: {
+    fetch_materials: true,
+    jobs: {
+      checks: {
+        timeout: 1200,
+        elastic_profile_id: 'taskbroker',
+        environment_variables: {
+          GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+        },
+        tasks: [
+          gocdtasks.script(importstr '../bash/check-github-runs.sh'),
+          gocdtasks.script(importstr '../bash/check-cloudbuild.sh'),
+        ],
+      },
+    },
+  },
+};
+
+local deploy_canary_stage(region) =
+  if region == 'us' then
+    [
+      {
+        'deploy-canary': {
+          fetch_materials: true,
+          jobs: {
+            deploy: {
+              timeout: 600,
+              elastic_profile_id: 'taskbroker',
+              environment_variables: {
+                LABEL_SELECTOR: 'service=taskbroker,env=canary',
+              },
+              tasks: [
+                gocdtasks.script(importstr '../bash/deploy.sh'),
+                gocdtasks.script(importstr '../bash/wait-canary.sh'),
+              ],
+            },
+          },
+        },
+      },
+    ] else [];
+
+local deployPrimaryStage = {
+  'deploy-primary': {
+    fetch_materials: true,
+    jobs: {
+      deploy: {
+        timeout: 600,
+        elastic_profile_id: 'taskbroker',
+        environment_variables: {
+          LABEL_SELECTOR: 'service=taskbroker',
+        },
+        tasks: [
+          gocdtasks.script(importstr '../bash/deploy.sh'),
+        ],
+      },
+    },
+  },
+};
+
+function(region) {
+  environment_variables: {
+    // SENTRY_REGION is used by the dev-infra scripts to connect to GKE
+    SENTRY_REGION: region,
+  },
+  materials: {
+    taskbroker_repo: {
+      git: 'git@github.com:getsentry/taskbroker.git',
+      shallow_clone: true,
+      branch: 'main',
+      destination: 'taskbroker',
+    },
+  },
+  lock_behavior: 'unlockWhenFinished',
+  stages: [checks_stage] + deploy_canary_stage(region) + [deployPrimaryStage],
+}

--- a/gocd/templates/pipelines/taskbroker.libsonnet
+++ b/gocd/templates/pipelines/taskbroker.libsonnet
@@ -5,7 +5,7 @@ local checks_stage = {
     fetch_materials: true,
     jobs: {
       checks: {
-        timeout: 1200,
+        timeout: 20,
         elastic_profile_id: 'taskbroker',
         environment_variables: {
           GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
@@ -27,7 +27,7 @@ local deploy_canary_stage(region) =
           fetch_materials: true,
           jobs: {
             deploy: {
-              timeout: 600,
+              timeout: 30,
               elastic_profile_id: 'taskbroker',
               environment_variables: {
                 LABEL_SELECTOR: 'service=taskbroker,env=canary',
@@ -47,7 +47,7 @@ local deployPrimaryStage = {
     fetch_materials: true,
     jobs: {
       deploy: {
-        timeout: 600,
+        timeout: 30,
         elastic_profile_id: 'taskbroker',
         environment_variables: {
           LABEL_SELECTOR: 'service=taskbroker',

--- a/gocd/templates/taskbroker.jsonnet
+++ b/gocd/templates/taskbroker.jsonnet
@@ -19,7 +19,7 @@ local pipedream_config = {
     stage: 'deploy-primary',
     elastic_profile_id: 'taskbroker',
   },
-  exclude_regions: ['de', 'us', 'control', 'customer-1', 'customer-2', 'customer-3', 'customer-4', 'customer-6', 'customer-7'],
+  include_regions: ['s4s'],
 };
 
 pipedream.render(pipedream_config, taskbroker)

--- a/gocd/templates/taskbroker.jsonnet
+++ b/gocd/templates/taskbroker.jsonnet
@@ -1,0 +1,25 @@
+local taskbroker = import './pipelines/taskbroker.libsonnet';
+local pipedream = import 'github.com/getsentry/gocd-jsonnet/libs/pipedream.libsonnet';
+
+// Pipedream can be configured using this object, you can learn more about the
+// configuration options here: https://github.com/getsentry/gocd-jsonnet#readme
+local pipedream_config = {
+  name: 'taskbroker',
+  auto_deploy: true,
+  materials: {
+    taskbroker_repo: {
+      git: 'git@github.com:getsentry/taskbroker.git',
+      shallow_clone: true,
+      branch: 'main',
+      destination: 'taskbroker',
+    },
+  },
+  rollback: {
+    material_name: 'taskbroker_repo',
+    stage: 'deploy-primary',
+    elastic_profile_id: 'taskbroker',
+  },
+  exclude_regions: ['de', 'us', 'control', 'customer-1', 'customer-2', 'customer-3', 'customer-4', 'customer-6', 'customer-7'],
+};
+
+pipedream.render(pipedream_config, taskbroker)

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -360,7 +360,7 @@ pub async fn handle_events(
 
     let mut state = ConsumerState::Ready;
 
-    while let ConsumerState::Ready { .. } | ConsumerState::Consuming { .. } = state {
+    while let ConsumerState::Ready | ConsumerState::Consuming { .. } = state {
         select! {
             res = match state {
                 ConsumerState::Consuming(ref mut handles, _) => Either::Left(handles.join_next()),


### PR DESCRIPTION
- Create a basic pipeline with canary support.
- Wait 5 min between canary and full deploy.
- Use the `service` and `env` labels for deployment like we do for other applications.
- Initially only s4s will be deployed to.

Refs #209