### PR TITLE
feat(reduce): Backpressure when delay task limit reached

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,10 @@ pub struct Config {
     /// in the InflightTaskStore (sqlite)
     pub max_pending_count: usize,
 
+    /// The maximum number of delay records that can be
+    /// in the InflightTaskStore (sqlite)
+    pub max_delay_count: usize,
+
     /// The maximum number of times a task can be reset from
     /// processing back to pending. When this limit is reached,
     /// the activation will be discarded/deadlettered.
@@ -136,6 +140,7 @@ impl Default for Config {
             db_insert_batch_size: 1024,
             runtime_config_path: None,
             max_pending_count: 2048,
+            max_delay_count: 8192,
             max_processing_attempts: 5,
             upkeep_task_interval_ms: 1000,
             maintenance_task_interval_ms: 6000,

--- a/src/kafka/inflight_activation_writer.rs
+++ b/src/kafka/inflight_activation_writer.rs
@@ -94,11 +94,10 @@ impl Reducer for InflightActivationWriter {
         // 2. The batch exceeds the pending limit, does not exceed delay limit, and is entirely delay
         // 3. The batch exceeds the delay limit, does not exceed pending limit, and is entirely pending
         // Otherwise, emit backpressure.
-        if exceeded_pending_limit && exceeded_delay_limit {
-            return Ok(None);
-        } else if exceeded_delay_limit && !exceeded_pending_limit && !entire_batch_is_pending {
-            return Ok(None);
-        } else if exceeded_pending_limit && !exceeded_delay_limit && !entire_batch_is_delay {
+        if (exceeded_pending_limit && exceeded_delay_limit)
+            || (exceeded_delay_limit && !exceeded_pending_limit && !entire_batch_is_pending)
+            || (exceeded_pending_limit && !exceeded_delay_limit && !entire_batch_is_delay)
+        {
             return Ok(None);
         }
 

--- a/src/kafka/inflight_activation_writer.rs
+++ b/src/kafka/inflight_activation_writer.rs
@@ -66,25 +66,39 @@ impl Reducer for InflightActivationWriter {
             return Ok(None);
         };
 
-        if self
+        // Check if writing the batch would exceed the limits
+        let exceeded_pending_limit = self
             .store
             .count_pending_activations()
             .await
             .expect("Error communicating with activation store")
             + batch.len()
-            > self.config.max_pending_activations
-        {
-            return Ok(None);
-        }
-
-        if self
+            > self.config.max_pending_activations;
+        let exceeded_delay_limit = self
             .store
             .count_by_status(InflightActivationStatus::Delay)
             .await
             .expect("Error communicating with activation store")
             + batch.len()
-            > self.config.max_delay_activations
-        {
+            > self.config.max_delay_activations;
+        // Check if the entire batch is either pending or delay
+        let entire_batch_is_pending = batch
+            .iter()
+            .all(|activation| activation.status == InflightActivationStatus::Pending);
+        let entire_batch_is_delay = batch
+            .iter()
+            .all(|activation| activation.status == InflightActivationStatus::Delay);
+
+        // We want to allow the batch to be inserted if:
+        // 1. The batch does not exceed both the pending and delay limits
+        // 2. The batch exceeds the pending limit, does not exceed delay limit, and is entirely delay
+        // 3. The batch exceeds the delay limit, does not exceed pending limit, and is entirely pending
+        // Otherwise, emit backpressure.
+        if exceeded_pending_limit && exceeded_delay_limit {
+            return Ok(None);
+        } else if exceeded_delay_limit && !exceeded_pending_limit && !entire_batch_is_pending {
+            return Ok(None);
+        } else if exceeded_pending_limit && !exceeded_delay_limit && !entire_batch_is_delay {
             return Ok(None);
         }
 
@@ -129,5 +143,393 @@ impl Reducer for InflightActivationWriter {
             shutdown_condition: ReduceShutdownCondition::Signal,
             flush_interval: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ActivationWriterConfig, InflightActivation, InflightActivationWriter, Reducer};
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    use sentry_protos::taskbroker::v1::TaskActivation;
+    use std::sync::Arc;
+
+    use crate::store::inflight_activation::{
+        InflightActivationStatus, InflightActivationStore, InflightActivationStoreConfig,
+    };
+    use crate::test_utils::{create_integration_config, generate_temp_filename};
+
+    #[tokio::test]
+    async fn test_writer_flush_batch() {
+        let writer_config = ActivationWriterConfig {
+            max_buf_len: 100,
+            max_pending_activations: 10,
+            max_delay_activations: 10,
+        };
+        let mut writer = InflightActivationWriter::new(
+            Arc::new(
+                InflightActivationStore::new(
+                    &generate_temp_filename(),
+                    InflightActivationStoreConfig::from_config(&create_integration_config()),
+                )
+                .await
+                .unwrap(),
+            ),
+            writer_config,
+        );
+
+        let batch = vec![
+            InflightActivation {
+                activation: TaskActivation {
+                    id: "0".to_string(),
+                    namespace: "namespace".to_string(),
+                    taskname: "pending_task".to_string(),
+                    parameters: "{}".to_string(),
+                    headers: HashMap::new(),
+                    received_at: Some(prost_types::Timestamp {
+                        seconds: 0,
+                        nanos: 0,
+                    }),
+                    retry_state: None,
+                    processing_deadline_duration: 0,
+                    expires: None,
+                    delay: None,
+                },
+                status: InflightActivationStatus::Pending,
+                partition: 0,
+                offset: 0,
+                added_at: Utc::now(),
+                processing_attempts: 0,
+                expires_at: None,
+                delay_until: None,
+                processing_deadline: None,
+                at_most_once: false,
+                namespace: "namespace".to_string(),
+            },
+            InflightActivation {
+                activation: TaskActivation {
+                    id: "1".to_string(),
+                    namespace: "namespace".to_string(),
+                    taskname: "delay_task".to_string(),
+                    parameters: "{}".to_string(),
+                    headers: HashMap::new(),
+                    received_at: Some(prost_types::Timestamp {
+                        seconds: 0,
+                        nanos: 0,
+                    }),
+                    retry_state: None,
+                    processing_deadline_duration: 0,
+                    expires: None,
+                    delay: None,
+                },
+                status: InflightActivationStatus::Delay,
+                partition: 0,
+                offset: 0,
+                added_at: Utc::now(),
+                processing_attempts: 0,
+                expires_at: None,
+                delay_until: None,
+                processing_deadline: None,
+                at_most_once: false,
+                namespace: "namespace".to_string(),
+            },
+        ];
+
+        writer.reduce(batch).await.unwrap();
+        writer.flush().await.unwrap();
+        let count_pending = writer.store.count_pending_activations().await.unwrap();
+        let count_delay = writer
+            .store
+            .count_by_status(InflightActivationStatus::Delay)
+            .await
+            .unwrap();
+        assert_eq!(count_pending + count_delay, 2);
+    }
+
+    #[tokio::test]
+    async fn test_writer_flush_only_pending() {
+        let writer_config = ActivationWriterConfig {
+            max_buf_len: 100,
+            max_pending_activations: 10,
+            max_delay_activations: 0,
+        };
+        let mut writer = InflightActivationWriter::new(
+            Arc::new(
+                InflightActivationStore::new(
+                    &generate_temp_filename(),
+                    InflightActivationStoreConfig::from_config(&create_integration_config()),
+                )
+                .await
+                .unwrap(),
+            ),
+            writer_config,
+        );
+
+        let batch = vec![InflightActivation {
+            activation: TaskActivation {
+                id: "0".to_string(),
+                namespace: "namespace".to_string(),
+                taskname: "pending_task".to_string(),
+                parameters: "{}".to_string(),
+                headers: HashMap::new(),
+                received_at: Some(prost_types::Timestamp {
+                    seconds: 0,
+                    nanos: 0,
+                }),
+                retry_state: None,
+                processing_deadline_duration: 0,
+                expires: None,
+                delay: None,
+            },
+            status: InflightActivationStatus::Pending,
+            partition: 0,
+            offset: 0,
+            added_at: Utc::now(),
+            processing_attempts: 0,
+            expires_at: None,
+            delay_until: None,
+            processing_deadline: None,
+            at_most_once: false,
+            namespace: "namespace".to_string(),
+        }];
+
+        writer.reduce(batch).await.unwrap();
+        writer.flush().await.unwrap();
+        let count_pending = writer.store.count_pending_activations().await.unwrap();
+        assert_eq!(count_pending, 1);
+    }
+
+    #[tokio::test]
+    async fn test_writer_flush_only_delay() {
+        let writer_config = ActivationWriterConfig {
+            max_buf_len: 100,
+            max_pending_activations: 0,
+            max_delay_activations: 10,
+        };
+        let mut writer = InflightActivationWriter::new(
+            Arc::new(
+                InflightActivationStore::new(
+                    &generate_temp_filename(),
+                    InflightActivationStoreConfig::from_config(&create_integration_config()),
+                )
+                .await
+                .unwrap(),
+            ),
+            writer_config,
+        );
+
+        let batch = vec![InflightActivation {
+            activation: TaskActivation {
+                id: "0".to_string(),
+                namespace: "namespace".to_string(),
+                taskname: "pending_task".to_string(),
+                parameters: "{}".to_string(),
+                headers: HashMap::new(),
+                received_at: Some(prost_types::Timestamp {
+                    seconds: 0,
+                    nanos: 0,
+                }),
+                retry_state: None,
+                processing_deadline_duration: 0,
+                expires: None,
+                delay: None,
+            },
+            status: InflightActivationStatus::Delay,
+            partition: 0,
+            offset: 0,
+            added_at: Utc::now(),
+            processing_attempts: 0,
+            expires_at: None,
+            delay_until: None,
+            processing_deadline: None,
+            at_most_once: false,
+            namespace: "namespace".to_string(),
+        }];
+
+        writer.reduce(batch).await.unwrap();
+        writer.flush().await.unwrap();
+        let count_delay = writer
+            .store
+            .count_by_status(InflightActivationStatus::Delay)
+            .await
+            .unwrap();
+        assert_eq!(count_delay, 1);
+    }
+
+    #[tokio::test]
+    async fn test_writer_backpressure() {
+        let writer_config = ActivationWriterConfig {
+            max_buf_len: 100,
+            max_pending_activations: 0,
+            max_delay_activations: 0,
+        };
+        let mut writer = InflightActivationWriter::new(
+            Arc::new(
+                InflightActivationStore::new(
+                    &generate_temp_filename(),
+                    InflightActivationStoreConfig::from_config(&create_integration_config()),
+                )
+                .await
+                .unwrap(),
+            ),
+            writer_config,
+        );
+
+        let batch = vec![
+            InflightActivation {
+                activation: TaskActivation {
+                    id: "0".to_string(),
+                    namespace: "namespace".to_string(),
+                    taskname: "pending_task".to_string(),
+                    parameters: "{}".to_string(),
+                    headers: HashMap::new(),
+                    received_at: Some(prost_types::Timestamp {
+                        seconds: 0,
+                        nanos: 0,
+                    }),
+                    retry_state: None,
+                    processing_deadline_duration: 0,
+                    expires: None,
+                    delay: None,
+                },
+                status: InflightActivationStatus::Pending,
+                partition: 0,
+                offset: 0,
+                added_at: Utc::now(),
+                processing_attempts: 0,
+                expires_at: None,
+                delay_until: None,
+                processing_deadline: None,
+                at_most_once: false,
+                namespace: "namespace".to_string(),
+            },
+            InflightActivation {
+                activation: TaskActivation {
+                    id: "1".to_string(),
+                    namespace: "namespace".to_string(),
+                    taskname: "delay_task".to_string(),
+                    parameters: "{}".to_string(),
+                    headers: HashMap::new(),
+                    received_at: Some(prost_types::Timestamp {
+                        seconds: 0,
+                        nanos: 0,
+                    }),
+                    retry_state: None,
+                    processing_deadline_duration: 0,
+                    expires: None,
+                    delay: None,
+                },
+                status: InflightActivationStatus::Delay,
+                partition: 0,
+                offset: 0,
+                added_at: Utc::now(),
+                processing_attempts: 0,
+                expires_at: None,
+                delay_until: None,
+                processing_deadline: None,
+                at_most_once: false,
+                namespace: "namespace".to_string(),
+            },
+        ];
+
+        writer.reduce(batch).await.unwrap();
+        writer.flush().await.unwrap();
+        let count_pending = writer.store.count_pending_activations().await.unwrap();
+        assert_eq!(count_pending, 0);
+        let count_delay = writer
+            .store
+            .count_by_status(InflightActivationStatus::Delay)
+            .await
+            .unwrap();
+        assert_eq!(count_delay, 0);
+    }
+
+    #[tokio::test]
+    async fn test_writer_backpressure_only_delay_limit_reached_and_entire_batch_is_pending() {
+        let writer_config = ActivationWriterConfig {
+            max_buf_len: 100,
+            max_pending_activations: 10,
+            max_delay_activations: 0,
+        };
+        let mut writer = InflightActivationWriter::new(
+            Arc::new(
+                InflightActivationStore::new(
+                    &generate_temp_filename(),
+                    InflightActivationStoreConfig::from_config(&create_integration_config()),
+                )
+                .await
+                .unwrap(),
+            ),
+            writer_config,
+        );
+
+        let batch = vec![
+            InflightActivation {
+                activation: TaskActivation {
+                    id: "0".to_string(),
+                    namespace: "namespace".to_string(),
+                    taskname: "pending_task".to_string(),
+                    parameters: "{}".to_string(),
+                    headers: HashMap::new(),
+                    received_at: Some(prost_types::Timestamp {
+                        seconds: 0,
+                        nanos: 0,
+                    }),
+                    retry_state: None,
+                    processing_deadline_duration: 0,
+                    expires: None,
+                    delay: None,
+                },
+                status: InflightActivationStatus::Pending,
+                partition: 0,
+                offset: 0,
+                added_at: Utc::now(),
+                processing_attempts: 0,
+                expires_at: None,
+                delay_until: None,
+                processing_deadline: None,
+                at_most_once: false,
+                namespace: "namespace".to_string(),
+            },
+            InflightActivation {
+                activation: TaskActivation {
+                    id: "1".to_string(),
+                    namespace: "namespace".to_string(),
+                    taskname: "pending_task".to_string(),
+                    parameters: "{}".to_string(),
+                    headers: HashMap::new(),
+                    received_at: Some(prost_types::Timestamp {
+                        seconds: 0,
+                        nanos: 0,
+                    }),
+                    retry_state: None,
+                    processing_deadline_duration: 0,
+                    expires: None,
+                    delay: None,
+                },
+                status: InflightActivationStatus::Pending,
+                partition: 0,
+                offset: 0,
+                added_at: Utc::now(),
+                processing_attempts: 0,
+                expires_at: None,
+                delay_until: None,
+                processing_deadline: None,
+                at_most_once: false,
+                namespace: "namespace".to_string(),
+            },
+        ];
+
+        writer.reduce(batch).await.unwrap();
+        writer.flush().await.unwrap();
+        let count_pending = writer.store.count_pending_activations().await.unwrap();
+        assert_eq!(count_pending, 2);
+        let count_delay = writer
+            .store
+            .count_by_status(InflightActivationStatus::Delay)
+            .await
+            .unwrap();
+        assert_eq!(count_delay, 0);
     }
 }

--- a/src/kafka/inflight_activation_writer.rs
+++ b/src/kafka/inflight_activation_writer.rs
@@ -95,9 +95,9 @@ impl Reducer for InflightActivationWriter {
         // 2. The batch exceeds the pending limit, does not exceed delay limit, and is entirely delay
         // 3. The batch exceeds the delay limit, does not exceed pending limit, and is entirely pending
         // Otherwise, emit backpressure.
-        if (exceeded_pending_limit && exceeded_delay_limit)
-            || (exceeded_delay_limit && !exceeded_pending_limit && has_delay)
-            || (exceeded_pending_limit && !exceeded_delay_limit && has_pending)
+        if exceeded_pending_limit && exceeded_delay_limit
+            || exceeded_delay_limit && has_delay
+            || exceeded_pending_limit && has_pending
         {
             return Ok(None);
         }


### PR DESCRIPTION
### Overview
Currently, if a very large influx of delayed tasks are produced to kafka, there is nothing stopping from the sqlite from growing unboundedly and running out of disk. This PR is responsible for adding a upper limit to the number of delayed tasks that can be stored in sqlite at a given moment. If an incoming batch exceeds this number, then the reduce step will stop receiving messages in its buffer, which bubbles up the pipeline and stops the consumer from reading more messages from kafka.

This has a few implications:
- Since we write in batches, we do not distinguish between delayed tasks and regular tasks at the reduce step.
- Therefore, if the incoming batch causes either the `max_pending_count` or `max_delay_count` to exceed, then emit backpressure. This means that either of these limits can halt ingestion despite the other limit not being reached.
- We should be careful with `max_delay_count`. Even though we have ample disk available, there can be scenarios where a bunch (or all) delayed tasks moved to pending at once. If `max_delay_count` is set to high, this would cause a large amount of task to move to the pending state which will halt ingestion until all pending tasks are burned below 2048 (our current default). I've set this default to `8192` for now.


Other change:
- Added a `upkeep.delay_count` gauge metric which shows the active number of delayed tasks sitting in sqlite at a given moment