### PR TITLE
logs(consumer): fix info log when consumer partitions revoked

### DIFF
--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -162,7 +162,7 @@ impl ConsumerContext for KafkaContext {
                     Event::Revoke(tpl.to_topic_map().keys().cloned().collect()),
                     rendezvous_sender,
                 ));
-                info!("Partition assignment event sent, waiting for rendezvous...");
+                info!("Partition revocation event sent, waiting for rendezvous...");
                 let _ = rendezvous_receiver.recv();
                 info!("Rendezvous complete");
             }


### PR DESCRIPTION
Should say `Partition revocation event` instead of `Partition assignment event`