### PR TITLE
fix(gocd): Use exclude_regions

### DIFF
--- a/gocd/templates/taskbroker.jsonnet
+++ b/gocd/templates/taskbroker.jsonnet
@@ -19,7 +19,7 @@ local pipedream_config = {
     stage: 'deploy-primary',
     elastic_profile_id: 'taskbroker',
   },
-  include_regions: ['s4s', 'customer-1', 'customer-2'],
+  exclude_regions: ['de', 'us', 'customer-4', 'customer-7'],
 };
 
 pipedream.render(pipedream_config, taskbroker)


### PR DESCRIPTION
`include_regions` is a little non-intuitive, it's not including to an empty list but including to a default list (all `getsentry` 'region mode' regions).  `include_regions` is used for adding `control` to specific pipelines as we run a subset of our services for `control`.

To limit to regions we want to deploy to we need to use `exclude_regions` which removes the provided list of regions from the default list.