### PR TITLE
feat(python): Move client.py and tests from python-client branch

### DIFF
--- a/clients/python/src/taskbroker_client/worker/client.py
+++ b/clients/python/src/taskbroker_client/worker/client.py
@@ -1,0 +1,350 @@
+import hashlib
+import hmac
+import logging
+import random
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import grpc
+import orjson
+from google.protobuf.message import Message
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
+    FetchNextTask,
+    GetTaskRequest,
+    SetTaskStatusRequest,
+)
+from sentry_protos.taskbroker.v1.taskbroker_pb2_grpc import ConsumerServiceStub
+
+from taskbroker_client.constants import (
+    DEFAULT_CONSECUTIVE_UNAVAILABLE_ERRORS,
+    DEFAULT_REBALANCE_AFTER,
+    DEFAULT_TEMPORARY_UNAVAILABLE_HOST_TIMEOUT,
+)
+from taskbroker_client.metrics import MetricsBackend
+from taskbroker_client.types import InflightTaskActivation, ProcessingResult
+
+logger = logging.getLogger("sentry.taskworker.client")
+
+MAX_ACTIVATION_SIZE = 1024 * 1024 * 10
+"""Max payload size we will process."""
+
+
+def make_broker_hosts(
+    host_prefix: str,
+    num_brokers: int | None,
+    host_list: str | None = None,
+) -> list[str]:
+    """
+    Handle RPC host CLI options and create a list of broker host:ports
+    """
+    if host_list:
+        stripped = map(lambda x: x.strip(), host_list.split(","))
+        return list(filter(lambda x: len(x), stripped))
+    if not num_brokers:
+        return [host_prefix]
+    domain, port = host_prefix.split(":")
+    return [f"{domain}-{i}:{port}" for i in range(0, num_brokers)]
+
+
+class ClientCallDetails(grpc.ClientCallDetails):
+    """
+    Subclass of grpc.ClientCallDetails that allows metadata to be updated
+    """
+
+    def __init__(
+        self,
+        method: str,
+        timeout: float | None,
+        metadata: tuple[tuple[str, str | bytes], ...] | None,
+        credentials: grpc.CallCredentials | None,
+    ):
+        self.timeout = timeout
+        self.method = method
+        self.metadata = metadata
+        self.credentials = credentials
+
+
+# Type alias based on grpc-stubs
+ContinuationType = Callable[[ClientCallDetails, Message], Any]
+
+
+if TYPE_CHECKING:
+    InterceptorBase = grpc.UnaryUnaryClientInterceptor[Message, Message]
+    CallFuture = grpc.CallFuture[Message]
+else:
+    InterceptorBase = grpc.UnaryUnaryClientInterceptor
+    CallFuture = Any
+
+
+class RequestSignatureInterceptor(InterceptorBase):
+    def __init__(self, shared_secret: list[str]):
+        self._secret = shared_secret[0].encode("utf-8")
+
+    def intercept_unary_unary(
+        self,
+        continuation: ContinuationType,
+        client_call_details: grpc.ClientCallDetails,
+        request: Message,
+    ) -> CallFuture:
+        request_body = request.SerializeToString()
+        method = client_call_details.method.encode("utf-8")
+
+        signing_payload = method + b":" + request_body
+        signature = hmac.new(self._secret, signing_payload, hashlib.sha256).hexdigest()
+
+        metadata = list(client_call_details.metadata) if client_call_details.metadata else []
+        metadata.append(("sentry-signature", signature))
+
+        call_details_with_meta = ClientCallDetails(
+            client_call_details.method,
+            client_call_details.timeout,
+            tuple(metadata),
+            client_call_details.credentials,
+        )
+        return continuation(call_details_with_meta, request)
+
+
+class HostTemporarilyUnavailable(Exception):
+    """Raised when a host is temporarily unavailable and should be retried later."""
+
+    pass
+
+
+@dataclass
+class HealthCheckSettings:
+    file_path: Path
+    touch_interval_sec: float
+
+
+class TaskbrokerClient:
+    """
+    Taskworker RPC client wrapper
+
+    When num_brokers is provided, the client will connect to all brokers
+    and choose a new broker to pair with randomly every max_tasks_before_rebalance tasks.
+    """
+
+    def __init__(
+        self,
+        hosts: list[str],
+        metrics: MetricsBackend,
+        max_tasks_before_rebalance: int = DEFAULT_REBALANCE_AFTER,
+        max_consecutive_unavailable_errors: int = DEFAULT_CONSECUTIVE_UNAVAILABLE_ERRORS,
+        temporary_unavailable_host_timeout: int = DEFAULT_TEMPORARY_UNAVAILABLE_HOST_TIMEOUT,
+        health_check_settings: HealthCheckSettings | None = None,
+        rpc_secret: str | None = None,
+        grpc_config: str | None = None,
+    ) -> None:
+        assert len(hosts) > 0, "You must provide at least one RPC host to connect to"
+        self._hosts = hosts
+        self._rpc_secret = rpc_secret
+        self._metrics = metrics
+
+        self._grpc_options: list[tuple[str, Any]] = [
+            ("grpc.max_receive_message_length", MAX_ACTIVATION_SIZE)
+        ]
+        if grpc_config:
+            self._grpc_options.append(("grpc.service_config", grpc_config))
+
+        logger.info(
+            "taskworker.client.start", extra={"hosts": hosts, "options": self._grpc_options}
+        )
+
+        self._cur_host = random.choice(self._hosts)
+        self._host_to_stubs: dict[str, ConsumerServiceStub] = {
+            self._cur_host: self._connect_to_host(self._cur_host)
+        }
+
+        self._max_tasks_before_rebalance = max_tasks_before_rebalance
+        self._num_tasks_before_rebalance = max_tasks_before_rebalance
+
+        self._max_consecutive_unavailable_errors = max_consecutive_unavailable_errors
+        self._num_consecutive_unavailable_errors = 0
+
+        self._temporary_unavailable_hosts: dict[str, float] = {}
+        self._temporary_unavailable_host_timeout = temporary_unavailable_host_timeout
+
+        self._health_check_settings = health_check_settings
+        self._timestamp_since_touch_lock = threading.Lock()
+        self._timestamp_since_touch = 0.0
+
+    def _emit_health_check(self) -> None:
+        if self._health_check_settings is None:
+            return
+
+        with self._timestamp_since_touch_lock:
+            cur_time = time.time()
+            if (
+                cur_time - self._timestamp_since_touch
+                < self._health_check_settings.touch_interval_sec
+            ):
+                return
+
+            self._health_check_settings.file_path.touch()
+            self._metrics.incr(
+                "taskworker.client.health_check.touched",
+            )
+            self._timestamp_since_touch = cur_time
+
+    def _connect_to_host(self, host: str) -> ConsumerServiceStub:
+        logger.info("taskworker.client.connect", extra={"host": host})
+        channel = grpc.insecure_channel(host, options=self._grpc_options)
+        if self._rpc_secret:
+            secrets = orjson.loads(self._rpc_secret)
+            channel = grpc.intercept_channel(channel, RequestSignatureInterceptor(secrets))
+        return ConsumerServiceStub(channel)
+
+    def _check_consecutive_unavailable_errors(self) -> None:
+        if self._num_consecutive_unavailable_errors >= self._max_consecutive_unavailable_errors:
+            self._temporary_unavailable_hosts[self._cur_host] = (
+                time.time() + self._temporary_unavailable_host_timeout
+            )
+
+    def _clear_temporary_unavailable_hosts(self) -> None:
+        hosts_to_remove = []
+        for host, timeout in self._temporary_unavailable_hosts.items():
+            if time.time() >= timeout:
+                hosts_to_remove.append(host)
+
+        for host in hosts_to_remove:
+            self._temporary_unavailable_hosts.pop(host)
+
+    def _get_cur_stub(self) -> tuple[str, ConsumerServiceStub]:
+        self._clear_temporary_unavailable_hosts()
+        available_hosts = [h for h in self._hosts if h not in self._temporary_unavailable_hosts]
+        if not available_hosts:
+            # If all hosts are temporarily unavailable, wait for the shortest timeout
+            current_time = time.time()
+            shortest_timeout = min(self._temporary_unavailable_hosts.values())
+            logger.info(
+                "taskworker.client.no_available_hosts",
+                extra={"sleeping for": shortest_timeout - current_time},
+            )
+            time.sleep(shortest_timeout - current_time)
+            return self._get_cur_stub()  # try again
+
+        if self._cur_host in self._temporary_unavailable_hosts:
+            self._cur_host = random.choice(available_hosts)
+            self._num_tasks_before_rebalance = self._max_tasks_before_rebalance
+            self._num_consecutive_unavailable_errors = 0
+            self._metrics.incr(
+                "taskworker.client.loadbalancer.rebalance",
+                tags={"reason": "unavailable_count_reached"},
+            )
+        elif self._num_tasks_before_rebalance == 0:
+            self._cur_host = random.choice(available_hosts)
+            self._num_tasks_before_rebalance = self._max_tasks_before_rebalance
+            self._num_consecutive_unavailable_errors = 0
+            self._metrics.incr(
+                "taskworker.client.loadbalancer.rebalance",
+                tags={"reason": "max_tasks_reached"},
+            )
+
+        if self._cur_host not in self._host_to_stubs:
+            self._host_to_stubs[self._cur_host] = self._connect_to_host(self._cur_host)
+
+        self._num_tasks_before_rebalance -= 1
+        return self._cur_host, self._host_to_stubs[self._cur_host]
+
+    def get_task(self, namespace: str | None = None) -> InflightTaskActivation | None:
+        """
+        Fetch a pending task.
+
+        If a namespace is provided, only tasks for that namespace will be fetched.
+        This will return None if there are no tasks to fetch.
+        """
+        self._emit_health_check()
+
+        request = GetTaskRequest(namespace=namespace)
+        try:
+            host, stub = self._get_cur_stub()
+            with self._metrics.timer("taskworker.get_task.rpc", tags={"host": host}):
+                response = stub.GetTask(request)
+        except grpc.RpcError as err:
+            self._metrics.incr(
+                "taskworker.client.rpc_error", tags={"method": "GetTask", "status": err.code().name}
+            )
+            if err.code() == grpc.StatusCode.NOT_FOUND:
+                # Because our current broker doesn't have any tasks, try rebalancing.
+                self._num_tasks_before_rebalance = 0
+                return None
+            if err.code() == grpc.StatusCode.UNAVAILABLE:
+                self._num_consecutive_unavailable_errors += 1
+                self._check_consecutive_unavailable_errors()
+            raise
+        self._num_consecutive_unavailable_errors = 0
+        self._temporary_unavailable_hosts.pop(host, None)
+        if response.HasField("task"):
+            self._metrics.incr(
+                "taskworker.client.get_task",
+                tags={"namespace": response.task.namespace},
+            )
+            return InflightTaskActivation(
+                activation=response.task, host=host, receive_timestamp=time.monotonic()
+            )
+        return None
+
+    def update_task(
+        self,
+        processing_result: ProcessingResult,
+        fetch_next_task: FetchNextTask | None = None,
+    ) -> InflightTaskActivation | None:
+        """
+        Update the status for a given task activation.
+
+        The return value is the next task that should be executed.
+        """
+        self._emit_health_check()
+
+        self._metrics.incr(
+            "taskworker.client.fetch_next", tags={"next": fetch_next_task is not None}
+        )
+        self._clear_temporary_unavailable_hosts()
+        request = SetTaskStatusRequest(
+            id=processing_result.task_id,
+            status=processing_result.status,
+            fetch_next_task=fetch_next_task,
+        )
+
+        try:
+            if processing_result.host in self._temporary_unavailable_hosts:
+                self._metrics.incr(
+                    "taskworker.client.skipping_set_task_due_to_unavailable_host",
+                    tags={"broker_host": processing_result.host},
+                )
+                raise HostTemporarilyUnavailable(
+                    f"Host: {processing_result.host} is temporarily unavailable"
+                )
+
+            with self._metrics.timer(
+                "taskworker.update_task.rpc", tags={"host": processing_result.host}
+            ):
+                response = self._host_to_stubs[processing_result.host].SetTaskStatus(request)
+        except grpc.RpcError as err:
+            self._metrics.incr(
+                "taskworker.client.rpc_error",
+                tags={"method": "SetTaskStatus", "status": err.code().name},
+            )
+            if err.code() == grpc.StatusCode.NOT_FOUND:
+                # The current broker is empty, switch.
+                self._num_tasks_before_rebalance = 0
+
+                return None
+            if err.code() == grpc.StatusCode.UNAVAILABLE:
+                self._num_consecutive_unavailable_errors += 1
+                self._check_consecutive_unavailable_errors()
+            raise
+
+        self._num_consecutive_unavailable_errors = 0
+        self._temporary_unavailable_hosts.pop(processing_result.host, None)
+        if response.HasField("task"):
+            return InflightTaskActivation(
+                activation=response.task,
+                host=processing_result.host,
+                receive_timestamp=time.monotonic(),
+            )
+        return None

