### PR TITLE
feat(sqlite): Add sqlite db status metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,6 +2918,7 @@ dependencies = [
  "hmac",
  "http",
  "http-body-util",
+ "libsqlite3-sys",
  "metrics",
  "metrics-exporter-statsd",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ bytes = "1.10.0"
 futures-util = "0.3.31"
 http-body-util = "0.1.2"
 rand = "0.8.5"
+libsqlite3-sys = "0.30.1"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -29,6 +29,7 @@ async fn get_pending_activations(num_activations: u32, num_workers: u32) {
                 max_processing_attempts: 1,
                 vacuum_page_count: None,
                 processing_deadline_grace_sec: 3,
+                enable_sqlite_status_metrics: false,
             },
         )
         .await
@@ -87,6 +88,7 @@ async fn set_status(num_activations: u32, num_workers: u32) {
                 max_processing_attempts: 1,
                 vacuum_page_count: None,
                 processing_deadline_grace_sec: 3,
+                enable_sqlite_status_metrics: false,
             },
         )
         .await

--- a/src/config.rs
+++ b/src/config.rs
@@ -208,6 +208,9 @@ pub struct Config {
 
     /// The interval in milliseconds between full `VACUUM`s on the database by the upkeep thread.
     pub vacuum_interval_ms: u64,
+
+    /// Enable additional metrics for the sqlite.
+    pub enable_sqlite_status_metrics: bool,
 }
 
 impl Default for Config {
@@ -271,6 +274,7 @@ impl Default for Config {
             full_vacuum_on_start: true,
             full_vacuum_on_upkeep: false,
             vacuum_interval_ms: 30000,
+            enable_sqlite_status_metrics: false,
         }
     }
 }

--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -322,141 +322,141 @@ impl InflightActivationStore {
             return;
         }
 
-        if let Ok(mut conn) = self.read_pool.acquire().await {
-            if let Ok(mut raw) = conn.lock_handle().await {
-                let mut cur: i32 = 0;
-                let mut hi: i32 = 0;
-                unsafe {
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_CACHE_USED,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.cache_used_bytes").set(cur);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_CACHE_USED_SHARED,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.cache_used_shared_bytes").set(cur);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_CACHE_HIT,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.cache_hit_total").set(cur);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_CACHE_MISS,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.cache_miss_total").set(cur);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_CACHE_WRITE,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.cache_write_total").set(cur);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_CACHE_SPILL,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.cache_spill_total").set(cur);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_SCHEMA_USED,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.schema_used_bytes").set(cur);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_STMT_USED,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.stmt_used_bytes").set(cur);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_LOOKASIDE_USED,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.lookaside_used").set(cur);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_LOOKASIDE_HIT,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.lookaside_hit_highwater").set(hi);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_LOOKASIDE_MISS_SIZE,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.lookaside_miss_size_highwater").set(hi);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_LOOKASIDE_MISS_FULL,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.lookaside_miss_full_highwater").set(hi);
-                    }
-                    if sqlite3_db_status(
-                        raw.as_raw_handle().as_mut(),
-                        SQLITE_DBSTATUS_DEFERRED_FKS,
-                        &mut cur,
-                        &mut hi,
-                        0,
-                    ) == SQLITE_OK
-                    {
-                        metrics::gauge!("sqlite.db.deferred_fks_unresolved").set(cur);
-                    }
+        if let Ok(mut conn) = self.read_pool.acquire().await
+            && let Ok(mut raw) = conn.lock_handle().await
+        {
+            let mut cur: i32 = 0;
+            let mut hi: i32 = 0;
+            unsafe {
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_CACHE_USED,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.cache_used_bytes").set(cur);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_CACHE_USED_SHARED,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.cache_used_shared_bytes").set(cur);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_CACHE_HIT,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.cache_hit_total").set(cur);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_CACHE_MISS,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.cache_miss_total").set(cur);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_CACHE_WRITE,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.cache_write_total").set(cur);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_CACHE_SPILL,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.cache_spill_total").set(cur);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_SCHEMA_USED,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.schema_used_bytes").set(cur);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_STMT_USED,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.stmt_used_bytes").set(cur);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_LOOKASIDE_USED,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.lookaside_used").set(cur);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_LOOKASIDE_HIT,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.lookaside_hit_highwater").set(hi);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_LOOKASIDE_MISS_SIZE,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.lookaside_miss_size_highwater").set(hi);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_LOOKASIDE_MISS_FULL,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.lookaside_miss_full_highwater").set(hi);
+                }
+                if sqlite3_db_status(
+                    raw.as_raw_handle().as_mut(),
+                    SQLITE_DBSTATUS_DEFERRED_FKS,
+                    &mut cur,
+                    &mut hi,
+                    0,
+                ) == SQLITE_OK
+                {
+                    metrics::gauge!("sqlite.db.deferred_fks_unresolved").set(cur);
                 }
             }
         }

