### PR TITLE
feat(taskbroker): Implement Global Backoff Mechanism

### DIFF
--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -1,0 +1,180 @@
+use std::{
+    sync::atomic::{AtomicU32, Ordering},
+    time::Duration,
+};
+
+use crate::config::Config;
+
+/// Shared leaky bucket wait to pace fetching in push mode.
+/// Certain events, such as submission failures, can call `increase` to increment `wait_ms` by `increment_ms` milliseconds.
+/// Before submitting each task to the push pool, a fetch thread will sleep `wait_ms` milliseconds first.
+/// Every `decay_interval` milliseconds, the value of `wait_ms` is decremented by `decay_amount_ms`.
+/// The value of `wait_ms` is capped at `max_wait_ms`.
+pub struct Backoff {
+    wait_ms: AtomicU32,
+    increment_ms: u32,
+    max_wait_ms: u32,
+    decay_interval_ms: u64,
+    decay_amount_ms: u32,
+}
+
+impl Backoff {
+    /// When `backoff_max_wait_ms` is zero, `increase` and `decay_tick` are NOPs.
+    pub fn from_config(config: &Config) -> Self {
+        Self {
+            wait_ms: AtomicU32::new(0),
+            increment_ms: config.backoff_increment_ms,
+            max_wait_ms: config.backoff_max_wait_ms,
+            decay_interval_ms: config.backoff_decay_interval_ms,
+            decay_amount_ms: config.backoff_decay_amount_ms,
+        }
+    }
+
+    /// Whether the decay task should run (push mode only; see `main`).
+    pub fn decays(&self) -> bool {
+        self.max_wait_ms > 0
+    }
+
+    pub fn decay_interval(&self) -> Duration {
+        Duration::from_millis(self.decay_interval_ms)
+    }
+
+    /// Add `increment_ms`, clamped to `max_wait_ms`. Does nothing if `increment_ms` is zero.
+    pub fn increase(&self) {
+        if self.increment_ms == 0 {
+            return;
+        }
+
+        let mut current = self.wait_ms.load(Ordering::Relaxed);
+        loop {
+            if current >= self.max_wait_ms {
+                return;
+            }
+
+            let new = (current + self.increment_ms).min(self.max_wait_ms);
+            match self.wait_ms.compare_exchange_weak(
+                current,
+                new,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    metrics::gauge!("push.backoff.wait_ms").set(new as f64);
+                    return;
+                }
+
+                Err(c) => current = c,
+            }
+        }
+    }
+
+    /// Get the current wait time.
+    pub fn get(&self) -> u32 {
+        self.wait_ms.load(Ordering::Relaxed)
+    }
+
+    /// Decrement the current wait time.
+    pub fn decay_tick(&self) {
+        if self.max_wait_ms == 0 {
+            // Global backoff not enabled
+            return;
+        }
+
+        let _ = self
+            .wait_ms
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                Some(v.saturating_sub(self.decay_amount_ms))
+            });
+
+        metrics::gauge!("push.backoff.wait_ms").set(self.get() as f64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(max: u32, increment: u32, decay_amt: u32) -> Config {
+        Config {
+            backoff_max_wait_ms: max,
+            backoff_increment_ms: increment,
+            backoff_decay_interval_ms: 10,
+            backoff_decay_amount_ms: decay_amt,
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn increase_respects_cap() {
+        let b = Backoff::from_config(&cfg(100, 40, 10));
+
+        b.increase();
+        assert_eq!(b.get(), 40);
+
+        b.increase();
+        assert_eq!(b.get(), 80);
+
+        b.increase();
+        assert_eq!(b.get(), 100);
+
+        b.increase();
+        assert_eq!(b.get(), 100);
+    }
+
+    #[test]
+    fn decay_tick_reduces_wait() {
+        let b = Backoff::from_config(&cfg(100, 50, 15));
+
+        b.increase();
+        assert_eq!(b.get(), 50);
+
+        b.decay_tick();
+        assert_eq!(b.get(), 35);
+
+        b.decay_tick();
+        assert_eq!(b.get(), 20);
+
+        b.decay_tick();
+        assert_eq!(b.get(), 5);
+
+        b.decay_tick();
+        assert_eq!(b.get(), 0);
+    }
+
+    #[test]
+    fn disabled_is_no_op() {
+        let b = Backoff::from_config(&Config::default());
+        assert!(!b.decays());
+
+        b.increase();
+        assert_eq!(b.get(), 0);
+
+        b.decay_tick();
+        assert_eq!(b.get(), 0);
+    }
+
+    #[test]
+    fn concurrent_increase_and_decay_stays_bounded() {
+        let b = std::sync::Arc::new(Backoff::from_config(&cfg(200, 5, 3)));
+        let mut handles = vec![];
+
+        for _ in 0..8 {
+            let x = b.clone();
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..100 {
+                    x.increase();
+                }
+            }));
+        }
+
+        for _ in 0..20 {
+            b.decay_tick();
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert!(b.get() <= 200);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -290,6 +290,18 @@ pub struct Config {
 
     /// List of namespaces for push mode. When set, application must also be set (store requirement).
     pub namespaces: Option<Vec<String>>,
+
+    /// Maximum sleep for global backoff.
+    pub backoff_max_wait_ms: u32,
+
+    /// How much wait (ms) to add per backoff signal, like a submit or push failure.
+    pub backoff_increment_ms: u32,
+
+    /// How often the backoff wait decays (ms).
+    pub backoff_decay_interval_ms: u64,
+
+    /// How much wait (ms) to subtract each decay tick.
+    pub backoff_decay_amount_ms: u32,
 }
 
 impl Default for Config {
@@ -372,6 +384,10 @@ impl Default for Config {
             callback_port: 50051,
             application: None,
             namespaces: None,
+            backoff_max_wait_ms: 0,
+            backoff_increment_ms: 100,
+            backoff_decay_interval_ms: 1000,
+            backoff_decay_amount_ms: 100,
         }
     }
 }

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -7,6 +7,7 @@ use tokio::time::sleep;
 use tonic::async_trait;
 use tracing::{debug, info, warn};
 
+use crate::backoff::Backoff;
 use crate::config::Config;
 use crate::push::{PushError, PushPool};
 use crate::store::inflight_activation::{BucketRange, InflightActivation, InflightActivationStore};
@@ -67,6 +68,9 @@ pub struct FetchPool<T: TaskPusher> {
 
     /// Taskbroker configuration.
     config: Arc<Config>,
+
+    /// Shared backoff; fetch sleeps [`Backoff::get`] ms at the start of each iteration when non-zero.
+    backoff: Arc<Backoff>,
 }
 
 impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
@@ -75,23 +79,25 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
         store: Arc<dyn InflightActivationStore>,
         config: Arc<Config>,
         pusher: Arc<T>,
+        backoff: Arc<Backoff>,
     ) -> Self {
         Self {
             store,
             config,
             pusher,
+            backoff,
         }
     }
 
     /// Spawns one task per effective fetch thread ([`normalize_fetch_threads`]), each claiming pending work only in its bucket subrange.
     pub async fn start(&self) -> Result<()> {
-        let fetch_wait_ms = self.config.fetch_wait_ms;
         let fetch_threads = normalize_fetch_threads(self.config.fetch_threads);
 
         let mut fetch_pool = crate::tokio::spawn_pool(fetch_threads, |thread_index| {
             let store = self.store.clone();
             let pusher = self.pusher.clone();
             let config = self.config.clone();
+            let backoff = self.backoff.clone();
 
             let limit = Some(config.fetch_batch_size.max(1));
             let bucket = Some(bucket_range_for_fetch_thread(thread_index, fetch_threads));
@@ -111,7 +117,6 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                             metrics::counter!("fetch.loop.count").increment(1);
 
                             let start = Instant::now();
-                            let mut backoff = false;
 
                             let application = config.application.as_deref();
                             let namespaces = config.namespaces.as_deref();
@@ -124,13 +129,19 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                     debug!("No pending activations");
 
                                     // Wait for pending activations to appear
-                                    backoff = true;
+                                    sleep(Duration::from_millis(config.fetch_wait_ms)).await;
                                 }
 
                                 Ok(activations) => {
                                     debug!("Fetched {} activations", activations.len());
 
                                     for activation in activations {
+                                        let w = backoff.get();
+
+                                        if w > 0 {
+                                            sleep(Duration::from_millis(w as u64)).await;
+                                        }
+
                                         let id = activation.id.clone();
 
                                         if let Err(e) = pusher.push_task(activation).await {
@@ -148,11 +159,9 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                                 )
                                             }
 
-                                            backoff = true;
+                                            backoff.increase();
                                         }
                                     }
-
-
                                 }
 
                                 Err(e) => {
@@ -162,16 +171,12 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                     );
 
                                     // Store may be down, wait before trying again
