### PR TITLE
ref(docker): Stop using config files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install cmake
+        uses: lukka/get-cmake@latest
+
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -59,6 +62,9 @@ jobs:
         run: |
           devservices up
 
+      - name: Install cmake
+        uses: lukka/get-cmake@latest
+
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -94,6 +100,9 @@ jobs:
         with:
           tool: cargo-llvm-cov
 
+      - name: Install cmake
+        uses: lukka/get-cmake@latest
+
       - name: Install protoc
         uses: arduino/setup-protoc@v3
 
@@ -123,6 +132,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install cmake
+        uses: lukka/get-cmake@latest
+
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -149,6 +161,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install cmake
+        uses: lukka/get-cmake@latest
+
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -167,13 +182,16 @@ jobs:
       - name: Run worker processing integration test
         run: |
           make test-worker-processing
-  
+
   upkeep-retry-integration-test:
     name: Upkeep retry integration test
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install cmake
+        uses: lukka/get-cmake@latest
 
       - name: Install protoc
         uses: arduino/setup-protoc@v3
@@ -193,13 +211,16 @@ jobs:
       - name: Run upkeep retry integration test
         run: |
           make test-upkeep-retry
-  
+
   upkeep-expiry-integration-test:
     name: Upkeep expiry integration test
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install cmake
+        uses: lukka/get-cmake@latest
 
       - name: Install protoc
         uses: arduino/setup-protoc@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ ENV TASKBROKER_VERSION=$TASKBROKER_GIT_REVISION
 COPY ./Cargo.lock ./Cargo.lock
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./migrations ./migrations
-COPY ./config/${CONFIG_FILE} ./config.yaml
 COPY ./benches ./benches
 
 # Build dependencies in a way they can be cached
@@ -48,12 +47,11 @@ RUN mkdir /opt/sqlite
 
 # Import the built binary and config file and run it
 COPY --from=build /taskbroker/VERSION /opt/VERSION
-COPY --from=build /taskbroker/config.yaml /opt/config.yaml
 COPY --from=build /taskbroker/target/release/taskbroker /opt/taskbroker
 
 WORKDIR /opt
 
-CMD ["/opt/taskbroker", "--config", "/opt/config.yaml"]
+CMD ["/opt/taskbroker"]
 
 # To build and run locally:
 # docker build -t taskbroker --no-cache . && docker rm taskbroker && docker run --name taskbroker -p 127.0.0.1:50051:50051 -e TASKBROKER_KAFKA_CLUSTER=sentry_kafka:9093 --network sentry  taskbroker

--- a/config/config-dev.yaml
+++ b/config/config-dev.yaml
@@ -1,2 +1,0 @@
-upkeep_task_interval_ms: 2000
-create_missing_topics: true

--- a/config/config-sentry-dev.yaml
+++ b/config/config-sentry-dev.yaml
@@ -1,3 +1,0 @@
-upkeep_task_interval_ms: 2000
-kafka_cluster: 127.0.0.1:9092
-create_missing_topics: true


### PR DESCRIPTION
Using a config file instead of the default config specified in code is a bit of a footgun.