--- a/clients/python/tests/worker/test_client.py
+++ b/clients/python/tests/worker/test_client.py
@@ -1,0 +1,917 @@
+import dataclasses
+import random
+import string
+import time
+from collections import defaultdict
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock, patch
+
+import grpc
+import pytest
+from google.protobuf.message import Message
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
+    TASK_ACTIVATION_STATUS_COMPLETE,
+    TASK_ACTIVATION_STATUS_RETRY,
+    FetchNextTask,
+    GetTaskResponse,
+    SetTaskStatusResponse,
+    TaskActivation,
+)
+
+from taskbroker_client.constants import DEFAULT_WORKER_HEALTH_CHECK_SEC_PER_TOUCH
+from taskbroker_client.metrics import NoOpMetricsBackend
+from taskbroker_client.types import ProcessingResult
+from taskbroker_client.worker.client import (
+    HealthCheckSettings,
+    HostTemporarilyUnavailable,
+    TaskbrokerClient,
+    make_broker_hosts,
+)
+
+
+@dataclasses.dataclass
+class MockServiceCall:
+    response: Any
+    metadata: tuple[tuple[str, str | bytes], ...] | None = None
+
+
+class MockServiceMethod:
+    """Stub for grpc service methods"""
+
+    def __init__(
+        self,
+        path: str,
+        responses: list[Any],
+        request_serializer: Callable[..., Any],
+        response_deserializer: Callable[..., Any],
+    ):
+        self.path = path
+        self.request_serializer = request_serializer
+        self.response_deserializer = response_deserializer
+        self.responses = responses
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Capture calls and use registered mocks"""
+        # move the head to the tail
+        res = self.responses[0]
+        tail = self.responses[1:]
+        self.responses = tail + [res]
+
+        if isinstance(res.response, Exception):
+            raise res.response
+        return res.response
+
+    def with_call(self, *args: Any, **kwargs: Any) -> Any:
+        res = self.responses[0]
+        if res.metadata:
+            assert res.metadata == kwargs.get("metadata"), "Metadata mismatch"
+        if isinstance(res.response, Exception):
+            raise res.response
+        return (res.response, None)
+
+
+class MockChannel:
+    def __init__(self) -> None:
+        self._responses: dict[str, list[Any]] = defaultdict(list)
+
+    def unary_unary(
+        self,
+        path: str,
+        request_serializer: Callable[..., Any],
+        response_deserializer: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> MockServiceMethod:
+        return MockServiceMethod(
+            path, self._responses.get(path, []), request_serializer, response_deserializer
+        )
+
+    def add_response(
+        self,
+        path: str,
+        resp: Message | Exception,
+        metadata: tuple[tuple[str, str | bytes], ...] | None = None,
+    ) -> None:
+        self._responses[path].append(MockServiceCall(response=resp, metadata=metadata))
+
+
+class MockGrpcError(grpc.RpcError):
+    """Grpc error are elusive and this mock simulates the interface in mypy stubs"""
+
+    def __init__(self, code: grpc.StatusCode, message: str) -> None:
+        self._code = code
+        self._message = message
+
+    def code(self) -> grpc.StatusCode:
+        return self._code
+
+    def details(self) -> str:
+        return self._message
+
+    def result(self) -> None:
+        raise self
+
+
+def test_make_broker_hosts() -> None:
+    hosts = make_broker_hosts(host_prefix="broker:50051", num_brokers=3)
+    assert len(hosts) == 3
+    assert hosts == ["broker-0:50051", "broker-1:50051", "broker-2:50051"]
+
+    hosts = make_broker_hosts(
+        host_prefix="",
+        num_brokers=None,
+        host_list="broker:50051, broker-a:50051 ,  , broker-b:50051",
+    )
+    assert len(hosts) == 3
+    assert hosts == ["broker:50051", "broker-a:50051", "broker-b:50051"]
+
+
+def test_init_no_hosts() -> None:
+    with pytest.raises(AssertionError) as err:
+        TaskbrokerClient(hosts=[], metrics=NoOpMetricsBackend())
+    assert "You must provide at least one RPC host" in str(err)
+
+
+def test_health_check_is_debounced() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        SetTaskStatusResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        health_check_path = Path(f"/tmp/{''.join(random.choices(string.ascii_letters, k=16))}")
+        client = TaskbrokerClient(
+            hosts=["localhost-0:50051"],
+            metrics=NoOpMetricsBackend(),
+            health_check_settings=HealthCheckSettings(health_check_path, 1),
+        )
+        client._health_check_settings.file_path = Mock()  # type: ignore[union-attr]
+
+        _ = client.get_task()
+        _ = client.get_task()
+        assert client._health_check_settings.file_path.touch.call_count == 1  # type: ignore[union-attr]
+
+        with patch("taskbroker_client.worker.client.time") as mock_time:
+            mock_time.time.return_value = time.time() + 1
+            _ = client.get_task()
+            assert client._health_check_settings.file_path.touch.call_count == 2  # type: ignore[union-attr]
+
+
+def test_get_task_ok() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(["localhost-0:50051"], metrics=NoOpMetricsBackend())
+        result = client.get_task()
+
+        assert result
+        assert result.host == "localhost-0:50051"
+        assert result.activation.id
+        assert result.activation.namespace == "testing"
+
+
+def test_get_task_writes_to_health_check_file() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        health_check_path = Path(f"/tmp/{''.join(random.choices(string.ascii_letters, k=16))}")
+        client = TaskbrokerClient(
+            ["localhost-0:50051"],
+            metrics=NoOpMetricsBackend(),
+            health_check_settings=HealthCheckSettings(health_check_path, 3),
+        )
+        _ = client.get_task()
+        assert health_check_path.exists()
+
+
+def test_get_task_with_interceptor() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+        metadata=(
+            (
+                "sentry-signature",
+                "3202702605c1b65055c28e7c78a5835e760830cff3e9f995eb7ad5f837130b1f",
+            ),
+        ),
+    )
+    secret = '["a long secret value","notused"]'
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(
+            ["localhost-0:50051"], metrics=NoOpMetricsBackend(), rpc_secret=secret
+        )
+        result = client.get_task()
+
+        assert result
+        assert result.host == "localhost-0:50051"
+        assert result.activation.id
+        assert result.activation.namespace == "testing"
+
+
+def test_get_task_with_namespace() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(
+            hosts=make_broker_hosts("localhost:50051", num_brokers=1), metrics=NoOpMetricsBackend()
+        )
+        result = client.get_task(namespace="testing")
+
+        assert result
+        assert result.host == "localhost-0:50051"
+        assert result.activation.id
+        assert result.activation.namespace == "testing"
+
+
+def test_get_task_not_found() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.NOT_FOUND, "no pending task found"),
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(["localhost:50051"], metrics=NoOpMetricsBackend())
+        result = client.get_task()
+
+        assert result is None
+
+
+def test_get_task_failure() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.INTERNAL, "something bad"),
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(["localhost:50051"], metrics=NoOpMetricsBackend())
+        with pytest.raises(grpc.RpcError):
+            client.get_task()
+
+
+def test_update_task_writes_to_health_check_file() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        SetTaskStatusResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        health_check_path = Path(f"/tmp/{''.join(random.choices(string.ascii_letters, k=16))}")
+        client = TaskbrokerClient(
+            make_broker_hosts("localhost:50051", num_brokers=1),
+            metrics=NoOpMetricsBackend(),
+            health_check_settings=HealthCheckSettings(
+                health_check_path, DEFAULT_WORKER_HEALTH_CHECK_SEC_PER_TOUCH
+            ),
+        )
+        _ = client.update_task(
+            ProcessingResult("abc123", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0),
+            FetchNextTask(namespace=None),
+        )
+        assert health_check_path.exists()
+
+
+def test_update_task_ok_with_next() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        SetTaskStatusResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(
+            make_broker_hosts("localhost:50051", num_brokers=1), metrics=NoOpMetricsBackend()
+        )
+        assert set(client._host_to_stubs.keys()) == {"localhost-0:50051"}
+        result = client.update_task(
+            ProcessingResult("abc123", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0),
+            FetchNextTask(namespace=None),
+        )
+
+        assert result
+        assert result.host == "localhost-0:50051"
+        assert result.activation.id == "abc123"
+
+
+def test_update_task_ok_with_next_namespace() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        SetTaskStatusResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(
+            make_broker_hosts("localhost:50051", num_brokers=1), metrics=NoOpMetricsBackend()
+        )
+        result = client.update_task(
+            ProcessingResult(
+                task_id="id",
+                status=TASK_ACTIVATION_STATUS_RETRY,
+                host="localhost-0:50051",
+                receive_timestamp=0,
+            ),
+            FetchNextTask(namespace="testing"),
+        )
+        assert result
+        assert result.activation.id == "abc123"
+        assert result.activation.namespace == "testing"
+
+
+def test_update_task_ok_no_next() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus", SetTaskStatusResponse()
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(
+            make_broker_hosts("localhost:50051", num_brokers=1), metrics=NoOpMetricsBackend()
+        )
+        result = client.update_task(
+            ProcessingResult(
+                task_id="abc123",
+                status=TASK_ACTIVATION_STATUS_RETRY,
+                host="localhost-0:50051",
+                receive_timestamp=0,
+            ),
+            FetchNextTask(namespace=None),
+        )
+        assert result is None
+
+
+def test_update_task_not_found() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        MockGrpcError(grpc.StatusCode.NOT_FOUND, "no pending tasks found"),
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(["localhost-0:50051"], metrics=NoOpMetricsBackend())
+        result = client.update_task(
+            ProcessingResult(
+                task_id="abc123",
+                status=TASK_ACTIVATION_STATUS_RETRY,
+                host="localhost-0:50051",
+                receive_timestamp=0,
+            ),
+            FetchNextTask(namespace=None),
+        )
+        assert result is None
+
+
+def test_update_task_unavailable_retain_task_to_host() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "broker down"),
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(["localhost-0:50051"], metrics=NoOpMetricsBackend())
+        with pytest.raises(MockGrpcError) as err:
+            client.update_task(
+                ProcessingResult(
+                    task_id="abc123",
+                    status=TASK_ACTIVATION_STATUS_RETRY,
+                    host="localhost-0:50051",
+                    receive_timestamp=0,
+                ),
+                FetchNextTask(namespace=None),
+            )
+        assert "broker down" in str(err.value)
+
+
+def test_client_loadbalance() -> None:
+    channel_0 = MockChannel()
+    channel_0.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="0",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    channel_0.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        SetTaskStatusResponse(task=None),
+    )
+    channel_1 = MockChannel()
+    channel_1.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="1",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    channel_1.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        SetTaskStatusResponse(task=None),
+    )
+    channel_2 = MockChannel()
+    channel_2.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="2",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    channel_2.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        SetTaskStatusResponse(task=None),
+    )
+    channel_3 = MockChannel()
+    channel_3.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="3",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    channel_3.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        SetTaskStatusResponse(task=None),
+    )
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.side_effect = [channel_0, channel_1, channel_2, channel_3]
+        with patch("taskbroker_client.worker.client.random.choice") as mock_randchoice:
+            mock_randchoice.side_effect = [
+                "localhost-0:50051",
+                "localhost-1:50051",
+                "localhost-2:50051",
+                "localhost-3:50051",
+            ]
+            client = TaskbrokerClient(
+                hosts=make_broker_hosts(host_prefix="localhost:50051", num_brokers=4),
+                metrics=NoOpMetricsBackend(),
+                max_tasks_before_rebalance=1,
+            )
+
+            task_0 = client.get_task()
+            assert task_0 is not None and task_0.activation.id == "0"
+            task_1 = client.get_task()
+            assert task_1 is not None and task_1.activation.id == "1"
+            task_2 = client.get_task()
+            assert task_2 is not None and task_2.activation.id == "2"
+            task_3 = client.get_task()
+            assert task_3 is not None and task_3.activation.id == "3"
+
+            client.update_task(
+                ProcessingResult(
+                    task_0.activation.id, TASK_ACTIVATION_STATUS_COMPLETE, task_0.host, 0
+                ),
+                None,
+            )
+            client.update_task(
+                ProcessingResult(
+                    task_1.activation.id, TASK_ACTIVATION_STATUS_COMPLETE, task_1.host, 0
+                ),
+                None,
+            )
+            client.update_task(
+                ProcessingResult(
+                    task_2.activation.id, TASK_ACTIVATION_STATUS_COMPLETE, task_2.host, 0
+                ),
+                None,
+            )
+            client.update_task(
+                ProcessingResult(
+                    task_3.activation.id, TASK_ACTIVATION_STATUS_COMPLETE, task_3.host, 0
+                ),
+                None,
+            )
+
+
+def test_client_loadbalance_on_notfound() -> None:
+    channel_0 = MockChannel()
+    channel_0.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.NOT_FOUND, "no pending task found"),
+    )
+
+    channel_1 = MockChannel()
+    channel_1.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="1",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    channel_1.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/SetTaskStatus",
+        MockGrpcError(grpc.StatusCode.NOT_FOUND, "no pending task found"),
+    )
+
+    channel_2 = MockChannel()
+    channel_2.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="2",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.side_effect = [channel_0, channel_1, channel_2]
+        with patch("taskbroker_client.worker.client.random.choice") as mock_randchoice:
+            mock_randchoice.side_effect = [
+                "localhost-0:50051",
+                "localhost-1:50051",
+                "localhost-2:50051",
+            ]
+            client = TaskbrokerClient(
+                hosts=make_broker_hosts(host_prefix="localhost:50051", num_brokers=3),
+                metrics=NoOpMetricsBackend(),
+                max_tasks_before_rebalance=30,
+            )
+
+            # Fetch from the first channel, it should return notfound
+            task_0 = client.get_task()
+            assert task_0 is None
+
+            # Fetch again, this time from channel_1
+            task_1 = client.get_task()
+            assert task_1 and task_1.activation.id == "1"
+
+            res = client.update_task(
+                ProcessingResult(
+                    task_1.activation.id, TASK_ACTIVATION_STATUS_COMPLETE, task_1.host, 0
+                ),
+                None,
+            )
+            assert res is None
+
+            # Because SetStatus on channel_1 returned notfound the client
+            # should switch brokers.
+            task_2 = client.get_task()
+            assert task_2 and task_2.activation.id == "2"
+
+
+def test_client_loadbalance_on_unavailable() -> None:
+    channel_0 = MockChannel()
+    channel_0.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "host is unavailable"),
+    )
+    channel_0.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "host is unavailable"),
+    )
+    channel_0.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "host is unavailable"),
+    )
+
+    channel_1 = MockChannel()
+    channel_1.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="1",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.side_effect = [channel_0, channel_1]
+        with patch("taskbroker_client.worker.client.random.choice") as mock_randchoice:
+            mock_randchoice.side_effect = [
+                "localhost-0:50051",
+                "localhost-1:50051",
+            ]
+            client = TaskbrokerClient(
+                hosts=make_broker_hosts(host_prefix="localhost:50051", num_brokers=2),
+                metrics=NoOpMetricsBackend(),
+                max_consecutive_unavailable_errors=3,
+            )
+
+            # Fetch from the first channel, host should be unavailable
+            with pytest.raises(grpc.RpcError, match="host is unavailable"):
+                client.get_task()
+            assert client._num_consecutive_unavailable_errors == 1
+
+            # Fetch from the first channel, host should be unavailable
+            with pytest.raises(grpc.RpcError, match="host is unavailable"):
+                client.get_task()
+            assert client._num_consecutive_unavailable_errors == 2
+
+            # Fetch from the first channel, host should be unavailable
+            with pytest.raises(grpc.RpcError, match="host is unavailable"):
+                client.get_task()
+            assert client._num_consecutive_unavailable_errors == 3
+
+            # Should rebalance to the second host and receive task
+            task = client.get_task()
+            assert task and task.activation.id == "1"
+            assert client._num_consecutive_unavailable_errors == 0
+
+
+def test_client_single_host_unavailable() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "host is unavailable"),
+    )
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "host is unavailable"),
+    )
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "host is unavailable"),
+    )
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="1",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+
+    with (patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel,):
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(
+            hosts=["localhost-0:50051"],
+            metrics=NoOpMetricsBackend(),
+            max_consecutive_unavailable_errors=3,
+            temporary_unavailable_host_timeout=2,
+        )
+
+        for _ in range(3):
+            with pytest.raises(grpc.RpcError, match="host is unavailable"):
+                client.get_task()
+        assert client._num_consecutive_unavailable_errors == 3
+
+        # Verify host was marked as temporarily unavailable
+        assert "localhost-0:50051" in client._temporary_unavailable_hosts
+        assert isinstance(client._temporary_unavailable_hosts["localhost-0:50051"], float)
+
+        client.get_task()
+        assert client._cur_host == "localhost-0:50051"
+
+
+def test_client_reset_errors_after_success() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "host is unavailable"),
+    )
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="1",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "host is unavailable"),
+    )
+
+    with patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(
+            ["localhost:50051"], metrics=NoOpMetricsBackend(), max_consecutive_unavailable_errors=3
+        )
+
+        with pytest.raises(grpc.RpcError, match="host is unavailable"):
+            client.get_task()
+        assert client._num_consecutive_unavailable_errors == 1
+
+        task = client.get_task()
+        assert task and task.activation.id == "1"
+        assert client._num_consecutive_unavailable_errors == 0
+
+        with pytest.raises(grpc.RpcError, match="host is unavailable"):
+            client.get_task()
+        assert client._num_consecutive_unavailable_errors == 1
+
+
+def test_client_update_task_host_unavailable() -> None:
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="1",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "host is unavailable"),
+    )
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "host is unavailable"),
+    )
+    channel.add_response(
+        "/sentry_protos.taskbroker.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.UNAVAILABLE, "host is unavailable"),
+    )
+
+    current_time = 1000.0
+
+    def mock_time() -> float:
+        return current_time
+
+    with (
+        patch("taskbroker_client.worker.client.grpc.insecure_channel") as mock_channel,
+        patch("taskbroker_client.worker.client.time.time", side_effect=mock_time),
+    ):
+        mock_channel.return_value = channel
+        client = TaskbrokerClient(
+            ["localhost:50051"],
+            metrics=NoOpMetricsBackend(),
+            max_consecutive_unavailable_errors=3,
+            temporary_unavailable_host_timeout=10,
+        )
+
+        # Get a task to establish the host mapping
+        task = client.get_task()
+        assert task and task.activation.id == "1"
+        host = task.host
+
+        # Make the host temporarily unavailable
+        for _ in range(3):
+            with pytest.raises(grpc.RpcError, match="host is unavailable"):
+                client.get_task()
+        assert client._num_consecutive_unavailable_errors == 3
+        assert host in client._temporary_unavailable_hosts
+
+        # Try to update the task
+        with pytest.raises(
+            HostTemporarilyUnavailable, match=f"Host: {host} is temporarily unavailable"
+        ):
+            client.update_task(
+                ProcessingResult(
+                    task_id="1",
+                    status=TASK_ACTIVATION_STATUS_COMPLETE,
+                    host=host,
+                    receive_timestamp=0,
+                ),
+                fetch_next_task=None,
+            )


### PR DESCRIPTION
Moves the client implementation and its test suite from the python-client branch to continue development on the chore-client-class branch.

Part of STREAM-605