-                                    backoff = true;
+                                    sleep(Duration::from_millis(config.fetch_wait_ms)).await;
                                 }
                             };
 
                             metrics::histogram!("fetch.loop.duration")
                                 .record(start.elapsed());
-
-                            if backoff {
-                                sleep(Duration::from_millis(fetch_wait_ms)).await;
-                            }
                         } => {}
                     }
                 }

--- a/src/fetch/tests.rs
+++ b/src/fetch/tests.rs
@@ -7,6 +7,7 @@ use tokio::time::{Duration, sleep};
 use tonic::async_trait;
 
 use super::*;
+use crate::backoff::Backoff;
 use crate::config::Config;
 use crate::push::PushError;
 use crate::store::inflight_activation::InflightActivationStore;
@@ -207,13 +208,17 @@ fn test_config() -> Arc<Config> {
     })
 }
 
+fn test_backoff() -> Arc<Backoff> {
+    Arc::new(Backoff::from_config(test_config().as_ref()))
+}
+
 #[tokio::test]
 async fn fetch_pool_delivers_activation_to_pusher() {
     let activation = make_activations(1).remove(0);
     let store: Arc<dyn InflightActivationStore> = Arc::new(MockStore::one(activation.clone()));
     let pusher = Arc::new(RecordingPusher::new(false));
 
-    let pool = FetchPool::new(store, test_config(), pusher.clone());
+    let pool = FetchPool::new(store, test_config(), pusher.clone(), test_backoff());
     let handle = tokio::spawn(async move { pool.start().await });
 
     sleep(Duration::from_millis(200)).await;
@@ -228,7 +233,7 @@ async fn fetch_pool_calls_pusher_once_when_push_errors() {
     let store: Arc<dyn InflightActivationStore> = Arc::new(MockStore::one(activation));
     let pusher = Arc::new(RecordingPusher::new(true));
 
-    let pool = FetchPool::new(store, test_config(), pusher.clone());
+    let pool = FetchPool::new(store, test_config(), pusher.clone(), test_backoff());
     let handle = tokio::spawn(async move { pool.start().await });
 
     sleep(Duration::from_millis(100)).await;
@@ -242,7 +247,7 @@ async fn fetch_pool_skips_pusher_when_store_errors() {
     let store: Arc<dyn InflightActivationStore> = Arc::new(MockStore::error());
     let pusher = Arc::new(RecordingPusher::new(false));
 
-    let pool = FetchPool::new(store, test_config(), pusher.clone());
+    let pool = FetchPool::new(store, test_config(), pusher.clone(), test_backoff());
     let handle = tokio::spawn(async move { pool.start().await });
 
     sleep(Duration::from_millis(80)).await;
@@ -256,7 +261,7 @@ async fn fetch_pool_skips_pusher_when_no_pending() {
     let store: Arc<dyn InflightActivationStore> = Arc::new(MockStore::empty());
     let pusher = Arc::new(RecordingPusher::new(false));
 
-    let pool = FetchPool::new(store, test_config(), pusher.clone());
+    let pool = FetchPool::new(store, test_config(), pusher.clone(), test_backoff());
     let handle = tokio::spawn(async move { pool.start().await });
 
     sleep(Duration::from_millis(80)).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use std::fs;
 
+pub mod backoff;
 pub mod config;
 pub mod fetch;
 pub mod grpc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use anyhow::{Error, anyhow};
 use chrono::Utc;
 use clap::Parser;
+use elegant_departure::get_shutdown_guard;
 use std::{sync::Arc, time::Duration};
+use taskbroker::backoff::Backoff;
 use taskbroker::fetch::FetchPool;
 use taskbroker::kafka::inflight_activation_batcher::{
     ActivationBatcherConfig, InflightActivationBatcher,
@@ -130,7 +132,7 @@ async fn main() -> Result<(), Error> {
 
     // Maintenance task loop
     let maintenance_task = tokio::spawn({
-        let guard = elegant_departure::get_shutdown_guard().shutdown_on_drop();
+        let guard = get_shutdown_guard().shutdown_on_drop();
         let maintenance_store = store.clone();
         let mut timer = time::interval(Duration::from_millis(config.maintenance_task_interval_ms));
         timer.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
@@ -214,7 +216,7 @@ async fn main() -> Result<(), Error> {
                 .add_service(health_service.clone())
                 .serve(addr);
 
-            let guard = elegant_departure::get_shutdown_guard().shutdown_on_drop();
+            let guard = get_shutdown_guard().shutdown_on_drop();
             info!("GRPC server listening on {}", addr);
             select! {
                 biased;
@@ -240,9 +242,39 @@ async fn main() -> Result<(), Error> {
         }
     });
 
+    // Global backoff mechanism for push mode
+    let backoff = Arc::new(Backoff::from_config(&config));
+
+    let backoff_decay_task = if config.delivery_mode == DeliveryMode::Push && backoff.decays() {
+        let backoff = backoff.clone();
+
+        Some(tokio::spawn(async move {
+            let guard = get_shutdown_guard().shutdown_on_drop();
+
+            let mut timer = time::interval(backoff.decay_interval());
+            timer.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+            loop {
+                select! {
+                    _ = timer.tick() => backoff.decay_tick(),
+                    _ = guard.wait() => break,
+                }
+            }
+
+            Ok(())
+        }))
+    } else {
+        None
+    };
+
     // Initialize push and fetch pools
-    let push_pool = Arc::new(PushPool::new(config.clone()));
-    let fetch_pool = FetchPool::new(store.clone(), config.clone(), push_pool.clone());
+    let push_pool = Arc::new(PushPool::new(config.clone(), backoff.clone()));
+    let fetch_pool = FetchPool::new(
+        store.clone(),
+        config.clone(),
+        push_pool.clone(),
+        backoff.clone(),
+    );
 
     // Initialize push threads
     let push_task = if config.delivery_mode == DeliveryMode::Push {
@@ -274,6 +306,10 @@ async fn main() -> Result<(), Error> {
 
     if let Some(task) = fetch_task {
         departure = departure.on_completion(log_task_completion("fetch_task", task));
+    }
+
+    if let Some(task) = backoff_decay_task {
+        departure = departure.on_completion(log_task_completion("backoff_decay_task", task));
     }
 
     departure.await;

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -15,6 +15,7 @@ use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
 use tracing::{debug, error, info};
 
+use crate::backoff::Backoff;
 use crate::config::Config;
 use crate::store::inflight_activation::InflightActivation;
 
@@ -88,26 +89,33 @@ pub struct PushPool {
 
     /// Taskbroker configuration.
     config: Arc<Config>,
+
+    /// Shared backoff, which grows on submit/push failures.
+    backoff: Arc<Backoff>,
 }
 
 impl PushPool {
     /// Initialize a new push pool.
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Arc<Config>, backoff: Arc<Backoff>) -> Self {
         let (sender, receiver) = flume::bounded(config.push_queue_size);
 
         Self {
             sender,
             receiver,
             config,
+            backoff,
         }
     }
 
     /// Spawn `config.push_threads` asynchronous tasks, each of which repeatedly moves pending activations from the channel to the worker service until the shutdown signal is received.
     pub async fn start(&self) -> Result<()> {
+        let backoff = self.backoff.clone();
+
         let mut push_pool: JoinSet<Result<()>> =
             crate::tokio::spawn_pool(self.config.push_threads, |_| {
                 let endpoint = self.config.worker_endpoint.clone();
                 let receiver = self.receiver.clone();
+                let backoff = backoff.clone();
 
                 let guard = get_shutdown_guard().shutdown_on_drop();
 
@@ -161,11 +169,15 @@ impl PushPool {
                                     Ok(_) => debug!(task_id = %id, "Activation sent to worker"),
 
                                     // Once processing deadline expires, status will be set back to pending
-                                    Err(e) => error!(
-                                        task_id = %id,
-                                        error = ?e,
-                                        "Failed to send activation to worker"
-                                    )
+                                    Err(e) => {
+                                        backoff.increase();
+
+                                        error!(
+                                            task_id = %id,
+                                            error = ?e,
+                                            "Failed to send activation to worker"
+                                        );
+                                    }
                                 };
                             }
                         }
@@ -188,11 +200,15 @@ impl PushPool {
                             Ok(_) => debug!(task_id = %id, "Activation sent to worker"),
 
                             // Once processing deadline expires, status will be set back to pending
-                            Err(e) => error!(
-                                task_id = %id,
-                                error = ?e,
-                                "Failed to send activation to worker"
-                            ),
+                            Err(e) => {
+                                backoff.increase();
+
+                                error!(
+                                    task_id = %id,
+                                    error = ?e,
+                                    "Failed to send activation to worker"
+                                );
+                            }
                         };
                     }
 

--- a/src/push/tests.rs
+++ b/src/push/tests.rs
@@ -6,6 +6,7 @@ use tokio::time::{Duration, timeout};
 use tonic::async_trait;
 
 use super::*;
+use crate::backoff::Backoff;
 use crate::config::Config;
 use crate::test_utils::make_activations;
 
@@ -117,7 +118,10 @@ async fn push_pool_submit_enqueues_item() {
         ..Config::default()
     });
 
-    let pool = PushPool::new(config);
+    let pool = PushPool::new(
+        config.clone(),
+        Arc::new(Backoff::from_config(config.as_ref())),
+    );
     let activation = make_activations(1).remove(0);
 
     let result = pool.submit(activation).await;
@@ -131,7 +135,10 @@ async fn push_pool_submit_backpressures_when_queue_full() {
         ..Config::default()
     });
 
-    let pool = PushPool::new(config);
+    let pool = PushPool::new(
+        config.clone(),
+        Arc::new(Backoff::from_config(config.as_ref())),
+    );
 
     let first = make_activations(1).remove(0);
     let second = make_activations(1).remove(0);


### PR DESCRIPTION
## Linear
Completes [STREAM-862](https://linear.app/getsentry/issue/STREAM-862/implement-global-backoff-mechanism)

## Description
Currently, taskworkers pull tasks from taskbrokers via RPC. This approach works, but has some drawbacks. Therefore, we want taskbrokers to push tasks to taskworkers instead. Read [this](https://www.notion.so/sentry/Push-Task-Broker-2c58b10e4b5d8045814fc6aa87491ae5?source=copy_link) page on Notion for more information.

This PR introduces a dynamic global backoff mechanism to slow down the push rate when workers are busy. Here is the basic idea...
* Every time there is a submit or push failure, we increase the global backoff value up to a configured maximum
* A background task gradually decrements the backoff value until it reaches zero again, or until an event triggers an increase instead - this is the "leaky bucket" part
* Before submitting each activation to the push pool, the fetch thread sleeps for the current backoff wait time, reducing in a smoother increase / decrease in throughput when workers are busy