### PR TITLE
fix(metric): Account for delayed tasks in latency metric

### DIFF
--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -8,9 +8,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use tonic::{Request, Response, Status};
 
-use crate::store::inflight_activation::{
-    InflightActivation, InflightActivationStatus, InflightActivationStore,
-};
+use crate::store::inflight_activation::{InflightActivationStatus, InflightActivationStore};
 use tracing::{error, instrument};
 
 pub struct TaskbrokerServer {
@@ -37,16 +35,22 @@ impl ConsumerService for TaskbrokerServer {
                     inflight.activation.received_at.unwrap().seconds,
                     inflight.activation.received_at.unwrap().nanos as u32,
                 ) {
+                    let mut received_to_gettask_latency = Utc::now()
+                        .signed_duration_since(sentry_ts)
+                        .num_milliseconds()
+                        as f64;
+                    if let Some(delay_until) = inflight.delay_until {
+                        received_to_gettask_latency -= delay_until
+                            .signed_duration_since(sentry_ts)
+                            .num_milliseconds()
+                            as f64;
+                    }
                     metrics::histogram!(
                         "grpc_server.received_to_gettask.latency",
                         "namespace" => inflight.namespace.clone(),
                         "taskname" => inflight.activation.taskname.clone(),
                     )
-                    .record(
-                        Utc::now()
-                            .signed_duration_since(sentry_ts)
-                            .num_milliseconds() as f64,
-                    );
+                    .record(received_to_gettask_latency);
                 }
 
                 let resp = GetTaskResponse {
@@ -144,24 +148,30 @@ impl ConsumerService for TaskbrokerServer {
                 Err(Status::internal("Unable to fetch next task"))
             }
             Ok(None) => Err(Status::not_found("No pending activation")),
-            Ok(Some(InflightActivation { activation, .. })) => {
+            Ok(Some(inflight)) => {
                 if let Some(sentry_ts) = DateTime::from_timestamp(
-                    activation.received_at.unwrap().seconds,
-                    activation.received_at.unwrap().nanos as u32,
+                    inflight.activation.received_at.unwrap().seconds,
+                    inflight.activation.received_at.unwrap().nanos as u32,
                 ) {
+                    let mut received_to_gettask_latency = Utc::now()
+                        .signed_duration_since(sentry_ts)
+                        .num_milliseconds()
+                        as f64;
+                    if let Some(delay_until) = inflight.delay_until {
+                        received_to_gettask_latency -= delay_until
+                            .signed_duration_since(sentry_ts)
+                            .num_milliseconds()
+                            as f64;
+                    }
                     metrics::histogram!(
                         "grpc_server.received_to_gettask.latency",
-                        "namespace" => activation.namespace.clone(),
-                        "taskname" => activation.taskname.clone(),
+                        "namespace" => inflight.namespace.clone(),
+                        "taskname" => inflight.activation.taskname.clone(),
                     )
-                    .record(
-                        Utc::now()
-                            .signed_duration_since(sentry_ts)
-                            .num_milliseconds() as f64,
-                    );
+                    .record(received_to_gettask_latency);
                 }
                 Ok(Response::new(SetTaskStatusResponse {
-                    task: Some(activation),
+                    task: Some(inflight.activation),
                 }))
             }
         };

--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -35,22 +35,20 @@ impl ConsumerService for TaskbrokerServer {
                     inflight.activation.received_at.unwrap().seconds,
                     inflight.activation.received_at.unwrap().nanos as u32,
                 ) {
-                    let mut received_to_gettask_latency = Utc::now()
+                    let received_to_gettask_latency = Utc::now()
                         .signed_duration_since(sentry_ts)
                         .num_milliseconds()
-                        as f64;
-                    if let Some(delay_until) = inflight.delay_until {
-                        received_to_gettask_latency -= delay_until
-                            .signed_duration_since(sentry_ts)
-                            .num_milliseconds()
-                            as f64;
-                    }
+                        - inflight.delay_until.map_or(0, |delay_until| {
+                            delay_until
+                                .signed_duration_since(sentry_ts)
+                                .num_milliseconds()
+                        });
                     metrics::histogram!(
                         "grpc_server.received_to_gettask.latency",
                         "namespace" => inflight.namespace.clone(),
                         "taskname" => inflight.activation.taskname.clone(),
                     )
-                    .record(received_to_gettask_latency);
+                    .record(received_to_gettask_latency as f64);
                 }
 
                 let resp = GetTaskResponse {
@@ -153,22 +151,20 @@ impl ConsumerService for TaskbrokerServer {
                     inflight.activation.received_at.unwrap().seconds,
                     inflight.activation.received_at.unwrap().nanos as u32,
                 ) {
-                    let mut received_to_gettask_latency = Utc::now()
+                    let received_to_gettask_latency = Utc::now()
                         .signed_duration_since(sentry_ts)
                         .num_milliseconds()
-                        as f64;
-                    if let Some(delay_until) = inflight.delay_until {
-                        received_to_gettask_latency -= delay_until
-                            .signed_duration_since(sentry_ts)
-                            .num_milliseconds()
-                            as f64;
-                    }
+                        - inflight.delay_until.map_or(0, |delay_until| {
+                            delay_until
+                                .signed_duration_since(sentry_ts)
+                                .num_milliseconds()
+                        });
                     metrics::histogram!(
                         "grpc_server.received_to_gettask.latency",
                         "namespace" => inflight.namespace.clone(),
                         "taskname" => inflight.activation.taskname.clone(),
                     )
-                    .record(received_to_gettask_latency);
+                    .record(received_to_gettask_latency as f64);
                 }
                 Ok(Response::new(SetTaskStatusResponse {
                     task: Some(inflight.activation),


### PR DESCRIPTION
Currently, our latency metric can incorrectly account for a task's delayed time. Since the latency metric is the duration between Kafka receive time and the time at which the activation was given to worker, delayed tasks can incorrectly skew this metric. Before emitting the metric, if a task was delayed, subtract the duration that it was delayed for, then emit its latency.