--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -251,6 +251,7 @@ pub struct InflightActivationStoreConfig {
     pub max_processing_attempts: usize,
     pub processing_deadline_grace_sec: u64,
     pub vacuum_page_count: Option<usize>,
+    pub enable_sqlite_status_metrics: bool,
 }
 
 impl InflightActivationStoreConfig {
@@ -259,6 +260,7 @@ impl InflightActivationStoreConfig {
             max_processing_attempts: config.max_processing_attempts,
             vacuum_page_count: config.vacuum_page_count,
             processing_deadline_grace_sec: config.processing_deadline_grace_sec,
+            enable_sqlite_status_metrics: config.enable_sqlite_status_metrics,
         }
     }
 }
@@ -316,6 +318,10 @@ impl InflightActivationStore {
     }
 
     async fn emit_db_status_metrics(&self) {
+        if !self.config.enable_sqlite_status_metrics {
+            return;
+        }
+
         if let Ok(mut conn) = self.read_pool.acquire().await {
             if let Ok(mut raw) = conn.lock_handle().await {
                 let mut cur: i32 = 0;

--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -14,7 +14,7 @@ use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivationStatus};
 use sqlx::{
     ConnectOptions, FromRow, Pool, QueryBuilder, Row, Sqlite, Type,
     migrate::MigrateDatabase,
-    pool::{PoolConnection, PoolOptions},
+    pool::PoolOptions,
     sqlite::{
         SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqliteQueryResult,
         SqliteRow, SqliteSynchronous,

--- a/src/store/inflight_activation_tests.rs
+++ b/src/store/inflight_activation_tests.rs
@@ -1252,6 +1252,7 @@ async fn test_db_status_calls_ok() {
             max_processing_attempts: 3,
             processing_deadline_grace_sec: 0,
             vacuum_page_count: None,
+            enable_sqlite_status_metrics: false,
         },
     )
     .await

--- a/src/store/inflight_activation_tests.rs
+++ b/src/store/inflight_activation_tests.rs
@@ -1230,6 +1230,65 @@ async fn test_pending_activation_max_lag_account_for_delayed() {
     assert!(result < 23.00, "result: {result}");
 }
 
+#[tokio::test]
+async fn test_db_status_calls_ok() {
+    use libsqlite3_sys::{
+        SQLITE_DBSTATUS_CACHE_USED, SQLITE_DBSTATUS_SCHEMA_USED, SQLITE_OK, sqlite3_db_status,
+    };
+    use std::time::SystemTime;
+
+    // Create a unique on-disk database URL
+    let nanos = SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let db_path = format!("/tmp/taskbroker-dbstatus-{nanos}.sqlite");
+    let url = format!("sqlite:{db_path}");
+
+    // Initialize a store to create the database and run migrations
+    InflightActivationStore::new(
+        &url,
+        InflightActivationStoreConfig {
+            max_processing_attempts: 3,
+            processing_deadline_grace_sec: 0,
+            vacuum_page_count: None,
+        },
+    )
+    .await
+    .expect("store init");
+
+    // Acquire a fresh read connection from a temporary pool, since store.read_pool is private
+    let (read_pool, _write_pool) = create_sqlite_pool(&url).await.expect("pool");
+    let mut conn = read_pool.acquire().await.expect("acquire read conn");
+    let mut raw = conn.lock_handle().await.expect("lock_handle");
+
+    let mut cur: i32 = 0;
+    let mut hi: i32 = 0;
+
+    unsafe {
+        // Should succeed and write some non-negative values
+        let rc = sqlite3_db_status(
+            raw.as_raw_handle().as_mut(),
+            SQLITE_DBSTATUS_CACHE_USED,
+            &mut cur,
+            &mut hi,
+            0,
+        );
+        assert_eq!(rc, SQLITE_OK);
+        assert!(cur >= 0);
+
+        let rc2 = sqlite3_db_status(
+            raw.as_raw_handle().as_mut(),
+            SQLITE_DBSTATUS_SCHEMA_USED,
+            &mut cur,
+            &mut hi,
+            0,
+        );
+        assert_eq!(rc2, SQLITE_OK);
+        assert!(cur >= 0);
+    }
+}
+
 struct TestFolders {
     parent_folder: String,
     initial_folder: String,


### PR DESCRIPTION
Emit status metrics via sqlite3_db_status to track cache usage, hit/miss counters, lookaside allocator, schema/statement memory, and cache write/spill totals.