### PR TITLE
fix: Reduce logging volume on brokers

### DIFF
--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::{select, time};
-use tracing::{error, info, instrument};
+use tracing::{debug, error, info, instrument};
 use uuid::Uuid;
 
 use crate::{

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -248,7 +248,7 @@ pub async fn do_upkeep(
     }
 
     if !result_context.empty() {
-        info!(
+        debug!(
             result_context.completed,
             result_context.deadlettered,
             result_context.discarded,


### PR DESCRIPTION
This log message is the bulk of our logging, and it isn't that useful in production as we also have metrics for all the attributes being logged here.