### PR TITLE
feat(taskbroker): Drop expired tasks early

### DIFF
--- a/python/integration_tests/test_upkeep_expiry.py
+++ b/python/integration_tests/test_upkeep_expiry.py
@@ -258,6 +258,4 @@ Running test with the following configuration:
         line = log_file.readline()
         total_hanging_tasks = int(line.split(":")[1])
 
-    assert (
-        total_hanging_tasks == 0
-    )  # there should no tasks in sqlite left
+    assert total_hanging_tasks == 0  # there should no tasks in sqlite left

--- a/src/kafka/inflight_activation_batcher.rs
+++ b/src/kafka/inflight_activation_batcher.rs
@@ -50,7 +50,6 @@ impl Reducer for InflightActivationBatcher {
     async fn reduce(&mut self, t: Self::Input) -> Result<(), anyhow::Error> {
         let runtime_config = self.runtime_config_manager.read().await;
         let task_name = &t.activation.taskname;
-        // drop the task if it has expired
 
         if runtime_config.drop_task_killswitch.contains(task_name) {
             metrics::counter!("filter.drop_task_killswitch", "taskname" => task_name.clone())

--- a/src/store/inflight_activation_tests.rs
+++ b/src/store/inflight_activation_tests.rs
@@ -733,7 +733,8 @@ async fn test_handle_expires_at() {
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 2);
 
-    assert_count_by_status(&store, InflightActivationStatus::Failure, 2).await;
+    assert_count_by_status(&store, InflightActivationStatus::Pending, 1).await;
+    assert_count_by_status(&store, InflightActivationStatus::Failure, 0).await;
 }
 
 #[tokio::test]

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -165,14 +165,14 @@ pub async fn do_upkeep(
     metrics::histogram!("upkeep.handle_processing_attempts_exceeded")
         .record(handle_processing_attempts_exceeded_start.elapsed());
 
-    // 6. Handle tasks that are past their expires_at deadline
+    // 6. Remove tasks that are past their expires_at deadline
     let handle_expires_at_start = Instant::now();
     if let Ok(expired_count) = store.handle_expires_at().await {
         result_context.expired = expired_count;
     }
     metrics::histogram!("upkeep.handle_expires_at").record(handle_expires_at_start.elapsed());
 
-    // 7. Handle tasks that are past their expires_at deadline
+    // 7. Handle tasks that are past their delay_until deadline
     let handle_delay_until_start = Instant::now();
     if let Ok(delay_elapsed) = store.handle_delay_until().await {
         result_context.delay_elapsed = delay_elapsed;

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -635,8 +635,7 @@ mod tests {
         let result_context = do_upkeep(config, store.clone(), producer).await;
 
         assert_eq!(result_context.expired, 2); // 0/2 removed as expired
-        assert_eq!(result_context.discarded, 2); // 0/2 discarded as well
-        assert_eq!(result_context.completed, 3); // 1 complete
+        assert_eq!(result_context.completed, 1); // 1 complete
         assert_eq!(
             store
                 .count_by_status(InflightActivationStatus::Pending)


### PR DESCRIPTION
This PR is responsible for dropping expired tasks earlier. When a task get consumed and reaches the reduce step, we now check whether the task is killswitched OR whether the task has already expired. If so, drop the task. By skipping the store + upkeep earlier, we would likely get some more throughput from the consumer when experiencing large backlogs of expired tasks. Additionally, this PR changes the way upkeep does `handle_expired_at()`. Instead of hopping the task from pending -> failure -> complete, just delete the activation immediately. This has two implications:
1. Taskbroker will not support DLQing expired tasks.
2. The expire metric will now indicate that the task has been purged from SQLite (previously, this metric only indicated that the activation has been set from pending to failure. This was usually coupled with the discarded and completed counter metrics).