### PR TITLE
ref(tele): Add debug info for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "taskbroker"
 version = "0.1.0"
 edition = "2024"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[profile.release]
+debug = 1
 
 [dependencies]
 sentry_protos = "0.2.0"


### PR DESCRIPTION
Adds debug symbols to production binary. This increases the binary size, but also means we don't need to upload the source map to sentry.