### PR TITLE
ref(logs): Allow better error grouping

### DIFF
--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -86,8 +86,10 @@ impl ConsumerService for TaskbrokerServer {
         let update_result = self.store.set_status(&id, status).await;
         if let Err(e) = update_result {
             error!(
-                "Unable to update status of {:?} to {:?}: {:?}",
-                id, status, e
+                ?id,
+                ?status,
+                "Unable to update status of activation: {:?}",
+                e,
             );
             return Err(Status::internal(format!(
                 "Unable to update status of {id:?} to {status:?}"

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -466,11 +466,10 @@ pub async fn map<T>(
                     }
                     Err(e) => {
                         error!(
-                            "Failed to map message at \
-                            (topic: {}, partition: {}, offset: {}), reason: {}",
-                            msg.topic(),
-                            msg.partition(),
-                            msg.offset(),
+                            topic = ?msg.topic(),
+                            partition = ?msg.partition(),
+                            offset = ?msg.offset(),
+                            "Failed to map message: {:?}",
                             e,
                         );
                         err.send(


### PR DESCRIPTION
Refactors our usage of the `error` macro to emit the high cardinality values are tags instead of error message.

We have places where we put high cardinality values into the error logs. i.e.
```rust
 error!(
    "Unable to update status of {:?} to {:?}: {:?}",
    id, status, e
);
```
Each error will pretty much show up as unique sentry errors, but they should really show up as a single kind of sentry error but with different tags.
