### PR TITLE
ref(dlq): Discard messages that fail to go to the DLQ

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use tokio::signal::unix::SignalKind;
 use tokio::task::JoinHandle;
 use tokio::{select, time};
 use tonic::transport::Server;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use sentry_protos::taskbroker::v1::consumer_service_server::ConsumerServiceServer;
 
@@ -100,7 +100,7 @@ async fn main() -> Result<(), Error> {
                 select! {
                     _ = timer.tick() => {
                         let _ = maintenance_store.vacuum_db().await;
-                        info!("ran maintenance vacuum");
+                        debug!("ran maintenance vacuum");
                     },
                     _ = guard.wait() => {
                         break;

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -326,7 +326,6 @@ mod tests {
     use std::time::Duration;
 
     use crate::{
-        config::Config,
         store::inflight_activation::{
             InflightActivationStatus, InflightActivationStore, InflightActivationStoreConfig,
         },

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -3,20 +3,23 @@ use futures::{StreamExt, stream::FuturesUnordered};
 use prost::Message;
 use prost_types::Timestamp;
 use rdkafka::{
-    message::OwnedMessage, producer::{FutureProducer, FutureRecord}, util::Timeout
+    producer::{FutureProducer, FutureRecord},
+    util::Timeout,
 };
 use sentry_protos::taskbroker::v1::TaskActivation;
 use std::{
-    fmt::Error, sync::Arc, time::{Duration, Instant}
+    sync::Arc,
+    time::{Duration, Instant},
 };
 use tokio::{select, time};
 use tracing::{error, info, instrument};
 use uuid::Uuid;
 
 use crate::{
-    config::Config, kafka::consumer::KafkaMessage, store::inflight_activation::{
+    config::Config,
+    store::inflight_activation::{
         InflightActivation, InflightActivationStatus, InflightActivationStore,
-    }
+    },
 };
 
 /// The upkeep task that periodically performs upkeep
@@ -334,6 +337,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::{
+        config::Config,
         store::inflight_activation::{
             InflightActivationStatus, InflightActivationStore, InflightActivationStoreConfig,
         },
@@ -342,7 +346,6 @@ mod tests {
             generate_temp_filename, make_activations, reset_topic,
         },
         upkeep::do_upkeep,
-        config::Config,
     };
 
     async fn create_inflight_store() -> Arc<InflightActivationStore> {
@@ -606,7 +609,6 @@ mod tests {
             kafka_deadletter_topic: "doesnotexist".into(),
             ..Config::default()
         });
-
         let store = create_inflight_store().await;
         let producer = create_producer(config.clone());
         let mut records = make_activations(2);

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -205,7 +205,13 @@ pub async fn do_upkeep(
 
                     match delivery {
                         Ok(_) => Ok(activation.id),
-                        Err(err) => Err(err),
+                        Err((err, _msg)) => {
+                            error!(
+                                "deadletter.publish.failure: {}, message: {:?}",
+                                err, payload
+                            );
+                            Err(err)
+                        }
                     }
                 }
             })
@@ -218,10 +224,7 @@ pub async fn do_upkeep(
             .into_iter()
             .filter_map(|result| match result {
                 Ok(id) => Some(id),
-                Err((err, _msg)) => {
-                    error!("deadletter.publish.failure {}", err);
-                    None
-                }
+                Err(_) => None,
             })
             .collect();
 


### PR DESCRIPTION
If a message can't be written to the DLQ, instead of holding on to it indefinitely log the message out and discard the message.