### PR TITLE
feat(taskbroker): Add delay on retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,12 +732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,12 +916,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
@@ -1551,12 +1539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
-
-[[package]]
 name = "native-tls"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,16 +1789,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.7.1",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,16 +1897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,26 +1935,6 @@ checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
  "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
-dependencies = [
- "heck",
- "itertools 0.13.0",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn",
- "tempfile",
 ]
 
 [[package]]
@@ -2439,17 +2381,14 @@ dependencies = [
 
 [[package]]
 name = "sentry_protos"
-version = "0.1.69"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2a036b77e9fd7894ff4f0ac130dad3ca651e5359b2952ddb432638c6ec7958"
+checksum = "51f7779da50a2f2507527e81589ab556d0588a301734cab5adb989a479a139be"
 dependencies = [
- "glob",
  "prost",
  "prost-types",
- "regex",
  "tokio",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -3142,20 +3081,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "prost-types",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sentry_protos = "0.1.69"
+sentry_protos = "0.2.0"
 anyhow = "1.0.92"
 chrono = { version = "0.4.26" }
 sqlx = { version = "0.8.3", features = ["sqlite", "runtime-tokio", "chrono"] }

--- a/src/store/inflight_activation_tests.rs
+++ b/src/store/inflight_activation_tests.rs
@@ -428,6 +428,7 @@ async fn test_handle_processing_at_most_once() {
         max_attempts: 1,
         on_attempts_exceeded: OnAttemptsExceeded::Discard as i32,
         at_most_once: Some(true),
+        delay_on_retry: None,
     });
     batch[1].at_most_once = true;
     batch[1].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
@@ -462,6 +463,7 @@ async fn test_handle_processing_deadline_discard_after() {
         max_attempts: 1,
         on_attempts_exceeded: OnAttemptsExceeded::Discard as i32,
         at_most_once: None,
+        delay_on_retry: None,
     });
 
     assert!(store.store(batch).await.is_ok());
@@ -483,6 +485,7 @@ async fn test_handle_processing_deadline_deadletter_after() {
         max_attempts: 1,
         on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
         at_most_once: None,
+        delay_on_retry: None,
     });
 
     assert!(store.store(batch).await.is_ok());
@@ -505,6 +508,7 @@ async fn test_handle_processing_deadline_no_retries_remaining() {
         max_attempts: 1,
         on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
         at_most_once: None,
+        delay_on_retry: None,
     });
 
     assert!(store.store(batch).await.is_ok());
@@ -648,6 +652,7 @@ async fn test_handle_failed_tasks() {
         max_attempts: 1,
         on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
         at_most_once: None,
+        delay_on_retry: None,
     });
     // discard
     records[1].status = InflightActivationStatus::Failure;
@@ -656,6 +661,7 @@ async fn test_handle_failed_tasks() {
         max_attempts: 1,
         on_attempts_exceeded: OnAttemptsExceeded::Discard as i32,
         at_most_once: None,
+        delay_on_retry: None,
     });
     // no retry state = discard
     records[2].status = InflightActivationStatus::Failure;
@@ -668,6 +674,7 @@ async fn test_handle_failed_tasks() {
         max_attempts: 1,
         on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
         at_most_once: None,
+        delay_on_retry: None,
     });
     assert!(store.store(records.clone()).await.is_ok());
 

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -315,7 +315,10 @@ fn create_retry_activation(inflight_activation: &InflightActivation) -> TaskActi
         seconds: now.timestamp(),
         nanos: now.nanosecond() as i32,
     });
-    new_activation.delay = None;
+    new_activation.delay = new_activation
+        .retry_state
+        .and_then(|retry_state| retry_state.delay_on_retry);
+
     if new_activation.retry_state.is_some() {
         new_activation.retry_state.as_mut().unwrap().attempts += 1;
     }
@@ -341,7 +344,7 @@ mod tests {
             consume_topic, create_config, create_integration_config, create_producer,
             generate_temp_filename, make_activations, reset_topic,
         },
