### PR TITLE
feat(taskworker): Backpressure with max processing count

### DIFF
--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -105,10 +105,7 @@ async fn set_status(num_activations: u32, num_workers: u32) {
             for task_id in 0..num_activations {
                 if task_id % num_workers == worker_idx {
                     store
-                        .set_status(
-                            &format!("id_{}", task_id),
-                            InflightActivationStatus::Complete,
-                        )
+                        .set_status(&format!("id_{task_id}"), InflightActivationStatus::Complete)
                         .await
                         .unwrap();
                 }

--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,7 @@ fn emit_version() {
             .unwrap_or("unknown-rev".to_string())
     };
 
-    let release_name = format!("{}@{}+{}", package_name, package_version, git_commit_sha);
+    let release_name = format!("{package_name}@{package_version}+{git_commit_sha}");
     fs::write("./VERSION", &release_name).expect("Unable to write version");
     println!("cargo:rustc-env=TASKWORKER_VERSION={}", &release_name);
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,6 +129,10 @@ pub struct Config {
     /// in the InflightTaskStore (sqlite)
     pub max_delay_count: usize,
 
+    /// The maximum number of processing records that can be
+    /// in the InflightTaskStore (sqlite)
+    pub max_processing_count: usize,
+
     /// The maximum number of times a task can be reset from
     /// processing back to pending. When this limit is reached,
     /// the activation will be discarded/deadlettered.
@@ -191,6 +195,7 @@ impl Default for Config {
             runtime_config_path: None,
             max_pending_count: 2048,
             max_delay_count: 8192,
+            max_processing_count: 2048,
             max_processing_attempts: 5,
             upkeep_task_interval_ms: 1000,
             maintenance_task_interval_ms: 6000,
@@ -308,6 +313,7 @@ mod tests {
         assert_eq!(config.kafka_topic, "taskworker");
         assert_eq!(config.db_path, "./taskbroker-inflight.sqlite");
         assert_eq!(config.max_pending_count, 2048);
+        assert_eq!(config.max_processing_count, 2048);
     }
 
     #[test]
@@ -329,6 +335,7 @@ mod tests {
                 kafka_auto_offset_reset: earliest
                 db_path: ./taskbroker-error.sqlite
                 max_pending_count: 512
+                max_processing_count: 512
                 max_processing_attempts: 5
             "#,
             )?;
@@ -358,6 +365,7 @@ mod tests {
             assert_eq!(config.kafka_deadletter_topic, "error-tasks-dlq".to_owned());
             assert_eq!(config.db_path, "./taskbroker-error.sqlite".to_owned());
             assert_eq!(config.max_pending_count, 512);
+            assert_eq!(config.max_processing_count, 512);
             assert_eq!(config.max_processing_attempts, 5);
 
             Ok(())
@@ -395,6 +403,7 @@ mod tests {
             assert_eq!(config.kafka_deadletter_topic, "taskworker-dlq".to_owned());
             assert_eq!(config.db_path, "./taskbroker-inflight.sqlite".to_owned());
             assert_eq!(config.max_pending_count, 2048);
+            assert_eq!(config.max_processing_count, 2048);
             assert_eq!(config.max_processing_attempts, 5);
             assert_eq!(
                 config.default_metrics_tags,

--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -70,14 +70,13 @@ impl ConsumerService for TaskbrokerServer {
         let status: InflightActivationStatus =
             TaskActivationStatus::try_from(request.get_ref().status)
                 .map_err(|e| {
-                    Status::invalid_argument(format!("Unable to deserialize status: {:?}", e))
+                    Status::invalid_argument(format!("Unable to deserialize status: {e:?}"))
                 })?
                 .into();
 
         if !status.is_conclusion() {
             return Err(Status::invalid_argument(format!(
-                "Invalid status, expects 3 (Failure), 4 (Retry), or 5 (Complete), but got: {:?}",
-                status
+                "Invalid status, expects 3 (Failure), 4 (Retry), or 5 (Complete), but got: {status:?}"
             )));
         }
         if status == InflightActivationStatus::Failure {

--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -90,8 +90,7 @@ impl ConsumerService for TaskbrokerServer {
                 id, status, e
             );
             return Err(Status::internal(format!(
-                "Unable to update status of {:?} to {:?}",
-                id, status
+                "Unable to update status of {id:?} to {status:?}"
             )));
         }
         metrics::histogram!("grpc_server.set_status.duration").record(start_time.elapsed());

--- a/src/kafka/os_stream_writer.rs
+++ b/src/kafka/os_stream_writer.rs
@@ -45,8 +45,8 @@ where
             return Ok(None);
         };
         match self.os_stream {
-            OsStream::StdOut => println!("{:?}", data),
-            OsStream::StdErr => eprintln!("{:?}", data),
+            OsStream::StdOut => println!("{data:?}"),
+            OsStream::StdErr => eprintln!("{data:?}"),
         }
         sleep(self.print_duration).await;
         Ok(Some(()))

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -121,7 +121,7 @@ droop_task_killswitch:
 
         let runtime_config = RuntimeConfigManager::new(Some(test_path.to_string())).await;
         let config = runtime_config.read().await;
-        println!("config: {:?}", config);
+        println!("config: {config:?}");
         assert_eq!(config.drop_task_killswitch.len(), 0);
 
         fs::remove_file(test_path).await.unwrap();

--- a/src/store/inflight_activation_tests.rs
+++ b/src/store/inflight_activation_tests.rs
@@ -1116,11 +1116,11 @@ async fn test_migrations() {
 
     // Move migrations to different folders
     let orig = fs::read_dir("./migrations");
-    assert!(orig.is_ok(), "{:?}", orig);
+    assert!(orig.is_ok(), "{orig:?}");
 
     let origdir = orig.unwrap();
     for result in origdir {
-        assert!(result.is_ok(), "{:?}", result);
+        assert!(result.is_ok(), "{result:?}");
         let entry = result.unwrap();
         let filename = entry.file_name().into_string().unwrap();
         // Write the initial migration to a separate folder, so the table can be initialized without any migrations.
@@ -1129,11 +1129,11 @@ async fn test_migrations() {
                 entry.path(),
                 folders.initial_folder.clone() + "/" + &filename,
             );
-            assert!(result.is_ok(), "{:?}", result);
+            assert!(result.is_ok(), "{result:?}");
         }
 
         let result = fs::copy(entry.path(), folders.other_folder.clone() + "/" + &filename);
-        assert!(result.is_ok(), "{:?}", result);
+        assert!(result.is_ok(), "{result:?}");
     }
 
     // Run initial migration
@@ -1143,7 +1143,7 @@ async fn test_migrations() {
         .unwrap()
         .run(&write_pool)
         .await;
-    assert!(result.is_ok(), "{:?}", result);
+    assert!(result.is_ok(), "{result:?}");
 
     // Insert rows. Note that this query lines up with the 0001 migration table.
     let mut query_builder = QueryBuilder::<Sqlite>::new(
@@ -1187,7 +1187,7 @@ async fn test_migrations() {
         .push(" ON CONFLICT(id) DO NOTHING")
         .build();
     let result = query.execute(&write_pool).await;
-    assert!(result.is_ok(), "{:?}", result);
+    assert!(result.is_ok(), "{result:?}");
     let meta_result: QueryResult = result.unwrap().into();
     assert_eq!(meta_result.rows_affected, 2);
 
@@ -1197,5 +1197,5 @@ async fn test_migrations() {
         .unwrap()
         .run(&write_pool)
         .await;
-    assert!(result.is_ok(), "{:?}", result);
+    assert!(result.is_ok(), "{result:?}");
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -32,9 +32,9 @@ pub fn make_activations(count: u32) -> Vec<InflightActivation> {
         let now = Utc::now();
         #[allow(deprecated)]
         let item = InflightActivation {
-            id: format!("id_{}", i),
+            id: format!("id_{i}"),
             activation: TaskActivation {
-                id: format!("id_{}", i),
+                id: format!("id_{i}"),
                 namespace: "namespace".into(),
                 taskname: "taskname".into(),
                 parameters: "{}".into(),


### PR DESCRIPTION
We've seen an issue emerge in production where sqlite gets overloaded due to high numbers of processing tasks in sqlite. From investigation, I suspect the following negative feedback cycle to exist in taskbroker.
1. A spike in large messages gets written to kafka and consumed by taskbroker.
2. Even after capping the max bytes per batch (default to ~16MB), the consumer thread holds on the the sqlite writer lock for a long time.
3. gRPC becomes slow which makes workers no longer able updates to their tasks quickly (processing -> complete, processing -> failure).
4. More and more tasks stay in the processing state (unboundingly increases).
5. Upkeep cant trigger processing deadlines fast enough to clean up these tasks due to busy sqlite writer.
6. Consumer keeps writing pending tasks to sqlite and they eventually pile on to the backlog of processing tasks.

This PR is responsible for adding a mitigation by capping the max number of processing tasks in sqlite. From observing production, a stable ratio between pending and processing counts is about roughly 1 : 0.25. The default set in configuration is 2048 (same number of max pending count, 1 : 1). By applying backpressure to the consumer, it gives sqlite a chance to catch up and allow workers to get a response to clean up processing tasks before new pending tasks and piled on.