### PR TITLE
ref(config): Rename and increase write batch size

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -75,16 +75,16 @@ pub struct Config {
     /// The path to the sqlite database
     pub db_path: String,
 
+    /// The maximum number of tasks that are buffered
+    /// before being written to InflightTaskStore (sqlite).
+    pub db_insert_batch_size: usize,
+
     /// The path to the runtime config file
     pub runtime_config_path: Option<String>,
 
     /// The maximum number of pending records that can be
     /// in the InflightTaskStore (sqlite)
     pub max_pending_count: usize,
-
-    /// The maximum number of tasks that are buffered
-    /// before being written to InflightTaskStore (sqlite).
-    pub max_pending_buffer_count: usize,
 
     /// The maximum number of times a task can be reset from
     /// processing back to pending. When this limit is reached,
@@ -119,9 +119,9 @@ impl Default for Config {
             kafka_auto_offset_reset: "latest".to_owned(),
             kafka_send_timeout_ms: 500,
             db_path: "./taskbroker-inflight.sqlite".to_owned(),
+            db_insert_batch_size: 1024,
             runtime_config_path: None,
             max_pending_count: 2048,
-            max_pending_buffer_count: 128,
             max_processing_attempts: 5,
             upkeep_task_interval_ms: 1000,
         }

--- a/src/kafka/inflight_activation_batcher.rs
+++ b/src/kafka/inflight_activation_batcher.rs
@@ -18,7 +18,7 @@ impl ActivationBatcherConfig {
     /// Convert from application configuration into ActivationBatcher config.
     pub fn from_config(config: &Config) -> Self {
         Self {
-            max_buf_len: config.max_pending_buffer_count,
+            max_buf_len: config.db_insert_batch_size,
         }
     }
 }

--- a/src/kafka/inflight_activation_writer.rs
+++ b/src/kafka/inflight_activation_writer.rs
@@ -23,7 +23,7 @@ impl ActivationWriterConfig {
     /// Convert from application configuration into InflightActivationWriter config.
     pub fn from_config(config: &Config) -> Self {
         Self {
-            max_buf_len: config.max_pending_buffer_count,
+            max_buf_len: config.db_insert_batch_size,
             max_pending_activations: config.max_pending_count,
         }
     }


### PR DESCRIPTION
Increase our db batch size to be 1024 from 128, since this is shown to have optimal performance. Also rename it from `pending_buffer_count` to `db_insert_batch_size` to make it consistent with other consumer terminologies