### PR TITLE
chore(release): Bump craft version

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: "0.27.2"
+minVersion: "2.19.0"
 changelogPolicy: auto
 artifactProvider:
   name: none
@@ -11,15 +11,6 @@ statusProvider:
     - 'assemble-taskbroker-image'
 preReleaseCommand: ""
 targets:
-- id: release
-  name: docker
-  source: ghcr.io/getsentry/taskbroker
-  target: getsentry/taskbroker
-- id: latest
-  name: docker
-  source: ghcr.io/getsentry/taskbroker
-  target: getsentry/taskbroker
-  targetFormat: '{{{target}}}:latest'
 - name: github
 versioning:
   policy: calver


### PR DESCRIPTION
Seeing this error on release for self-hosted: https://github.com/getsentry/taskbroker/actions/runs/21039796729/job/60507768284