### PR TITLE
fix(typo): Update devserver command for taskbroker

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -16,7 +16,7 @@ x-sentry-service-config:
     containerized: [kafka, taskbroker]
 
 x-programs:
-  taskbroker:
+  devserver:
     command: cargo run
 
 services:


### PR DESCRIPTION
Found out this was a typo, so correcting it since `devservices serve` doesn't work here