### PR TITLE
ci: tag GHCR image with release version

### DIFF
--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -1,0 +1,22 @@
+name: Release GHCR Versioned Image
+
+on:
+  release:
+    types: [prereleased, released]
+
+jobs:
+  release-ghcr-version-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag release version
+        run: |
+          docker buildx imagetools create --tag \
+           ghcr.io/getsentry/sentry-self-hosted:${{ github.ref_name }} \
+           ghcr.io/getsentry/sentry-self-hosted:${{ github.sha }}

--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -18,5 +18,5 @@ jobs:
       - name: Tag release version
         run: |
           docker buildx imagetools create --tag \
-           ghcr.io/getsentry/sentry-self-hosted:${{ github.ref_name }} \
-           ghcr.io/getsentry/sentry-self-hosted:${{ github.sha }}
+           ghcr.io/getsentry/taskbroker:${{ github.ref_name }} \
+           ghcr.io/getsentry/taskbroker:${{ github.sha }}


### PR DESCRIPTION
I nearly forgot about this, the very last one.

Other repositories:
* sentry https://github.com/getsentry/sentry/pull/88181
* relay https://github.com/getsentry/relay/pull/4532
* symbolicator https://github.com/getsentry/symbolicator/pull/1635
* snuba https://github.com/getsentry/snuba/pull/6997
* vroom https://github.com/getsentry/vroom/pull/576

As we're trying to provide a solution for https://github.com/getsentry/self-hosted/issues/3593