### PR TITLE
ci: setup self-hosted e2e test

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -118,6 +118,19 @@ jobs:
           # finally, nightly
           docker buildx imagetools create --tag getsentry/taskbroker:nightly ghcr.io/getsentry/taskbroker:${{ github.sha }}
 
+  self-hosted-end-to-end:
+    needs: [assemble-taskbroker-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Run Sentry self-hosted e2e CI
+        uses: getsentry/self-hosted@master
+        with:
+          project_name: taskbroker
+          image_url: ghcr.io/getsentry/taskbroker:${{ github.sha }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   build-taskworker:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Had an awful experience with this being missing on vroom for 25.6.0 release. Putting this here to avoid future problems.