### PR TITLE
fix(deploy): GH actions check for correct job name

### DIFF
--- a/gocd/templates/bash/check-github-runs.sh
+++ b/gocd/templates/bash/check-github-runs.sh
@@ -3,5 +3,6 @@
 checks-githubactions-checkruns \
 	"getsentry/taskbroker" \
 	"${GO_REVISION_TASKBROKER_REPO}" \
-	"Build and push production images" \
+	"Build and push production images to single-region registry" \
+	"Build and push production images to multi-region registry" \
 	"Tests (ubuntu)"


### PR DESCRIPTION
Fix taskbroker deploy error since the job "Build and push production images" doesn't exist anymore and GoCD keeps checking for this.