### PR TITLE
feat(security): add support for SASL authentication on Kafka connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ harness = false
 
 [features]
 bench-with-mnt-disk = []
+ssl = ["rdkafka/ssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1.43.1", features = ["full"] }
 tokio-util = "0.7.12"
 tokio-stream = { version = "0.1.16", features = ["full"] }
 futures = "0.3.31"
-rdkafka = { version = "0.37.0", features = ["cmake-build"] }
+rdkafka = { version = "0.37.0", features = ["cmake-build", "ssl"] }
 serde = "1.0.214"
 serde_yaml = "0.9.34"
 figment = { version = "0.10.19", features = ["env", "yaml", "test"] }
@@ -53,4 +53,3 @@ harness = false
 
 [features]
 bench-with-mnt-disk = []
-ssl = ["rdkafka/ssl"]


### PR DESCRIPTION
Building rdkafka with `ssl` support that includes SASL.

Testing the image:
```
$ docker run -it --rm -e TASKBROKER_KAFKA_SECURITY_PROTOCOL=sasl_plaintext -e TASKBROKER_KAFKA_SASL_MECHANISM=SCRAM-SHA-256 us-central1-docker.pkg.dev/sentryio/taskbroker/image:853721eb817033db71570177cc3324ba0e4e9b52 ./taskbroker | grep panicked
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
thread 'tokio-runtime-worker' panicked at /taskbroker/src/kafka/consumer.rs:58:14:
2025-04-30T10:30:43.504017Z ERROR taskbroker: Task consumer panicked: JoinError::Panic(Id(12), "Consumer creation failed: KafkaError (Client creation error: sasl.username and sasl.password must be set)", ...)
```