### PR TITLE
fix(taskbroker): Bump deploy watchers to 60min

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -4,7 +4,7 @@ eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 WAIT_TIMEOUT=""
 if [ "${SENTRY_REGION}" = "us" ]; then
-	WAIT_TIMEOUT="--wait-timeout-mins=40"
+	WAIT_TIMEOUT="--wait-timeout-mins=60"
 fi
 
 /devinfra/scripts/get-cluster-credentials && k8s-deploy \


### PR DESCRIPTION
The GoCD job is still timing out at 40min. Temporarily bump this to 60min to unblock our pipeline until we can find a better solution to increase deployment velocity.