### PR TITLE
fix: Make logging info level by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The simplest way to run taskbroker is with `cargo`. You'll also need
 `kafka` running. Kafka is typically managed with [devservices](https://github.com/getsentry/devservices):
 
 ```bash
+# Run with default config
+cargo run
+
+# Run with a specific config file
 cargo run -- -c ./config/config-sentry-dev.yaml
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,7 +142,7 @@ impl Default for Config {
             sentry_dsn: None,
             sentry_env: None,
             traces_sample_rate: Some(0.0),
-            log_filter: "debug,librdkafka=warn,h2=off".to_owned(),
+            log_filter: "info,librdkafka=warn,h2=off".to_owned(),
             log_format: LogFormat::Text,
             grpc_addr: "0.0.0.0".to_owned(),
             grpc_port: 50051,
@@ -281,7 +281,7 @@ mod tests {
         };
         assert_eq!(config.sentry_dsn, None);
         assert_eq!(config.sentry_env, None);
-        assert_eq!(config.log_filter, "debug,librdkafka=warn,h2=off");
+        assert_eq!(config.log_filter, "info,librdkafka=warn,h2=off");
         assert_eq!(config.log_format, LogFormat::Text);
         assert_eq!(config.grpc_port, 50051);
         assert_eq!(config.kafka_topic, "taskworker");


### PR DESCRIPTION
We don't want debug logging enabled in devservices usage or production.

Fixes #329