### PR TITLE
chore(devservices): Bump devservices to 1.1.5

### DIFF
--- a/devservices/programs.conf
+++ b/devservices/programs.conf
@@ -1,0 +1,3 @@
+[program:devserver]
+command=cargo run
+autostart=false

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,5 +1,5 @@
 confluent_kafka>=2.3.0
-devservices==1.0.18
+devservices==1.1.5
 grpcio==1.66.1
 orjson>=3.10.10
 protobuf>=5.28.3


### PR DESCRIPTION
This bumps devservices to version 1.1.5

https://github.com/getsentry/devservices/releases/tag/1.1.5

It also adds a programs.conf file to specify the entrypoint for running the relay development server to devservices