### PR TITLE
metrics: Enable sqlite status metrics by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -274,7 +274,7 @@ impl Default for Config {
             full_vacuum_on_start: true,
             full_vacuum_on_upkeep: false,
             vacuum_interval_ms: 30000,
-            enable_sqlite_status_metrics: false,
+            enable_sqlite_status_metrics: true,
         }
     }
 }


### PR DESCRIPTION
Sqlite status metrics have been enabled in s4s and look stable. Enable it for all other envs.