### PR TITLE
ref: Fix panic in get_pending_activations

### DIFF
--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -613,8 +613,7 @@ impl InflightActivationStore {
         let namespaces = namespace.map(|ns| vec![ns.to_string()]);
         let result = self
             .get_pending_activations_from_namespaces(namespaces.as_deref(), Some(1))
-            .await
-            .unwrap();
+            .await?;
         if result.is_empty() {
             return Ok(None);
         }


### PR DESCRIPTION
This seems to have been unintentional, don't see a reason why we
shouldn't propagate that error.

Fix TASKBROKER-6K