-        upkeep::do_upkeep,
+        upkeep::{create_retry_activation, do_upkeep},
     };
 
     async fn create_inflight_store() -> Arc<InflightActivationStore> {
@@ -353,6 +356,84 @@ mod tests {
                 .await
                 .unwrap(),
         )
+    }
+
+    #[tokio::test]
+    async fn test_retry_activation_sets_delay_with_delay_on_retry() {
+        let mut activation = make_activations(1).remove(0);
+        activation.activation.delay = None;
+        activation.activation.retry_state = Some(RetryState {
+            attempts: 0,
+            max_attempts: 3,
+            on_attempts_exceeded: OnAttemptsExceeded::Discard.into(),
+            at_most_once: Some(false),
+            delay_on_retry: Some(60),
+        });
+
+        let retry = create_retry_activation(&activation);
+        assert_eq!(retry.delay, Some(60));
+        assert_eq!(
+            retry.retry_state,
+            Some(RetryState {
+                attempts: 1,
+                max_attempts: 3,
+                on_attempts_exceeded: OnAttemptsExceeded::Discard.into(),
+                at_most_once: Some(false),
+                delay_on_retry: Some(60),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_activation_updates_delay_with_delay_on_retry() {
+        let mut activation = make_activations(1).remove(0);
+        activation.activation.delay = Some(100);
+        activation.activation.retry_state = Some(RetryState {
+            attempts: 0,
+            max_attempts: 3,
+            on_attempts_exceeded: OnAttemptsExceeded::Discard.into(),
+            at_most_once: Some(false),
+            delay_on_retry: Some(60),
+        });
+
+        let retry = create_retry_activation(&activation);
+        assert_eq!(retry.delay, Some(60));
+        assert_eq!(
+            retry.retry_state,
+            Some(RetryState {
+                attempts: 1,
+                max_attempts: 3,
+                on_attempts_exceeded: OnAttemptsExceeded::Discard.into(),
+                at_most_once: Some(false),
+                delay_on_retry: Some(60),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_activation_clears_delay_without_delay_on_retry() {
+        let mut activation = make_activations(1).remove(0);
+        activation.activation.delay = Some(60);
+        activation.activation.retry_state = Some(RetryState {
+            attempts: 0,
+            max_attempts: 3,
+            on_attempts_exceeded: OnAttemptsExceeded::Discard.into(),
+            at_most_once: Some(false),
+            delay_on_retry: None,
+        });
+
+        let retry = create_retry_activation(&activation);
+        assert_eq!(retry.delay, None);
+        assert_eq!(
+            retry.retry_state,
+            Some(RetryState {
+                attempts: 1,
+                max_attempts: 3,
+                on_attempts_exceeded: OnAttemptsExceeded::Discard.into(),
+                at_most_once: Some(false),
+                delay_on_retry: None,
+            })
+        );
     }
 
     #[tokio::test]
@@ -376,6 +457,7 @@ mod tests {
             max_attempts: 2,
             on_attempts_exceeded: OnAttemptsExceeded::Discard as i32,
             at_most_once: None,
+            delay_on_retry: None,
         });
         records[0].activation.delay = Some(30);
         records[0].delay_until = Some(Utc::now() + Duration::from_secs(30));
@@ -494,6 +576,7 @@ mod tests {
             max_attempts: 1,
             on_attempts_exceeded: OnAttemptsExceeded::Discard as i32,
             at_most_once: Some(true),
+            delay_on_retry: None,
         });
         assert!(store.store(batch.clone()).await.is_ok());
 
@@ -572,6 +655,7 @@ mod tests {
             max_attempts: 1,
             on_attempts_exceeded: OnAttemptsExceeded::Deadletter as i32,
             at_most_once: None,
+            delay_on_retry: None,
         });
         records[1].added_at += Duration::from_secs(1);
         assert!(store.store(records.clone()).await.is_ok());


### PR DESCRIPTION
Bumps the proto version to 0.2.0, which adds the new fields to allow tasks to define delay upon a retry.
During upkeep, upon cloning/serializing a failed task for retry, we set the `delay` field if an activation has a `delay_on_retry` set.

Also adds a few unit tests as I forgot about this cloning/serialization part when implementing the original retry mechanism.

Worker changes
https://github.com/getsentry/sentry/pull/91197