### PR TITLE
fix(taskbroker): Bump deploy primary timeout in us

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -2,8 +2,14 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
+WAIT_TIMEOUT=""
+if [ "${SENTRY_REGION}" = "us" ]; then
+	WAIT_TIMEOUT="--wait-timeout-mins=40"
+fi
+
 /devinfra/scripts/get-cluster-credentials && k8s-deploy \
 		--label-selector="${LABEL_SELECTOR}" \
 		--image="us-central1-docker.pkg.dev/sentryio/taskbroker/image:${GO_REVISION_TASKBROKER_REPO}" \
 		--type="statefulset" \
-		--container-name="taskbroker";
+		--container-name="taskbroker" \
+		${WAIT_TIMEOUT:+"${WAIT_TIMEOUT}"};


### PR DESCRIPTION
The `k8s-deploy` script has a separate timeout arg for watchers: https://github.com/getsentry/devinfra-deployment-service/blob/e77bb0c9c3b6b800a89d2b229cf4b238d618fb0b/gocd_agent/scripts/scripts/k8s/k8s_deploy.py#L358-L363. Since we're hitting timeout limits in US, we should bump this limit until we can use `maxUnavailable` for statefulsets.