### PR TITLE
fix: Typo on release branch name for assembling image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -38,7 +38,7 @@ jobs:
   assemble-taskbroker-image:
     runs-on: ubuntu-latest
     needs: [build]
-    if: ${{ (github.ref_name == 'main' || startsWith(github.ref_name, 'releases/')) && github.event_name != 'pull_request' }}
+    if: ${{ (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) && github.event_name != 'pull_request' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
I wonder how the release pipeline is not broken after all this.