### PR TITLE
feat: Add a deadline quiet period after startup

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -165,6 +165,11 @@ pub struct Config {
     /// (discarding, retrying activations, etc.) are executed.
     pub upkeep_task_interval_ms: u64,
 
+    /// The number of seconds that deadline resets
+    /// are skipped after startup. This delay allows workers
+    /// time to publish results after a broker restart.
+    pub upkeep_deadline_reset_skip_after_startup_sec: u64,
+
     /// The frequency at which db maintenance tasks
     /// (reclaiming free pages) are executed
     pub maintenance_task_interval_ms: u64,
@@ -236,6 +241,7 @@ impl Default for Config {
             max_processing_count: 2048,
             max_processing_attempts: 5,
             upkeep_task_interval_ms: 1000,
+            upkeep_deadline_reset_skip_after_startup_sec: 60,
             maintenance_task_interval_ms: 6000,
             max_delayed_task_allowed_sec: 3600,
             max_message_size: 10485760,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::{Error, anyhow};
+use chrono::Utc;
 use clap::Parser;
 use std::{sync::Arc, time::Duration};
 use taskbroker::kafka::inflight_activation_batcher::{
@@ -84,13 +85,15 @@ async fn main() -> Result<(), Error> {
             Err(err) => error!("Failed to run full vacuum on startup: {:?}", err),
         }
     }
+    // Get startup time after migrations and vacuum
+    let startup_time = Utc::now();
 
     // Upkeep loop
     let upkeep_task = tokio::spawn({
         let upkeep_store = store.clone();
         let upkeep_config = config.clone();
         async move {
-            upkeep(upkeep_config, upkeep_store).await;
+            upkeep(upkeep_config, upkeep_store, startup_time).await;
             Ok(())
         }
     });


### PR DESCRIPTION
When taskbrokers are restarted, workers are unable to publish results, and the results they do have get buffered in the worker until the broker is back online. During this restart period, tasks with short deadlines will expire and be made pending again after a broker's first upkeep is completed.

By having an upkeep 'quiet period' we give workers time to flush results which should reduce the number of broker-side deadline resets without a worker kill that we see. This could create a heavier first upkeep if many deadlines have been exceeded, but I think the benefits are worth the tradeoff.