### PR TITLE
feat(ci): Use composite gha for build/push images

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -15,6 +15,9 @@ jobs:
           - os: ubuntu-24.04-arm
             platform: arm64
     name: build-${{ matrix.platform }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -36,6 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: ${{ (github.ref_name == 'main' || startsWith(github.ref_name, 'releases/')) && github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -70,6 +76,9 @@ jobs:
 
   build-taskworker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
This PR adds support to use composite action for building and pushing docker images to registries. The standard is outlined here:

https://www.notion.so/sentry/Standard-Spec-Artifact-Management-22a8b10e4b5d80ecb6dcca3eb4558f5b