### PR TITLE
feat: Add processing deadline grace period

### DIFF
--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -28,6 +28,7 @@ async fn get_pending_activations(num_activations: u32, num_workers: u32) {
             InflightActivationStoreConfig {
                 max_processing_attempts: 1,
                 vacuum_page_count: None,
+                processing_deadline_grace_sec: 3,
             },
         )
         .await
@@ -85,6 +86,7 @@ async fn set_status(num_activations: u32, num_workers: u32) {
             InflightActivationStoreConfig {
                 max_processing_attempts: 1,
                 vacuum_page_count: None,
+                processing_deadline_grace_sec: 3,
             },
         )
         .await

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,7 +164,7 @@ pub struct Config {
     /// The number of additional seconds that processing deadlines
     /// are extended by. This helps reduce broker deadline resets when
     /// brokers are under load, or there are small networking delays.
-    pub processing_deadline_grace_sec: i64,
+    pub processing_deadline_grace_sec: u64,
 
     /// The frequency at which upkeep tasks
     /// (discarding, retrying activations, etc.) are executed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,11 @@ pub struct Config {
     /// the activation will be discarded/deadlettered.
     pub max_processing_attempts: usize,
 
+    /// The number of additional seconds that processing deadlines
+    /// are extended by. This helps reduce broker deadline resets when
+    /// brokers are under load, or there are small networking delays.
+    pub processing_deadline_grace_sec: i64,
+
     /// The frequency at which upkeep tasks
     /// (discarding, retrying activations, etc.) are executed.
     pub upkeep_task_interval_ms: u64,
@@ -235,6 +240,7 @@ impl Default for Config {
             max_delay_count: 8192,
             max_processing_count: 2048,
             max_processing_attempts: 5,
+            processing_deadline_grace_sec: 3,
             upkeep_task_interval_ms: 1000,
             maintenance_task_interval_ms: 6000,
             max_delayed_task_allowed_sec: 3600,

--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -241,7 +241,7 @@ pub async fn create_sqlite_pool(url: &str) -> Result<(Pool<Sqlite>, Pool<Sqlite>
 
 pub struct InflightActivationStoreConfig {
     pub max_processing_attempts: usize,
-    pub processing_deadline_grace_sec: i64,
+    pub processing_deadline_grace_sec: u64,
     pub vacuum_page_count: Option<usize>,
 }
 

--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -241,6 +241,7 @@ pub async fn create_sqlite_pool(url: &str) -> Result<(Pool<Sqlite>, Pool<Sqlite>
 
 pub struct InflightActivationStoreConfig {
     pub max_processing_attempts: usize,
+    pub processing_deadline_grace_sec: i64,
     pub vacuum_page_count: Option<usize>,
 }
 
@@ -249,6 +250,7 @@ impl InflightActivationStoreConfig {
         Self {
             max_processing_attempts: config.max_processing_attempts,
             vacuum_page_count: config.vacuum_page_count,
+            processing_deadline_grace_sec: config.processing_deadline_grace_sec,
         }
     }
 }
@@ -430,15 +432,15 @@ impl InflightActivationStore {
     ) -> Result<Option<InflightActivation>, Error> {
         let now = Utc::now();
 
-        let mut query_builder = QueryBuilder::new(
-            "
-            UPDATE inflight_taskactivations
+        let grace_period = self.config.processing_deadline_grace_sec;
+        let mut query_builder = QueryBuilder::new(format!(
+            "UPDATE inflight_taskactivations
             SET
                 processing_deadline = unixepoch(
-                    'now', '+' || processing_deadline_duration || ' seconds'
+                    'now', '+' || (processing_deadline_duration + {grace_period}) || ' seconds'
                 ),
-                status = ",
-        );
+                status = "
+        ));
         query_builder.push_bind(InflightActivationStatus::Processing);
         query_builder.push(
             "

--- a/src/store/inflight_activation_tests.rs
+++ b/src/store/inflight_activation_tests.rs
@@ -130,7 +130,11 @@ async fn test_get_pending_activation() {
 
     assert_eq!(result.id, "id_0");
     assert_eq!(result.status, InflightActivationStatus::Processing);
-    assert!(result.processing_deadline.unwrap() > Utc::now());
+    assert_eq!(result.processing_deadline_duration, 10);
+    assert!(
+        result.processing_deadline.unwrap().timestamp() >= Utc::now().timestamp() + 13,
+        "Should be at least processing_deadline_duration + grace period ahead"
+    );
     assert_counts(
         StatusCount {
             pending: 1,


### PR DESCRIPTION
Because of clock skew, and overloaded brokers we can end up resetting deadlines in the brokers while workers don't terminate tasks. This leads to duplicate execution and reduces our ability to make progress.

By giving workers an additional 3 seconds of runtime we should be able to work around most clock skew, and many slow broker scenarios. I chose 3 seconds arbitrarily, and am open to changing it.

I've enabled this behavior by default as I think it will be relatively safe as it reduces strictness.