### PR TITLE
chore: Fix lint build with rust 1.94

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 use figment::{
     Figment, Metadata, Profile, Provider,
     providers::{Env, Format, Yaml},


### PR DESCRIPTION
New clippy release doesn't like the size of figment::Error, but there aren't any newer releases to upgrade to.