### PR TITLE
ref(eco): Adds report_timeout_errors options to Task definitions, allows ProcessingDeadlineExceeded to be retried

### DIFF
--- a/clients/python/src/taskbroker_client/retry.py
+++ b/clients/python/src/taskbroker_client/retry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from enum import Enum
+from multiprocessing.context import TimeoutError
 
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     ON_ATTEMPTS_EXCEEDED_DEADLETTER,
@@ -68,14 +69,12 @@ class Retry:
         ignore: tuple[type[BaseException], ...] | None = None,
         times_exceeded: LastAction = LastAction.Discard,
         delay: int | None = None,
-        retry_on_timeout: bool = True,
     ):
         self._times = times
         self._allowed_exception_types: tuple[type[BaseException], ...] = on or ()
         self._denied_exception_types: tuple[type[BaseException], ...] = ignore or ()
         self._times_exceeded = times_exceeded
         self._delay = delay
-        self._retry_on_timeout = retry_on_timeout
 
     def max_attempts_reached(self, state: RetryState) -> bool:
         # We subtract one, as attempts starts at 0, but `times`
@@ -95,8 +94,9 @@ class Retry:
         if isinstance(exc, self._denied_exception_types):
             return False
 
-        # Retry for allowed exception types
-        if isinstance(exc, self._allowed_exception_types):
+        # In the retry allow list or processing deadline is exceeded
+        # When processing deadline is exceeded, the subprocess raises a TimeoutError
+        if isinstance(exc, (TimeoutError, self._allowed_exception_types)):
             return True
 
         return False

--- a/clients/python/src/taskbroker_client/retry.py
+++ b/clients/python/src/taskbroker_client/retry.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from enum import Enum
-from multiprocessing.context import TimeoutError
 
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     ON_ATTEMPTS_EXCEEDED_DEADLETTER,
@@ -69,19 +68,21 @@ class Retry:
         ignore: tuple[type[BaseException], ...] | None = None,
         times_exceeded: LastAction = LastAction.Discard,
         delay: int | None = None,
+        retry_on_timeout: bool = True,
     ):
         self._times = times
         self._allowed_exception_types: tuple[type[BaseException], ...] = on or ()
         self._denied_exception_types: tuple[type[BaseException], ...] = ignore or ()
         self._times_exceeded = times_exceeded
         self._delay = delay
+        self._retry_on_timeout = retry_on_timeout
 
     def max_attempts_reached(self, state: RetryState) -> bool:
         # We subtract one, as attempts starts at 0, but `times`
         # starts at 1.
         return state.attempts >= (self._times - 1)
 
-    def should_retry(self, state: RetryState, exc: Exception) -> bool:
+    def should_retry(self, state: RetryState, exc: BaseException) -> bool:
         # If there are no retries remaining we should not retry
         if self.max_attempts_reached(state):
             return False
@@ -94,9 +95,13 @@ class Retry:
         if isinstance(exc, self._denied_exception_types):
             return False
 
-        # In the retry allow list or processing deadline is exceeded
-        # When processing deadline is exceeded, the subprocess raises a TimeoutError
-        if isinstance(exc, (TimeoutError, self._allowed_exception_types)):
+        # Retry for allowed exception types
+        if isinstance(exc, self._allowed_exception_types):
+            return True
+
+        from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
+
+        if self._retry_on_timeout and isinstance(exc, ProcessingDeadlineExceeded):
             return True
 
         return False

--- a/clients/python/src/taskbroker_client/retry.py
+++ b/clients/python/src/taskbroker_client/retry.py
@@ -99,11 +99,6 @@ class Retry:
         if isinstance(exc, self._allowed_exception_types):
             return True
 
-        from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
-
-        if self._retry_on_timeout and isinstance(exc, ProcessingDeadlineExceeded):
-            return True
-
         return False
 
     def initial_state(self) -> RetryState:

--- a/clients/python/src/taskbroker_client/task.py
+++ b/clients/python/src/taskbroker_client/task.py
@@ -51,6 +51,7 @@ class Task(Generic[P, R]):
         at_most_once: bool = False,
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
+        report_timeout_errors: bool = True,
     ):
         self.name = name
         self._func = func
@@ -71,6 +72,7 @@ class Task(Generic[P, R]):
         self.at_most_once = at_most_once
         self.wait_for_delivery = wait_for_delivery
         self.compression_type = compression_type
+        self.report_timeout_errors = report_timeout_errors
         update_wrapper(self, func)
 
     @property

