### PR TITLE
ref(build): Add missing dependency to Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,6 +2046,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -192,7 +192,7 @@ impl Default for Config {
 
 impl Config {
     /// Build a config instance from defaults, env vars, file + CLI options
-    pub fn from_args(args: &Args) -> Result<Self, figment::Error> {
+    pub fn from_args(args: &Args) -> Result<Self, Box<figment::Error>> {
         let mut builder = Figment::from(Config::default());
         if let Some(path) = &args.config {
             builder = builder.merge(Yaml::file(path));


### PR DESCRIPTION
This pr https://github.com/getsentry/taskbroker/pull/326 forgot to add open ssl to the Cargo.lock file after updating Cargo.toml. Everytime we run cargo check, cargo will try and add it.