### PR TITLE
fix: Pull image before adding tags

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -50,6 +50,10 @@ jobs:
         run: |
           IMAGE_URL="ghcr.io/getsentry/taskbroker:${{ github.sha }}"
           echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin
+
+          # fetch the image
+          docker pull "$IMAGE_URL"
+
           # We push 3 tags to Dockerhub:
           # first, the full sha of the commit
           docker tag "$IMAGE_URL" getsentry/taskbroker:${GITHUB_SHA}


### PR DESCRIPTION
The previous build failed because the image that was being tagged was not present on the build runner. Fetching the image first should fix that.