### PR TITLE
fix: Add namespace to the timing metric

### DIFF
--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -37,7 +37,7 @@ impl ConsumerService for TaskbrokerServer {
                     inflight.activation.received_at.unwrap().seconds,
                     inflight.activation.received_at.unwrap().nanos as u32,
                 ) {
-                    metrics::histogram!("grpc_server.received_to_gettask.latency").record(
+                    metrics::histogram!("grpc_server.received_to_gettask.latency", "namespace" => inflight.namespace.clone()).record(
                         Utc::now()
                             .signed_duration_since(sentry_ts)
                             .num_milliseconds() as f64,
@@ -140,6 +140,16 @@ impl ConsumerService for TaskbrokerServer {
             }
             Ok(None) => Err(Status::not_found("No pending activation")),
             Ok(Some(InflightActivation { activation, .. })) => {
+                if let Some(sentry_ts) = DateTime::from_timestamp(
+                    activation.received_at.unwrap().seconds,
+                    activation.received_at.unwrap().nanos as u32,
+                ) {
+                    metrics::histogram!("grpc_server.received_to_gettask.latency", "namespace" => activation.namespace.clone()).record(
+                        Utc::now()
+                            .signed_duration_since(sentry_ts)
+                            .num_milliseconds() as f64,
+                    );
+                }
                 Ok(Response::new(SetTaskStatusResponse {
                     task: Some(activation),
                 }))

--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -40,7 +40,7 @@ impl ConsumerService for TaskbrokerServer {
                     metrics::histogram!(
                         "grpc_server.received_to_gettask.latency",
                         "namespace" => inflight.namespace.clone(),
-                        "taskname" => inflight.activation.taskname.clone()
+                        "taskname" => inflight.activation.taskname.clone(),
                     )
                     .record(
                         Utc::now()
@@ -149,7 +149,12 @@ impl ConsumerService for TaskbrokerServer {
                     activation.received_at.unwrap().seconds,
                     activation.received_at.unwrap().nanos as u32,
                 ) {
-                    metrics::histogram!("grpc_server.received_to_gettask.latency", "namespace" => activation.namespace.clone(), "taskname" => activation.taskname.clone(),).record(
+                    metrics::histogram!(
+                        "grpc_server.received_to_gettask.latency",
+                        "namespace" => activation.namespace.clone(),
+                        "taskname" => activation.taskname.clone(),
+                    )
+                    .record(
                         Utc::now()
                             .signed_duration_since(sentry_ts)
                             .num_milliseconds() as f64,

--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -37,7 +37,12 @@ impl ConsumerService for TaskbrokerServer {
                     inflight.activation.received_at.unwrap().seconds,
                     inflight.activation.received_at.unwrap().nanos as u32,
                 ) {
-                    metrics::histogram!("grpc_server.received_to_gettask.latency", "namespace" => inflight.namespace.clone()).record(
+                    metrics::histogram!(
+                        "grpc_server.received_to_gettask.latency",
+                        "namespace" => inflight.namespace.clone(),
+                        "taskname" => inflight.activation.taskname.clone()
+                    )
+                    .record(
                         Utc::now()
                             .signed_duration_since(sentry_ts)
                             .num_milliseconds() as f64,
@@ -144,7 +149,7 @@ impl ConsumerService for TaskbrokerServer {
                     activation.received_at.unwrap().seconds,
                     activation.received_at.unwrap().nanos as u32,
                 ) {
-                    metrics::histogram!("grpc_server.received_to_gettask.latency", "namespace" => activation.namespace.clone()).record(
+                    metrics::histogram!("grpc_server.received_to_gettask.latency", "namespace" => activation.namespace.clone(), "taskname" => activation.taskname.clone(),).record(
                         Utc::now()
                             .signed_duration_since(sentry_ts)
                             .num_milliseconds() as f64,


### PR DESCRIPTION
Also add the metric to set task. This can be used to show product teams how long it's taking for the workers to start processing their tasks.