### PR TITLE
feat: Pause ingestion when sqlite is full

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,11 @@ pub struct Config {
     /// before being written to InflightTaskStore (sqlite).
     pub db_insert_batch_max_time_ms: u64,
 
+    /// The maximum size of the sqlite database in bytes.
+    /// If the database reaches or exceeds this size, ingestion will
+    /// pause until the database size is reduced.
+    pub db_max_size: Option<u64>,
+
     /// The path to the runtime config file
     pub runtime_config_path: Option<String>,
 
@@ -224,6 +229,7 @@ impl Default for Config {
             db_insert_batch_max_len: 256,
             db_insert_batch_max_size: 16_000_000,
             db_insert_batch_max_time_ms: 1000,
+            db_max_size: None,
             runtime_config_path: None,
             max_pending_count: 2048,
             max_delay_count: 8192,
@@ -388,6 +394,7 @@ mod tests {
                 kafka_deadletter_topic: error-tasks-dlq
                 kafka_auto_offset_reset: earliest
                 db_path: ./taskbroker-error.sqlite
+                db_max_size: 3000000000
                 max_pending_count: 512
                 max_processing_count: 512
                 max_processing_attempts: 5
@@ -424,6 +431,7 @@ mod tests {
             assert_eq!(config.max_processing_count, 512);
             assert_eq!(config.max_processing_attempts, 5);
             assert_eq!(config.vacuum_page_count, Some(1000));
+            assert_eq!(config.db_max_size, Some(3_000_000_000));
             assert!(config.full_vacuum_on_start);
 
             Ok(())

--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -304,6 +304,18 @@ impl InflightActivationStore {
         Ok(())
     }
 
+    /// Get the size of the database in bytes based on SQLite metadata queries.
+    pub async fn db_size(&self) -> Result<u64, Error> {
+        let result: u64 = sqlx::query(
+            "SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()",
+        )
+        .fetch_one(&self.read_pool)
+        .await?
+        .get(0);
+
+        Ok(result)
+    }
+
     /// Get an activation by id. Primarily used for testing
     pub async fn get_by_id(&self, id: &str) -> Result<Option<InflightActivation>, Error> {
         let row_result: Option<TableRow> = sqlx::query_as(

--- a/src/store/inflight_activation_tests.rs
+++ b/src/store/inflight_activation_tests.rs
@@ -1109,6 +1109,24 @@ async fn test_vacuum_db_incremental() {
     assert!(result.is_ok());
 }
 
+#[tokio::test]
+async fn test_db_size() {
+    let store = create_test_store().await;
+
+    assert!(store.db_size().await.is_ok());
+    let first_size = store.db_size().await.unwrap();
+    assert!(first_size > 0, "should have some bytes");
+    println!("Initial DB size: {first_size} bytes");
+
+    // Generate a large enough batch that we use another page.
+    let batch = make_activations(50);
+    assert!(store.store(batch).await.is_ok());
+
+    let second_size = store.db_size().await.unwrap();
+    println!("second DB size: {second_size} bytes");
+    assert!(second_size > first_size, "should have more bytes now");
+}
+
 struct TestFolders {
     parent_folder: String,
     initial_folder: String,

--- a/src/store/inflight_activation_tests.rs
+++ b/src/store/inflight_activation_tests.rs
@@ -1112,18 +1112,16 @@ async fn test_vacuum_db_incremental() {
 #[tokio::test]
 async fn test_db_size() {
     let store = create_test_store().await;
-
     assert!(store.db_size().await.is_ok());
+
     let first_size = store.db_size().await.unwrap();
     assert!(first_size > 0, "should have some bytes");
-    println!("Initial DB size: {first_size} bytes");
 
     // Generate a large enough batch that we use another page.
     let batch = make_activations(50);
     assert!(store.store(batch).await.is_ok());
 
     let second_size = store.db_size().await.unwrap();
-    println!("second DB size: {second_size} bytes");
     assert!(second_size > first_size, "should have more bytes now");
 }
 


### PR DESCRIPTION
To help protect taskbroker against running out of space for sqlite, we can also enforce size limits based on the size of sqlite in bytes.

- Add store methods to get the size of the database (including freelist pages)
- Use the database size during ingestion to trigger backpressure when the size of the database crosses a configured value. In practice this limit is likely going to be 80% of total storage capacity.
- Record metrics whenever a broker is backpressuring so that we can see why and how often consumer activities are pausing.

Refs #438 