### PR TITLE
fix(attempts): Only track latency of first attempt

### DIFF
--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -32,15 +32,17 @@ impl ConsumerService for TaskbrokerServer {
 
         match inflight {
             Ok(Some(inflight)) => {
-                let now = Utc::now();
-                let received_to_gettask_latency = inflight.received_latency(now);
-                if received_to_gettask_latency > 0 {
-                    metrics::histogram!(
-                        "grpc_server.received_to_gettask.latency",
-                        "namespace" => inflight.namespace,
-                        "taskname" => inflight.taskname,
-                    )
-                    .record(received_to_gettask_latency as f64);
+                if inflight.processing_attempts == 0 {
+                    let now = Utc::now();
+                    let received_to_gettask_latency = inflight.received_latency(now);
+                    if received_to_gettask_latency > 0 {
+                        metrics::histogram!(
+                            "grpc_server.received_to_gettask.latency",
+                            "namespace" => inflight.namespace,
+                            "taskname" => inflight.taskname,
+                        )
+                        .record(received_to_gettask_latency as f64);
+                    }
                 }
 
                 let resp = GetTaskResponse {
@@ -142,15 +144,17 @@ impl ConsumerService for TaskbrokerServer {
             }
             Ok(None) => Err(Status::not_found("No pending activation")),
             Ok(Some(inflight)) => {
-                let now = Utc::now();
-                let received_to_gettask_latency = inflight.received_latency(now);
-                if received_to_gettask_latency > 0 {
-                    metrics::histogram!(
-                        "grpc_server.received_to_gettask.latency",
-                        "namespace" => inflight.namespace,
-                        "taskname" => inflight.taskname,
-                    )
-                    .record(received_to_gettask_latency as f64);
+                if inflight.processing_attempts == 0 {
+                    let now = Utc::now();
+                    let received_to_gettask_latency = inflight.received_latency(now);
+                    if received_to_gettask_latency > 0 {
+                        metrics::histogram!(
+                            "grpc_server.received_to_gettask.latency",
+                            "namespace" => inflight.namespace,
+                            "taskname" => inflight.taskname,
+                        )
+                        .record(received_to_gettask_latency as f64);
+                    }
                 }
                 Ok(Response::new(SetTaskStatusResponse {
                     task: Some(TaskActivation::decode(&inflight.activation as &[u8]).unwrap()),


### PR DESCRIPTION
If a task fails its processing deadline, the latency will automatically be <actual latency> + <processing deadline> which gives a misleading sense of the latency tasks are experiencing. This can be an enormous difference for tasks that have processing deadlines > 5 minutes.

If a task is not on its first processing attempt, skip tracking the metric.