### PR TITLE
ref(taskbroker): Consolidate Incomplete Status Count Queries

### DIFF
--- a/src/kafka/inflight_activation_writer.rs
+++ b/src/kafka/inflight_activation_writer.rs
@@ -10,7 +10,7 @@ use tracing::{debug, error, instrument};
 use crate::{
     config::Config,
     store::inflight_activation::{
-        InflightActivation, InflightActivationStatus, InflightActivationStore,
+        DepthCounts, InflightActivation, InflightActivationStatus, InflightActivationStore,
     },
 };
 
@@ -80,27 +80,21 @@ impl Reducer for InflightActivationWriter {
             self.batch.take();
             return Ok(Some(()));
         }
+
         // Check if writing the batch would exceed the limits
-        let exceeded_pending_limit = self
+        let DepthCounts {
+            pending,
+            delay,
+            processing,
+        } = self
             .store
-            .count_pending_activations()
+            .count_depths()
             .await
-            .expect("Error communicating with activation store")
-            + batch.len()
-            > self.config.max_pending_activations;
-        let exceeded_delay_limit = self
-            .store
-            .count_by_status(InflightActivationStatus::Delay)
-            .await
-            .expect("Error communicating with activation store")
-            + batch.len()
-            > self.config.max_delay_activations;
-        let exceeded_processing_limit = self
-            .store
-            .count_by_status(InflightActivationStatus::Processing)
-            .await
-            .expect("Error communicating with activation store")
-            >= self.config.max_processing_activations;
+            .expect("Error communicating with activation store");
+
+        let exceeded_pending_limit = pending + batch.len() > self.config.max_pending_activations;
+        let exceeded_delay_limit = delay + batch.len() > self.config.max_delay_activations;
+        let exceeded_processing_limit = processing >= self.config.max_processing_activations;
         let exceeded_db_size = if let Some(db_max_size) = self.config.db_max_size {
             self.store
                 .db_size()

--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -11,19 +11,20 @@ use libsqlite3_sys::{
     SQLITE_OK, sqlite3_db_status,
 };
 use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivationStatus};
-use sqlx::{
-    ConnectOptions, FromRow, Pool, QueryBuilder, Row, Sqlite, Type,
-    migrate::MigrateDatabase,
-    pool::{PoolConnection, PoolOptions},
-    postgres::PgQueryResult,
-    sqlite::{
-        SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqliteQueryResult,
-        SqliteRow, SqliteSynchronous,
-    },
+use tokio::join;
+use tracing::{instrument, warn};
+
+use sqlx::migrate::MigrateDatabase;
+use sqlx::pool::{PoolConnection, PoolOptions};
+use sqlx::postgres::PgQueryResult;
+use sqlx::sqlite::{
+    SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqliteQueryResult,
+    SqliteRow, SqliteSynchronous,
 };
+use sqlx::{ConnectOptions, FromRow, Pool, QueryBuilder, Row, Sqlite, Type};
+
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::{str::FromStr, time::Instant};
-use tracing::{instrument, warn};
 
 use crate::config::Config;
 
@@ -335,6 +336,18 @@ impl InflightActivationStoreConfig {
     }
 }
 
