### PR TITLE
ci: acquire release image from ghcr

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -6,16 +6,18 @@ statusProvider:
   name: github
   config:
     contexts:
-      - 'build-on-taskbroker-branch-push (sentryio)'
+      - 'build-arm64'
+      - 'build-amd64'
+      - 'assemble-taskbroker-image'
 preReleaseCommand: ""
 targets:
   - id: release
     name: docker
-    source: us-central1-docker.pkg.dev/sentryio/taskbroker/image
+    source: ghcr.io/getsentry/taskbroker
     target: getsentry/taskbroker
   - id: latest
     name: docker
-    source: us-central1-docker.pkg.dev/sentryio/taskbroker/image
+    source: ghcr.io/getsentry/taskbroker
     target: getsentry/taskbroker
     targetFormat: '{{{target}}}:latest'
   - name: github

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,7 +1,9 @@
 on:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release/**
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -12,8 +14,9 @@ jobs:
             platform: amd64
           - os: ubuntu-24.04-arm
             platform: arm64
+    name: build-${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -40,7 +43,7 @@ jobs:
     needs: [build]
     if: ${{ github.event_name != 'pull_request' }}
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - run: docker login --username '${{ github.actor }}' --password-stdin ghcr.io <<< "$GHCR_TOKEN"
         env:
@@ -98,10 +101,9 @@ jobs:
 
   publish-taskbroker-to-dockerhub:
     runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'main' }}
     needs: [assemble-taskbroker-image]
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - shell: bash
         run: |
@@ -121,7 +123,7 @@ jobs:
   build-taskworker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - run: docker login --username '${{ github.actor }}' --password-stdin ghcr.io <<< "$GHCR_TOKEN"
       env:


### PR DESCRIPTION
Craft should acquire the Docker image from GHCR instead of Google Artifact Registry. That way we'll include the arm64 platform image.