### PR TITLE
metric(taskbroker): Capture metric for tasks being set to failed state by taskworker

### DIFF
--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -87,6 +87,9 @@ impl ConsumerService for TaskbrokerServer {
                 status
             )));
         }
+        if status == InflightActivationStatus::Failure {
+            metrics::counter!("grpc_server.set_status.failure").increment(1);
+        }
 
         let update_result = self.store.set_status(&id, status).await;
         if let Err(e) = update_result {


### PR DESCRIPTION
When auditing our metrics, I noticed we were missing a metric that captures where a task was failed. Currently in the taskbroker system, there are two places a task can be set to a failed state:
1. A task exceeds its processing attempts. Upkeep is responsible for failing the task. We capture this metric via `"upkeep.cleanup_action", "kind" => "mark_processing_attempts_exceeded_as_failure"` 
2. A task fails to process in taskworker (e.g. task name does not exist in registry, uncaught exception, etc.). Taskworker will manually set the task status via gRPC endpoint.

This PR captures the metric for scenario 2. This will give us a more holistic picture of where tasks are being failed in taskbroker. 