### PR TITLE
feat(ci): Phase 1: Cutover to gha for prod images

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -64,6 +64,7 @@ jobs:
   build-production:
     runs-on: ubuntu-24.04
     if: github.ref_name == github.event.repository.default_branch
+    name: Build and push production images
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -85,7 +85,7 @@ jobs:
           publish_on_pr: true
           # TODO: remove this once we cut over GoCD to using gha for prod images
           tag_suffix: -gha
-          google_ar_image_name: us-central1-docker.pkg.dev/sentryio/taskbroker/image:${{ github.sha }}
+          google_ar_image_name: us-central1-docker.pkg.dev/sentryio/taskbroker/image
           google_workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
           google_service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com
 
@@ -103,7 +103,7 @@ jobs:
           publish_on_pr: true
           # TODO: remove this once we cut over GoCD to using gha for prod images
           tag_suffix: -gha
-          google_ar_image_name: us-central1-docker.pkg.dev/sentryio/taskworker/image:${{ github.sha }}
+          google_ar_image_name: us-central1-docker.pkg.dev/sentryio/taskworker/image
           google_workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
           google_service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com
 

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -63,7 +63,7 @@ jobs:
 
   build-production:
     runs-on: ubuntu-24.04
-    if: github.ref_name == github.event.repository.default_branch
+    # if: github.ref_name == github.event.repository.default_branch
     name: Build and push production images
     permissions:
       contents: read

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -99,6 +99,49 @@ jobs:
 
           docker manifest push ghcr.io/getsentry/taskbroker:nightly
 
+  build-production:
+    runs-on: ubuntu-24.04
+    if: github.ref_name == github.event.repository.default_branch
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build and push taskbroker image
+        uses: getsentry/action-build-and-push-images@a53f146fc1ea3cb404f2dcf7378f5b60dd98d3ca
+        with:
+          image_name: 'taskbroker'
+          platforms: linux/amd64
+          dockerfile_path: './Dockerfile'
+          build_args: TASKBROKER_GIT_REVISION=${{ github.sha }}
+          ghcr: false
+          google_ar: true
+          tag_nightly: false
+          tag_latest: true
+          # TODO: remove this once we cut over GoCD to using gha for prod images
+          tag_suffix: -gha
+          google_ar_image_name: us-central1-docker.pkg.dev/sentryio/taskbroker/image:${{ github.sha }}
+          google_workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+          google_service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com
+
+      - name: Build and push taskworker image
+        uses: getsentry/action-build-and-push-images@a53f146fc1ea3cb404f2dcf7378f5b60dd98d3ca
+        with:
+          image_name: 'taskworker'
+          platforms: linux/amd64
+          dockerfile_path: './python/Dockerfile'
+          build_context: './python'
+          ghcr: false
+          google_ar: true
+          tag_nightly: false
+          tag_latest: true
+          # TODO: remove this once we cut over GoCD to using gha for prod images
+          tag_suffix: -gha
+          google_ar_image_name: us-central1-docker.pkg.dev/sentryio/taskworker/image:${{ github.sha }}
+          google_workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+          google_service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com
+
   publish-taskbroker-to-dockerhub:
     runs-on: ubuntu-latest
     needs: [assemble-taskbroker-image]

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -82,6 +82,7 @@ jobs:
           google_ar: true
           tag_nightly: false
           tag_latest: true
+          publish_on_pr: true
           # TODO: remove this once we cut over GoCD to using gha for prod images
           tag_suffix: -gha
           google_ar_image_name: us-central1-docker.pkg.dev/sentryio/taskbroker/image:${{ github.sha }}
@@ -99,6 +100,7 @@ jobs:
           google_ar: true
           tag_nightly: false
           tag_latest: true
+          publish_on_pr: true
           # TODO: remove this once we cut over GoCD to using gha for prod images
           tag_suffix: -gha
           google_ar_image_name: us-central1-docker.pkg.dev/sentryio/taskworker/image:${{ github.sha }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -63,7 +63,7 @@ jobs:
 
   build-production:
     runs-on: ubuntu-24.04
-    # if: github.ref_name == github.event.repository.default_branch
+    if: github.ref_name == github.event.repository.default_branch
     name: Build and push production images
     permissions:
       contents: read

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -82,7 +82,6 @@ jobs:
           google_ar: true
           tag_nightly: false
           tag_latest: true
-          publish_on_pr: true
           # TODO: remove this once we cut over GoCD to using gha for prod images
           tag_suffix: -gha
           google_ar_image_name: us-central1-docker.pkg.dev/sentryio/taskbroker/image
@@ -100,7 +99,6 @@ jobs:
           google_ar: true
           tag_nightly: false
           tag_latest: true
-          publish_on_pr: true
           # TODO: remove this once we cut over GoCD to using gha for prod images
           tag_suffix: -gha
           google_ar_image_name: us-central1-docker.pkg.dev/sentryio/taskworker/image


### PR DESCRIPTION
This PR adds jobs in gha for publishing to artifact registry. These images will have the suffix `-gha` so that GoCD will avoid using them for deploys. A PR will follow to cutover GoCD to using these images and cloudbuild images will have a `-cloudbuild` suffix