### PR TITLE
feat: Enable deploys for US region for control silo

### DIFF
--- a/gocd/templates/pipelines/taskbroker.libsonnet
+++ b/gocd/templates/pipelines/taskbroker.libsonnet
@@ -20,7 +20,7 @@ local checks_stage = {
 };
 
 local deploy_canary_stage(region) =
-  if region == 'us' then
+  if region == 'us' || region == 'de' then
     [
       {
         'deploy-canary': {

--- a/gocd/templates/taskbroker.jsonnet
+++ b/gocd/templates/taskbroker.jsonnet
@@ -19,7 +19,7 @@ local pipedream_config = {
     stage: 'deploy-primary',
     elastic_profile_id: 'taskbroker',
   },
-  exclude_regions: ['de', 'us'],
+  exclude_regions: ['de'],
 };
 
 pipedream.render(pipedream_config, taskbroker)


### PR DESCRIPTION
The control silo brokers will live in the US region, so we'll need deploys for US region enabled.