### PR TITLE
feat: Add latency metric from upkeep

### DIFF
--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -467,6 +467,38 @@ impl InflightActivationStore {
         Ok(Some(row.into()))
     }
 
+    /// Get the age of the oldest pending activation
+    /// Only activations with status=pending and processing_attempts=0 are considered
+    /// as we are interested in latency to the *first* attempt.
+    /// Tasks with delay_until set, will have their age adjusted based on their
+    /// delay time. No tasks = 0 lag
+    pub async fn pending_activation_max_lag(&self, now: &DateTime<Utc>) -> i64 {
+        let result = sqlx::query(
+            "SELECT received_at, delay_until
+            FROM inflight_taskactivations
+            WHERE status = $1
+            AND processing_attempts = 0
+            ORDER BY received_at ASC
+            LIMIT 1
+            ",
+        )
+        .bind(InflightActivationStatus::Pending)
+        .fetch_one(&self.read_pool)
+        .await;
+
+        if let Ok(row) = result {
+            let received_at: DateTime<Utc> = row.get("received_at");
+            let delay_until: Option<DateTime<Utc>> = row.get("delay_until");
+            now.signed_duration_since(received_at).num_seconds()
+                - delay_until.map_or(0, |delay_time| {
+                    delay_time.signed_duration_since(received_at).num_seconds()
+                })
+        } else {
+            // If we couldn't find a row, there is no latency.
+            0
+        }
+    }
+
     #[instrument(skip_all)]
     pub async fn count_pending_activations(&self) -> Result<usize, Error> {
         self.count_by_status(InflightActivationStatus::Pending)
@@ -779,37 +811,5 @@ impl InflightActivationStore {
             .await?;
 
         Ok(query.rows_affected())
-    }
-
-    /// Get the age of the oldest pending activation
-    /// Only activations with status=pending and processing_attempts=0 are considered
-    /// as we are interested in latency to the *first* attempt.
-    /// Tasks with delay_until set, will have their age adjusted based on their
-    /// delay time.
-    pub async fn pending_activation_max_lag(&self, now: &DateTime<Utc>) -> i64 {
-        let result = sqlx::query(
-            "SELECT received_at, delay_until
-            FROM inflight_taskactivations
-            WHERE status = $1
-            AND processing_attempts = 0
-            ORDER BY received_at ASC
-            LIMIT 1
-            ",
-        )
-        .bind(InflightActivationStatus::Pending)
-        .fetch_one(&self.read_pool)
-        .await;
-
-        if let Ok(row) = result {
-            let received_at: DateTime<Utc> = row.get("received_at");
-            let delay_until: Option<DateTime<Utc>> = row.get("delay_until");
-            now.signed_duration_since(received_at).num_seconds()
-                - delay_until.map_or(0, |delay_time| {
-                    delay_time.signed_duration_since(received_at).num_seconds()
-                })
-        } else {
-            // If we couldn't find a row, there is no latency.
-            0
-        }
     }
 }

--- a/src/store/inflight_activation_tests.rs
+++ b/src/store/inflight_activation_tests.rs
@@ -1125,6 +1125,50 @@ async fn test_db_size() {
     assert!(second_size > first_size, "should have more bytes now");
 }
 
+#[tokio::test]
+async fn test_pending_activation_max_lag_no_pending() {
+    let now = Utc::now();
+    let store = create_test_store().await;
+    // No activations, max lag is 0
+    assert_eq!(0, store.pending_activation_max_lag(&now).await);
+
+    let mut processing = make_activations(1);
+    processing[0].status = InflightActivationStatus::Processing;
+    assert!(store.store(processing).await.is_ok());
+
+    // No pending activations, max lag is 0
+    assert_eq!(0, store.pending_activation_max_lag(&now).await);
+}
+
+#[tokio::test]
+async fn test_pending_activation_max_lag_ignore_processing_attempts() {
+    let now = Utc::now();
+    let store = create_test_store().await;
+
+    let mut pending = make_activations(2);
+    pending[0].received_at = now - Duration::from_secs(10);
+    pending[1].received_at = now - Duration::from_secs(500);
+    pending[1].processing_attempts = 1;
+    assert!(store.store(pending).await.is_ok());
+
+    assert_eq!(10, store.pending_activation_max_lag(&now).await);
+}
+
+#[tokio::test]
+async fn test_pending_activation_max_lag_account_for_delayed() {
+    let now = Utc::now();
+    let store = create_test_store().await;
+
+    let mut pending = make_activations(2);
+    // delayed tasks are received well before they become pending
+    // the lag of a delayed task should begin *after* the delay has passed.
+    pending[0].received_at = now - Duration::from_secs(520);
+    pending[0].delay_until = Some(now - Duration::from_secs(20));
+    assert!(store.store(pending).await.is_ok());
+
+    assert_eq!(20, store.pending_activation_max_lag(&now).await);
+}
+
 struct TestFolders {
     parent_folder: String,
     initial_folder: String,

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -293,7 +293,7 @@ pub async fn do_upkeep(
     metrics::gauge!("upkeep.current_pending_tasks").set(result_context.pending);
     metrics::gauge!("upkeep.current_processing_tasks").set(result_context.processing);
     metrics::gauge!("upkeep.current_delayed_tasks").set(result_context.delay);
-    metrics::gauge!("upkeep.pending_activation.max_lag").set(max_lag as f64);
+    metrics::gauge!("upkeep.pending_activation.max_lag.ms").set(max_lag);
 
     result_context
 }

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -247,6 +247,7 @@ pub async fn do_upkeep(
     if let Ok(delay_count) = store.count_by_status(InflightActivationStatus::Delay).await {
         result_context.delay = delay_count as u32;
     }
+    let max_lag = store.pending_activation_max_lag(&Utc::now()).await;
 
     if !result_context.empty() {
         debug!(
@@ -292,6 +293,7 @@ pub async fn do_upkeep(
     metrics::gauge!("upkeep.current_pending_tasks").set(result_context.pending);
     metrics::gauge!("upkeep.current_processing_tasks").set(result_context.processing);
     metrics::gauge!("upkeep.current_delayed_tasks").set(result_context.delay);
+    metrics::gauge!("upkeep.pending_activation.max_lag").set(max_lag as f64);
 
     result_context
 }


### PR DESCRIPTION
While we have a latency metric that is driven by workers, this metric could become unavailable if all workers die. By emitting a lag metric from upkeep we are able to have consistent metrics when workers are dead, and when ingest is paused because sqlite is full. I'd like to compare this metric with our existing grpc based lag metric before changing any alerts.

Refs #448