### PR TITLE
Fix clippy lint

### DIFF
--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -876,11 +876,11 @@ mod tests {
         type Output = ();
 
         async fn reduce(&mut self, t: Self::Input) -> Result<(), anyhow::Error> {
-            if let Some(idx) = self.error_on_idx {
-                if idx == self.pipe.read().unwrap().len() {
-                    self.error_on_idx.take();
-                    return Err(anyhow!("err"));
-                }
+            if let Some(idx) = self.error_on_idx
+                && idx == self.pipe.read().unwrap().len()
+            {
+                self.error_on_idx.take();
+                return Err(anyhow!("err"));
             }
             assert!(self.data.is_none());
             self.data = Some(t);

--- a/src/kafka/inflight_activation_batcher.rs
+++ b/src/kafka/inflight_activation_batcher.rs
@@ -63,11 +63,11 @@ impl Reducer for InflightActivationBatcher {
             return Ok(());
         }
 
-        if let Some(expires_at) = t.expires_at {
-            if Utc::now() > expires_at {
-                metrics::counter!("filter.expired_at_consumer").increment(1);
-                return Ok(());
-            }
+        if let Some(expires_at) = t.expires_at
+            && Utc::now() > expires_at
+        {
+            metrics::counter!("filter.expired_at_consumer").increment(1);
+            return Ok(());
         }
 
         self.batch_size += t.activation.len();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -181,12 +181,9 @@ pub fn replace_retry_state(inflight: &mut InflightActivation, retry: Option<Retr
     let mut activation = TaskActivation::decode(&inflight.activation as &[u8]).unwrap();
     activation.retry_state = retry;
     inflight.activation = activation.encode_to_vec();
-    if retry.is_some() {
-        inflight.on_attempts_exceeded = retry
-            .unwrap()
-            .on_attempts_exceeded
-            .try_into()
-            .expect("invalid enum");
+    if let Some(retry) = retry {
+        inflight.on_attempts_exceeded =
+            retry.on_attempts_exceeded.try_into().expect("invalid enum");
     } else {
         inflight.on_attempts_exceeded = OnAttemptsExceeded::Discard;
     }


### PR DESCRIPTION
Fixes the lint error that clippy is complaining about on main.

It seems like it's mostly complaining because `if let` chaining has been stabilized.