### PR TITLE
ref(gocd): use console script entry points

### DIFF
--- a/gocd/templates/bash/check-cloudbuild.sh
+++ b/gocd/templates/bash/check-cloudbuild.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/googlecloud/check_cloudbuild.py \
+checks-googlecloud-check-cloudbuild \
 	sentryio \
 	taskbroker \
 	build-on-taskbroker-branch-push \

--- a/gocd/templates/bash/check-github-runs.sh
+++ b/gocd/templates/bash/check-github-runs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/githubactions/checkruns.py \
+checks-githubactions-checkruns \
 	"getsentry/taskbroker" \
 	"${GO_REVISION_TASKBROKER_REPO}" \
     "Tests (ubuntu)"

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -2,7 +2,7 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-/devinfra/scripts/k8s/k8stunnel &&
+/devinfra/scripts/get-cluster-credentials &&
 	k8s-deploy \
 		--label-selector="${LABEL_SELECTOR}" \
 		--image="us-central1-docker.pkg.dev/sentryio/taskbroker/image:${GO_REVISION_TASKBROKER_REPO}" \

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel &&
-	/devinfra/scripts/k8s/k8s-deploy.py \
+	k8s-deploy \
 		--label-selector="${LABEL_SELECTOR}" \
 		--image="us-central1-docker.pkg.dev/sentryio/taskbroker/image:${GO_REVISION_TASKBROKER_REPO}" \
 		--type="statefulset" \


### PR DESCRIPTION
Updating gocd scripts to use console script entry points.

Please see: https://github.com/getsentry/devinfra-deployment-service/pull/698