### PR TITLE
fix(upkeep): Add a semaphore to prevent concurrent upkeep/vacuum

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -138,6 +138,12 @@ pub struct Config {
     /// The maximum size allowed for a message on the Kafka producer.
     /// If a message is bigger than this then the produce will fail.
     pub max_message_size: u64,
+
+    /// The maximum number of concurrent upkeep processes
+    pub max_concurrent_upkeep: usize,
+
+    /// The maximum number of concurrent sqlite vacuum processes
+    pub max_concurrent_vacuum: usize,
 }
 
 impl Default for Config {
@@ -182,6 +188,8 @@ impl Default for Config {
             maintenance_task_interval_ms: 6000,
             max_delayed_task_allowed_sec: 3600,
             max_message_size: 10485760,
+            max_concurrent_upkeep: 3,
+            max_concurrent_vacuum: 3,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<(), Error> {
                 select! {
                     _ = timer.tick() => {
                         let permit_attempt = vacuum_semaphore.try_acquire();
-                        if permit_attempt.err().is_none() {
+                        if permit_attempt.is_ok() {
                             let _ = maintenance_store.vacuum_db().await;
                         }
                         debug!("ran maintenance vacuum");

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -41,7 +41,7 @@ pub async fn upkeep(config: Arc<Config>, store: Arc<InflightActivationStore>) {
         select! {
             _ = timer.tick() => {
                 let permit_attempt = upkeep_semaphore.try_acquire();
-                if permit_attempt.err().is_none() {
+                if permit_attempt.is_ok() {
                     let _ = do_upkeep(config.clone(), store.clone(), producer.clone()).await;
                 }
             }


### PR DESCRIPTION
In a situtation where the broker is overloaded, and the upkeep/vacuum are taking longer than a single interval to run, the old functionality would simply continue calling the function. If the upkeep was taking 30 seconds to run, and there was a 1 second interval, that means there would be 30 concurrent upkeeps all running at the same time, and all effectively doing the same thing.

In the case of an incident like INC-1158, this would compound the issue the broker was facing: it was already under high load, and this would simply keep piling on more and more load, as well as potentially consuming a lot of memory keeping all the stack traces in memory.

Add a simple semaphore to limit the number of concurrent upkeeps/vacuums that can be running at once to avoid this compounding issue. Hopefully this will help prevent high load causing incidents.