--- a/clients/python/src/taskbroker_client/worker/workerchild.py
+++ b/clients/python/src/taskbroker_client/worker/workerchild.py
@@ -229,14 +229,15 @@ def child_process(
                     _execute_activation(task_func, inflight.activation, app.context_hooks)
                 next_state = TASK_ACTIVATION_STATUS_COMPLETE
             except ProcessingDeadlineExceeded as err:
-                with sentry_sdk.isolation_scope() as scope:
-                    scope.fingerprint = [
-                        "taskworker.processing_deadline_exceeded",
-                        inflight.activation.namespace,
-                        inflight.activation.taskname,
-                    ]
-                    scope.set_transaction_name(inflight.activation.taskname)
-                    sentry_sdk.capture_exception(err)
+                if task_func.report_timeout_errors:
+                    with sentry_sdk.isolation_scope() as scope:
+                        scope.fingerprint = [
+                            "taskworker.processing_deadline_exceeded",
+                            inflight.activation.namespace,
+                            inflight.activation.taskname,
+                        ]
+                        scope.set_transaction_name(inflight.activation.taskname)
+                        sentry_sdk.capture_exception(err)
                 metrics.incr(
                     "taskworker.worker.processing_deadline_exceeded",
                     tags={
@@ -245,7 +246,11 @@ def child_process(
                         "taskname": inflight.activation.taskname,
                     },
                 )
-                next_state = TASK_ACTIVATION_STATUS_FAILURE
+                retry = task_func.retry
+                if retry and retry.should_retry(inflight.activation.retry_state, err):
+                    next_state = TASK_ACTIVATION_STATUS_RETRY
+                else:
+                    next_state = TASK_ACTIVATION_STATUS_FAILURE
             except Exception as err:
                 retry = task_func.retry
                 captured_error = False

--- a/clients/python/tests/test_retry.py
+++ b/clients/python/tests/test_retry.py
@@ -71,7 +71,7 @@ def test_should_retry_retryerror() -> None:
 
 
 def test_should_retry_processing_deadline_exceeded() -> None:
-    retry = Retry(times=3, retry_on_timeout=True)
+    retry = Retry(times=3, on=(ProcessingDeadlineExceeded,))
     state = retry.initial_state()
 
     deadline_exceeded = ProcessingDeadlineExceeded("processing deadline exceeded")

--- a/clients/python/tests/test_retry.py
+++ b/clients/python/tests/test_retry.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from multiprocessing.context import TimeoutError
-
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     ON_ATTEMPTS_EXCEEDED_DEADLETTER,
     ON_ATTEMPTS_EXCEEDED_DISCARD,
 )
 
 from taskbroker_client.retry import LastAction, Retry, RetryTaskError
+from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 
 class RuntimeChildError(RuntimeError):
@@ -71,22 +70,21 @@ def test_should_retry_retryerror() -> None:
     assert not retry.should_retry(state, err)
 
 
-def test_should_retry_multiprocessing_timeout() -> None:
-    retry = Retry(times=3)
+def test_should_retry_processing_deadline_exceeded() -> None:
+    retry = Retry(times=3, retry_on_timeout=True)
     state = retry.initial_state()
 
-    timeout = TimeoutError("timeouts should retry if there are attempts left")
-    assert retry.should_retry(state, timeout)
+    deadline_exceeded = ProcessingDeadlineExceeded("processing deadline exceeded")
+    assert retry.should_retry(state, deadline_exceeded)
 
     state.attempts = 1
-    assert retry.should_retry(state, timeout)
+    assert retry.should_retry(state, deadline_exceeded)
 
-    # attempt = 2 is actually the third attempt.
     state.attempts = 2
-    assert not retry.should_retry(state, timeout)
+    assert not retry.should_retry(state, deadline_exceeded)
 
     state.attempts = 3
-    assert not retry.should_retry(state, timeout)
+    assert not retry.should_retry(state, deadline_exceeded)
 
 
 def test_should_retry_error_allow_list() -> None:


### PR DESCRIPTION
Updates the python lib code with the following changes:
1. Broadens allowable retry exceptions in `retry.py` to include BaseException types (like `ProcessingDeadlineExceeded`)
2. Updates workerchild to check for retries on the `ProcessingDeadlineExceeded` handling branch.
3. Adds a new `report_timeout_errors` check which allows us to opt out of Sentry reporting on a per-task definition basis.

This will allow developers to optionally specify retries on task timeouts.

Resolves ISWF-2447