+/// Counts pending, delayed, and processing tasks for backpressure and upkeep.
+pub struct DepthCounts {
+    /// The number of pending tasks in the store.
+    pub pending: usize,
+
+    /// Number of delayed tasks in the store.
+    pub delay: usize,
+
+    /// The number of processing tasks in the store.
+    pub processing: usize,
+}
+
 #[async_trait]
 pub trait InflightActivationStore: Send + Sync {
     /// Trigger incremental vacuum to reclaim free pages in the database
@@ -399,6 +412,22 @@ pub trait InflightActivationStore: Send + Sync {
 
     /// Count all activations
     async fn count(&self) -> Result<usize, Error>;
+
+    /// Queue depths for pending, delay, and processing (writer backpressure and upkeep gauges).
+    /// Default implementation uses separate calls, but stores may override with a single query.
+    async fn count_depths(&self) -> Result<DepthCounts, Error> {
+        let (pending, delay, processing) = join!(
+            self.count_by_status(InflightActivationStatus::Pending),
+            self.count_by_status(InflightActivationStatus::Delay),
+            self.count_by_status(InflightActivationStatus::Processing),
+        );
+
+        Ok(DepthCounts {
+            pending: pending?,
+            delay: delay?,
+            processing: processing?,
+        })
+    }
 
     /// Update the status of a specific activation
     async fn set_status(

--- a/src/store/inflight_activation_tests.rs
+++ b/src/store/inflight_activation_tests.rs
@@ -127,6 +127,75 @@ async fn test_store(#[case] adapter: &str) {
 #[rstest]
 #[case::sqlite("sqlite")]
 #[case::postgres("postgres")]
+async fn test_count_depths(#[case] adapter: &str) {
+    let store = create_test_store(adapter).await;
+
+    // Check counts for an empty store
+    let pending = store
+        .count_by_status(InflightActivationStatus::Pending)
+        .await
+        .unwrap();
+    let delay = store
+        .count_by_status(InflightActivationStatus::Delay)
+        .await
+        .unwrap();
+    let processing = store
+        .count_by_status(InflightActivationStatus::Processing)
+        .await
+        .unwrap();
+
+    let depths = store.count_depths().await.unwrap();
+
+    assert_eq!(depths.pending, pending);
+    assert_eq!(depths.delay, delay);
+    assert_eq!(depths.processing, processing);
+
+    // Check counts for a store with four activations with varying statuses
+    let batch = make_activations(4);
+    assert!(store.store(batch).await.is_ok());
+
+    store
+        .set_status("id_0", InflightActivationStatus::Processing)
+        .await
+        .unwrap();
+    store
+        .set_status("id_1", InflightActivationStatus::Delay)
+        .await
+        .unwrap();
+    store
+        .set_status("id_2", InflightActivationStatus::Complete)
+        .await
+        .unwrap();
+
+    let pending = store
+        .count_by_status(InflightActivationStatus::Pending)
+        .await
+        .unwrap();
+    let delay = store
+        .count_by_status(InflightActivationStatus::Delay)
+        .await
+        .unwrap();
+    let processing = store
+        .count_by_status(InflightActivationStatus::Processing)
+        .await
+        .unwrap();
+
+    let depths = store.count_depths().await.unwrap();
+
+    assert_eq!(depths.pending, pending, "pending");
+    assert_eq!(depths.delay, delay, "delay");
+    assert_eq!(depths.processing, processing, "processing");
+    assert_eq!(pending, 1);
+    assert_eq!(delay, 1);
+    assert_eq!(processing, 1);
+
+    store.remove_db().await.unwrap();
+}
+
+#[tokio::test]
+#[rstest]
+#[case::sqlite("sqlite")]
+#[case::postgres("postgres")]
 async fn test_store_duplicate_id_in_batch(#[case] adapter: &str) {
     let store = create_test_store(adapter).await;
 

--- a/src/store/postgres_activation_store.rs
+++ b/src/store/postgres_activation_store.rs
@@ -1,6 +1,6 @@
 use crate::store::inflight_activation::{
-    FailedTasksForwarder, InflightActivation, InflightActivationStatus, InflightActivationStore,
-    QueryResult, TableRow,
+    DepthCounts, FailedTasksForwarder, InflightActivation, InflightActivationStatus,
+    InflightActivationStore, QueryResult, TableRow,
 };
 use anyhow::{Error, anyhow};
 use async_trait::async_trait;
@@ -371,6 +371,28 @@ impl InflightActivationStore for PostgresActivationStore {
             .fetch_one(&self.read_pool)
             .await?;
         Ok(result.get::<i64, _>("count") as usize)
+    }
+
+    #[instrument(skip_all)]
+    async fn count_depths(&self) -> Result<DepthCounts, Error> {
+        let sql = "
+             SELECT COUNT(*) FILTER (WHERE status = $1) AS pending,
+                    COUNT(*) FILTER (WHERE status = $2) AS delay,
+                    COUNT(*) FILTER (WHERE status = $3) AS processing
+             FROM inflight_taskactivations";
+
+        let row: (i64, i64, i64) = sqlx::query_as(sql)
+            .bind(InflightActivationStatus::Pending.to_string())
+            .bind(InflightActivationStatus::Delay.to_string())
+            .bind(InflightActivationStatus::Processing.to_string())
+            .fetch_one(&self.read_pool)
+            .await?;
+
+        Ok(DepthCounts {
+            pending: row.0 as usize,
+            delay: row.1 as usize,
+            processing: row.2 as usize,
+        })
     }
 
     /// Update the status of a specific activation

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -1,29 +1,24 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
 use chrono::{DateTime, Timelike, Utc};
 use futures::{StreamExt, stream::FuturesUnordered};
 use prost::Message;
 use prost_types::Timestamp;
 use rdkafka::error::KafkaError;
-use rdkafka::{
-    producer::{FutureProducer, FutureRecord},
-    util::Timeout,
-};
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::util::Timeout;
 use sentry_protos::taskbroker::v1::TaskActivation;
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
 use tokio::{fs, join, select, time};
 use tonic_health::ServingStatus;
 use tonic_health::server::HealthReporter;
 use tracing::{debug, error, info, instrument};
 use uuid::Uuid;
 
-use crate::{
-    SERVICE_NAME,
-    config::Config,
-    runtime_config::RuntimeConfigManager,
-    store::inflight_activation::{InflightActivationStatus, InflightActivationStore},
-};
+use crate::SERVICE_NAME;
+use crate::config::Config;
+use crate::runtime_config::RuntimeConfigManager;
+use crate::store::inflight_activation::InflightActivationStore;
 
 /// The upkeep task that periodically performs upkeep
 /// on the inflight store
@@ -370,23 +365,17 @@ pub async fn do_upkeep(
     }
 
     let now = Utc::now();
-    let (pending_count, processing_count, delay_count, max_lag, db_file_meta, wal_file_meta) = join!(
-        store.count_by_status(InflightActivationStatus::Pending),
-        store.count_by_status(InflightActivationStatus::Processing),
-        store.count_by_status(InflightActivationStatus::Delay),
+    let (depth_counts, max_lag, db_file_meta, wal_file_meta) = join!(
+        store.count_depths(),
         store.pending_activation_max_lag(&now),
         fs::metadata(config.db_path.clone()),
         fs::metadata(config.db_path.clone() + "-wal")
     );
 
-    if let Ok(pending_count) = pending_count {
-        result_context.pending = pending_count as u32;
-    }
-    if let Ok(processing_count) = processing_count {
-        result_context.processing = processing_count as u32;
-    }
-    if let Ok(delay_count) = delay_count {
-        result_context.delay = delay_count as u32;
+    if let Ok(depths) = depth_counts {
+        result_context.pending = depths.pending as u32;
+        result_context.delay = depths.delay as u32;
+        result_context.processing = depths.processing as u32;
     }
 
     if !result_context.empty() {


### PR DESCRIPTION
## Linear
Completes [STREAM-847](https://linear.app/getsentry/issue/STREAM-847/consolidate-incomplete-status-count-queries)

## Description
Currently, taskworkers pull tasks from taskbrokers via RPC. This approach works, but has some drawbacks. Therefore, we want taskbrokers to _push_ tasks to taskworkers instead. Read [this](https://www.notion.so/sentry/Push-Task-Broker-2c58b10e4b5d8045814fc6aa87491ae5?source=copy_link) page on Notion for more information.

The upkeep task and activation writer execute queries to count the number of pending, delayed, and processing tasks separately and sequentially. By combining these queries into one, we can reduce load on the database and reduce latency due to multiple round trips.

## Details
- Adds a `count_depths` method to the store trait along with a default implementation (three queries) and an optimized implementation (one query) for Postgres
- Adds a `DepthCounts` struct to contain the results of `count_depths`
- Adds testing to make sure there is no difference between calling `count_depths` and `count_by_status` three times