### PR TITLE
feat(taskbroker): Add Useful Push Taskbroker Metrics

### DIFF
--- a/clients/python/src/taskbroker_client/worker/worker.py
+++ b/clients/python/src/taskbroker_client/worker/worker.py
@@ -60,6 +60,11 @@ class WorkerServicer(taskbroker_pb2_grpc.WorkerServiceServicer):
         context: grpc.ServicerContext,
     ) -> PushTaskResponse:
         """Handle incoming task activation."""
+        start_time = time.monotonic()
+        self.worker._metrics.incr(
+            "taskworker.worker.push_rpc",
+            tags={"result": "attempt", "processing_pool": self.worker._processing_pool_name},
+        )
         # Create `InflightTaskActivation` from the pushed task
         inflight = InflightTaskActivation(
             activation=request.task,
@@ -69,8 +74,26 @@ class WorkerServicer(taskbroker_pb2_grpc.WorkerServiceServicer):
 
         # Push the task to the worker queue (wait at most 5 seconds)
         if not self.worker.push_task(inflight, timeout=5):
+            self.worker._metrics.incr(
+                "taskworker.worker.push_rpc",
+                tags={"result": "busy", "processing_pool": self.worker._processing_pool_name},
+            )
+            self.worker._metrics.distribution(
+                "taskworker.worker.push_rpc.duration",
+                time.monotonic() - start_time,
+                tags={"result": "busy", "processing_pool": self.worker._processing_pool_name},
+            )
             context.abort(grpc.StatusCode.RESOURCE_EXHAUSTED, "worker busy")
 
+        self.worker._metrics.incr(
+            "taskworker.worker.push_rpc",
+            tags={"result": "accepted", "processing_pool": self.worker._processing_pool_name},
+        )
+        self.worker._metrics.distribution(
+            "taskworker.worker.push_rpc.duration",
+            time.monotonic() - start_time,
+            tags={"result": "accepted", "processing_pool": self.worker._processing_pool_name},
+        )
         return PushTaskResponse()
 
 

--- a/clients/python/src/taskbroker_client/worker/worker.py
+++ b/clients/python/src/taskbroker_client/worker/worker.py
@@ -65,6 +65,7 @@ class WorkerServicer(taskbroker_pb2_grpc.WorkerServiceServicer):
             "taskworker.worker.push_rpc",
             tags={"result": "attempt", "processing_pool": self.worker._processing_pool_name},
         )
+
         # Create `InflightTaskActivation` from the pushed task
         inflight = InflightTaskActivation(
             activation=request.task,
@@ -78,22 +79,26 @@ class WorkerServicer(taskbroker_pb2_grpc.WorkerServiceServicer):
                 "taskworker.worker.push_rpc",
                 tags={"result": "busy", "processing_pool": self.worker._processing_pool_name},
             )
+
             self.worker._metrics.distribution(
                 "taskworker.worker.push_rpc.duration",
                 time.monotonic() - start_time,
                 tags={"result": "busy", "processing_pool": self.worker._processing_pool_name},
             )
+
             context.abort(grpc.StatusCode.RESOURCE_EXHAUSTED, "worker busy")
 
         self.worker._metrics.incr(
             "taskworker.worker.push_rpc",
             tags={"result": "accepted", "processing_pool": self.worker._processing_pool_name},
         )
+
         self.worker._metrics.distribution(
             "taskworker.worker.push_rpc.duration",
             time.monotonic() - start_time,
             tags={"result": "accepted", "processing_pool": self.worker._processing_pool_name},
         )
+
         return PushTaskResponse()
 
 

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -121,6 +121,7 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                 .await
                             {
                                 Ok(activations) if activations.is_empty() => {
+                                    metrics::counter!("push.fetch.empty").increment(1);
                                     debug!("No pending activations");
 
                                     // Wait for pending activations to appear
@@ -128,12 +129,27 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                 }
 
                                 Ok(activations) => {
+                                    metrics::counter!("push.fetch.claimed")
+                                        .increment(activations.len() as u64);
+                                    metrics::histogram!("push.fetch.claim_batch_size")
+                                        .record(activations.len() as f64);
                                     debug!("Fetched {} activations", activations.len());
 
                                     for activation in activations {
                                         let id = activation.id.clone();
 
-                                        if let Err(e) = pusher.push_task(activation).await {
+                                        match pusher.push_task(activation).await {
+                                            Ok(()) => {
+                                                metrics::counter!("push.fetch.submit", "result" => "ok")
+                                                    .increment(1);
+                                            }
+                                            Err(e) => {
+                                                let reason = match &e {
+                                                    PushError::Timeout => "timeout",
+                                                    PushError::Channel(_) => "channel_error",
+                                                };
+                                                metrics::counter!("push.fetch.submit", "result" => reason)
+                                                    .increment(1);
                                             match e {
                                                 PushError::Timeout => warn!(
                                                     task_id = %id,
@@ -149,13 +165,13 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                             }
 
                                             backoff = true;
+                                            }
                                         }
                                     }
-
-
                                 }
 
                                 Err(e) => {
+                                    metrics::counter!("push.fetch.store_error").increment(1);
                                     warn!(
                                         error = ?e,
                                         "Store failed while fetching tasks"

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -123,7 +123,7 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                 .await
                             {
                                 Ok(activations) if activations.is_empty() => {
-                                    metrics::counter!("push.fetch.empty").increment(1);
+                                    metrics::counter!("fetch.empty").increment(1);
                                     debug!("No pending activations");
 
                                     // Wait for pending activations to appear
@@ -131,9 +131,9 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                 }
 
                                 Ok(activations) => {
-                                    metrics::counter!("push.fetch.claimed")
+                                    metrics::counter!("fetch.claimed")
                                         .increment(activations.len() as u64);
-                                    metrics::histogram!("push.fetch.claim_batch_size")
+                                    metrics::histogram!("fetch.claim_batch_size")
                                         .record(activations.len() as f64);
 
                                     debug!("Fetched {} activations", activations.len());
@@ -142,10 +142,10 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                         let id = activation.id.clone();
 
                                         match pusher.submit_task(activation).await {
-                                            Ok(()) => metrics::counter!("push.fetch.submit", "result" => "ok").increment(1),
+                                            Ok(()) => metrics::counter!("fetch.submit", "result" => "ok").increment(1),
 
                                             Err(PushError::Timeout) => {
-                                                metrics::counter!("push.fetch.submit", "result" => "timeout")
+                                                metrics::counter!("fetch.submit", "result" => "timeout")
                                                     .increment(1);
 
                                                 warn!(
@@ -159,7 +159,7 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                             }
 
                                             Err(PushError::Channel(e)) => {
-                                                metrics::counter!("push.fetch.submit", "result" => "channel_error")
+                                                metrics::counter!("fetch.submit", "result" => "channel_error")
                                                     .increment(1);
 
                                                 warn!(
@@ -176,7 +176,7 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                 }
 
                                 Err(e) => {
-                                    metrics::counter!("push.fetch.store_error").increment(1);
+                                    metrics::counter!("fetch.store_error").increment(1);
                                     warn!(
                                         error = ?e,
                                         "Store failed while fetching tasks"

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -46,13 +46,13 @@ pub fn bucket_range_for_fetch_thread(thread_index: usize, fetch_threads: usize) 
 /// Thin interface for the push pool. It mostly serves to enable proper unit testing, but it also decouples fetch logic from push logic even further.
 #[async_trait]
 pub trait TaskPusher {
-    /// Push a single task to the worker service.
-    async fn push_task(&self, activation: InflightActivation) -> Result<(), PushError>;
+    /// Submit a single task to the push pool.
+    async fn submit_task(&self, activation: InflightActivation) -> Result<(), PushError>;
 }
 
 #[async_trait]
 impl TaskPusher for PushPool {
-    async fn push_task(&self, activation: InflightActivation) -> Result<(), PushError> {
+    async fn submit_task(&self, activation: InflightActivation) -> Result<(), PushError> {
         self.submit(activation).await
     }
 }
@@ -133,38 +133,38 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                         .increment(activations.len() as u64);
                                     metrics::histogram!("push.fetch.claim_batch_size")
                                         .record(activations.len() as f64);
+
                                     debug!("Fetched {} activations", activations.len());
 
                                     for activation in activations {
                                         let id = activation.id.clone();
 
-                                        match pusher.push_task(activation).await {
-                                            Ok(()) => {
-                                                metrics::counter!("push.fetch.submit", "result" => "ok")
+                                        match pusher.submit_task(activation).await {
+                                            Ok(()) => metrics::counter!("push.fetch.submit", "result" => "ok").increment(1),
+
+                                            Err(PushError::Timeout) => {
+                                                metrics::counter!("push.fetch.submit", "result" => "timeout")
                                                     .increment(1);
-                                            }
-                                            Err(e) => {
-                                                let reason = match &e {
-                                                    PushError::Timeout => "timeout",
-                                                    PushError::Channel(_) => "channel_error",
-                                                };
-                                                metrics::counter!("push.fetch.submit", "result" => reason)
-                                                    .increment(1);
-                                            match e {
-                                                PushError::Timeout => warn!(
+
+                                                warn!(
                                                     task_id = %id,
                                                     "Submit to push pool timed out after {} milliseconds",
                                                     config.push_queue_timeout_ms
-                                                ),
+                                                );
 
-                                                PushError::Channel(e) => warn!(
+                                                // Wait for push queue to empty
+                                                backoff = true;
+                                            }
+
+                                            Err(PushError::Channel(e)) => {
+                                                metrics::counter!("push.fetch.submit", "result" => "channel_error")
+                                                    .increment(1);
+
+                                                warn!(
                                                     task_id = %id,
                                                     error = ?e,
                                                     "Submit to push pool failed due to channel error",
-                                                )
-                                            }
-
-                                            backoff = true;
+                                                );
                                             }
                                         }
                                     }

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -167,6 +167,9 @@ impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
                                                     error = ?e,
                                                     "Submit to push pool failed due to channel error",
                                                 );
+
+                                                // Wait before trying again
+                                                backoff = true;
                                             }
                                         }
                                     }

--- a/src/fetch/tests.rs
+++ b/src/fetch/tests.rs
@@ -198,7 +198,7 @@ impl RecordingPusher {
 
 #[async_trait]
 impl TaskPusher for RecordingPusher {
-    async fn push_task(&self, activation: InflightActivation) -> Result<(), PushError> {
+    async fn submit_task(&self, activation: InflightActivation) -> Result<(), PushError> {
         self.pushed_ids.lock().await.push(activation.id.clone());
 
         if self.fail {

--- a/src/grpc/metrics_middleware.rs
+++ b/src/grpc/metrics_middleware.rs
@@ -43,9 +43,11 @@ where
             let path = req.uri().path().to_string();
 
             let response = inner.call(req).await?;
+            let status = response.status().as_u16().to_string();
 
-            metrics::counter!("grpc.request", "path" => path.clone()).increment(1);
-            metrics::histogram!("grpc.request.duration", "path" => path.clone())
+            metrics::counter!("grpc.request", "path" => path.clone(), "status" => status.clone())
+                .increment(1);
+            metrics::histogram!("grpc.request.duration", "path" => path.clone(), "status" => status)
                 .record(start.elapsed());
 
             Ok(response)

--- a/src/grpc/metrics_middleware.rs
+++ b/src/grpc/metrics_middleware.rs
@@ -43,11 +43,9 @@ where
             let path = req.uri().path().to_string();
 
             let response = inner.call(req).await?;
-            let status = response.status().as_u16().to_string();
 
-            metrics::counter!("grpc.request", "path" => path.clone(), "status" => status.clone())
-                .increment(1);
-            metrics::histogram!("grpc.request.duration", "path" => path.clone(), "status" => status)
+            metrics::counter!("grpc.request", "path" => path.clone()).increment(1);
+            metrics::histogram!("grpc.request.duration", "path" => path.clone())
                 .record(start.elapsed());
 
             Ok(response)

--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -100,17 +100,37 @@ impl ConsumerService for TaskbrokerServer {
         }
 
         let update_result = self.store.set_status(&id, status).await;
-        if let Err(e) = update_result {
-            error!(
-                ?id,
-                ?status,
-                "Unable to update status of activation: {:?}",
-                e,
-            );
-            return Err(Status::internal(format!(
-                "Unable to update status of {id:?} to {status:?}"
-            )));
-        }
+        let inflight = match update_result {
+            Ok(inflight) => inflight,
+            Err(e) => {
+                metrics::counter!(
+                    "grpc_server.set_status",
+                    "result" => "error",
+                    "status" => status.to_string()
+                )
+                .increment(1);
+                error!(
+                    ?id,
+                    ?status,
+                    "Unable to update status of activation: {:?}",
+                    e,
+                );
+                return Err(Status::internal(format!(
+                    "Unable to update status of {id:?} to {status:?}"
+                )));
+            }
+        };
+        let result_label = if inflight.is_some() {
+            "ok"
+        } else {
+            "not_found"
+        };
+        metrics::counter!(
+            "grpc_server.set_status",
+            "result" => result_label,
+            "status" => status.to_string()
+        )
+        .increment(1);
         metrics::histogram!("grpc_server.set_status.duration").record(start_time.elapsed());
 
         if self.config.delivery_mode == DeliveryMode::Push {

--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -130,11 +130,12 @@ impl ConsumerService for TaskbrokerServer {
                     e,
                 );
 
+                metrics::histogram!("grpc_server.set_status.duration").record(start_time.elapsed());
                 return Err(Status::internal(format!(
                     "Unable to update status of {id:?} to {status:?}"
                 )));
             }
-        };
+        }
 
         metrics::histogram!("grpc_server.set_status.duration").record(start_time.elapsed());
 

--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -99,9 +99,21 @@ impl ConsumerService for TaskbrokerServer {
             metrics::counter!("grpc_server.set_status.failure").increment(1);
         }
 
-        let update_result = self.store.set_status(&id, status).await;
-        let inflight = match update_result {
-            Ok(inflight) => inflight,
+        match self.store.set_status(&id, status).await {
+            Ok(Some(_)) => metrics::counter!(
+                "grpc_server.set_status",
+                "result" => "ok",
+                "status" => status.to_string()
+            )
+            .increment(1),
+
+            Ok(None) => metrics::counter!(
+                "grpc_server.set_status",
+                "result" => "not_found",
+                "status" => status.to_string()
+            )
+            .increment(1),
+
             Err(e) => {
                 metrics::counter!(
                     "grpc_server.set_status",
@@ -109,28 +121,20 @@ impl ConsumerService for TaskbrokerServer {
                     "status" => status.to_string()
                 )
                 .increment(1);
+
                 error!(
                     ?id,
                     ?status,
                     "Unable to update status of activation: {:?}",
                     e,
                 );
+
                 return Err(Status::internal(format!(
                     "Unable to update status of {id:?} to {status:?}"
                 )));
             }
         };
-        let result_label = if inflight.is_some() {
-            "ok"
-        } else {
-            "not_found"
-        };
-        metrics::counter!(
-            "grpc_server.set_status",
-            "result" => result_label,
-            "status" => status.to_string()
-        )
-        .increment(1);
+
         metrics::histogram!("grpc_server.set_status.duration").record(start_time.elapsed());
 
         if self.config.delivery_mode == DeliveryMode::Push {

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -1000,7 +1000,7 @@ mod tests {
             self.pipe
                 .write()
                 .unwrap()
-                .extend(take(&mut self.buffer.write().unwrap() as &mut Vec<T>).into_iter());
+                .extend(take(&mut self.buffer.write().unwrap() as &mut Vec<T>));
             Ok(Some(()))
         }
 

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -10,6 +10,7 @@ use sentry_protos::taskbroker::v1::worker_service_client::WorkerServiceClient;
 use sentry_protos::taskbroker::v1::{PushTaskRequest, TaskActivation};
 use sha2::Sha256;
 use tokio::task::JoinSet;
+use tonic::Code;
 use tonic::async_trait;
 use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
@@ -127,9 +128,15 @@ impl PushPool {
                 let grpc_shared_secret = self.config.grpc_shared_secret.clone();
 
                 async move {
+                    metrics::counter!("push.worker.connect.attempt").increment(1);
                     let mut worker = match WorkerServiceClient::connect(endpoint).await {
-                        Ok(w) => w,
+                        Ok(w) => {
+                            metrics::counter!("push.worker.connect", "result" => "ok").increment(1);
+                            w
+                        }
                         Err(e) => {
+                            metrics::counter!("push.worker.connect", "result" => "error")
+                                .increment(1);
                             error!("Failed to connect to worker - {:?}", e);
 
                             // When we fail to connect, the taskbroker will shut down, but this may change in the future
@@ -147,7 +154,10 @@ impl PushPool {
                             message = receiver.recv_async() => {
                                 let activation = match message {
                                     // Received activation from fetch thread
-                                    Ok(a) => a,
+                                    Ok(a) => {
+                                        metrics::gauge!("push.queue.depth").set(receiver.len() as f64);
+                                        a
+                                    }
 
                                     // Channel closed
                                     Err(_) => break
@@ -166,9 +176,11 @@ impl PushPool {
                                 .await
                                 {
                                     Ok(_) => {
+                                        metrics::counter!("push.delivery", "result" => "ok").increment(1);
                                         debug!(task_id = %id, "Activation sent to worker");
 
                                         if let Err(e) = store.mark_activation_processing(&id).await {
+                                            metrics::counter!("push.mark_activation_processing", "result" => "error").increment(1);
                                             error!(
                                                 task_id = %id,
                                                 error = ?e,
@@ -178,11 +190,21 @@ impl PushPool {
                                     }
 
                                     // Once processing deadline expires, status will be set back to pending
-                                    Err(e) => error!(
-                                        task_id = %id,
-                                        error = ?e,
-                                        "Failed to send activation to worker"
-                                    )
+                                    Err(e) => {
+                                        let (kind, status) = classify_push_error(&e);
+                                        metrics::counter!(
+                                            "push.delivery",
+                                            "result" => "error",
+                                            "error_kind" => kind,
+                                            "grpc_status" => status
+                                        )
+                                        .increment(1);
+                                        error!(
+                                            task_id = %id,
+                                            error = ?e,
+                                            "Failed to send activation to worker"
+                                        )
+                                    }
                                 };
                             }
                         }
@@ -203,9 +225,11 @@ impl PushPool {
                         .await
                         {
                             Ok(_) => {
+                                metrics::counter!("push.delivery", "result" => "ok").increment(1);
                                 debug!(task_id = %id, "Activation sent to worker");
 
                                 if let Err(e) = store.mark_activation_processing(&id).await {
+                                    metrics::counter!("push.mark_activation_processing", "result" => "error").increment(1);
                                     error!(
                                         task_id = %id,
                                         error = ?e,
@@ -215,11 +239,21 @@ impl PushPool {
                             }
 
                             // Once processing deadline expires, status will be set back to pending
-                            Err(e) => error!(
-                                task_id = %id,
-                                error = ?e,
-                                "Failed to send activation to worker"
-                            ),
+                            Err(e) => {
+                                let (kind, status) = classify_push_error(&e);
+                                metrics::counter!(
+                                    "push.delivery",
+                                    "result" => "error",
+                                    "error_kind" => kind,
+                                    "grpc_status" => status
+                                )
+                                .increment(1);
+                                error!(
+                                    task_id = %id,
+                                    error = ?e,
+                                    "Failed to send activation to worker"
+                                )
+                            }
                         };
                     }
 
@@ -246,15 +280,29 @@ impl PushPool {
     /// Send an activation to the internal asynchronous MPMC channel used by all running push threads. Times out after `config.push_queue_timeout_ms` milliseconds.
     pub async fn submit(&self, activation: InflightActivation) -> Result<(), PushError> {
         let duration = Duration::from_millis(self.config.push_queue_timeout_ms);
+        let start = Instant::now();
+        metrics::gauge!("push.queue.depth").set(self.sender.len() as f64);
 
         match tokio::time::timeout(duration, self.sender.send_async(activation)).await {
-            Ok(Ok(())) => Ok(()),
+            Ok(Ok(())) => {
+                metrics::histogram!("push.queue.wait_duration").record(start.elapsed());
+                metrics::gauge!("push.queue.depth").set(self.sender.len() as f64);
+                Ok(())
+            }
 
             // The channel has a problem
-            Ok(Err(e)) => Err(PushError::Channel(e)),
+            Ok(Err(e)) => {
+                metrics::histogram!("push.queue.wait_duration").record(start.elapsed());
+                metrics::counter!("push.queue.submit", "result" => "channel_error").increment(1);
+                Err(PushError::Channel(e))
+            }
 
             // The channel was full so the send timed out
-            Err(_elapsed) => Err(PushError::Timeout),
+            Err(_elapsed) => {
+                metrics::histogram!("push.queue.wait_duration").record(start.elapsed());
+                metrics::counter!("push.queue.submit", "result" => "timeout").increment(1);
+                Err(PushError::Timeout)
+            }
         }
     }
 }
@@ -268,9 +316,22 @@ async fn push_task<W: WorkerClient + Send>(
     grpc_shared_secret: &[String],
 ) -> Result<()> {
     let start = Instant::now();
+    metrics::counter!("push.rpc.attempt").increment(1);
 
     // Try to decode activation (if it fails, we will see the error where `push_task` is called)
-    let task = TaskActivation::decode(&activation.activation as &[u8])?;
+    let task = match TaskActivation::decode(&activation.activation as &[u8]) {
+        Ok(task) => task,
+        Err(err) => {
+            metrics::counter!(
+                "push.rpc.failure",
+                "error_kind" => "decode",
+                "grpc_status" => "none"
+            )
+            .increment(1);
+            metrics::histogram!("push.rpc.duration", "result" => "error").record(start.elapsed());
+            return Err(err.into());
+        }
+    };
 
     let request = PushTaskRequest {
         task: Some(task),
@@ -283,8 +344,66 @@ async fn push_task<W: WorkerClient + Send>(
         Err(e) => Err(e.into()),
     };
 
+    match &result {
+        Ok(()) => metrics::counter!("push.rpc.success").increment(1),
+        Err(err) => {
+            let (kind, status) = classify_push_error(err);
+            metrics::counter!(
+                "push.rpc.failure",
+                "error_kind" => kind,
+                "grpc_status" => status
+            )
+            .increment(1);
+        }
+    }
+    metrics::histogram!(
+        "push.rpc.duration",
+        "result" => if result.is_ok() { "ok" } else { "error" }
+    )
+    .record(start.elapsed());
     metrics::histogram!("push.push_task.duration").record(start.elapsed());
     result
+}
+
+fn classify_push_error(error: &anyhow::Error) -> (&'static str, &'static str) {
+    if error
+        .downcast_ref::<tokio::time::error::Elapsed>()
+        .is_some()
+    {
+        return ("timeout", "deadline_exceeded");
+    }
+
+    if let Some(status) = error.downcast_ref::<tonic::Status>() {
+        return ("grpc", tonic_code_name(status.code()));
+    }
+
+    if error.downcast_ref::<prost::DecodeError>().is_some() {
+        return ("decode", "none");
+    }
+
+    ("other", "none")
+}
+
+fn tonic_code_name(code: Code) -> &'static str {
+    match code {
+        Code::Ok => "ok",
+        Code::Cancelled => "cancelled",
+        Code::Unknown => "unknown",
+        Code::InvalidArgument => "invalid_argument",
+        Code::DeadlineExceeded => "deadline_exceeded",
+        Code::NotFound => "not_found",
+        Code::AlreadyExists => "already_exists",
+        Code::PermissionDenied => "permission_denied",
+        Code::ResourceExhausted => "resource_exhausted",
+        Code::FailedPrecondition => "failed_precondition",
+        Code::Aborted => "aborted",
+        Code::OutOfRange => "out_of_range",
+        Code::Unimplemented => "unimplemented",
+        Code::Internal => "internal",
+        Code::Unavailable => "unavailable",
+        Code::DataLoss => "data_loss",
+        Code::Unauthenticated => "unauthenticated",
+    }
 }
 
 #[cfg(test)]

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -10,7 +10,6 @@ use sentry_protos::taskbroker::v1::worker_service_client::WorkerServiceClient;
 use sentry_protos::taskbroker::v1::{PushTaskRequest, TaskActivation};
 use sha2::Sha256;
 use tokio::task::JoinSet;
-use tonic::Code;
 use tonic::async_trait;
 use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
@@ -129,11 +128,13 @@ impl PushPool {
 
                 async move {
                     metrics::counter!("push.worker.connect.attempt").increment(1);
+
                     let mut worker = match WorkerServiceClient::connect(endpoint).await {
                         Ok(w) => {
                             metrics::counter!("push.worker.connect", "result" => "ok").increment(1);
                             w
                         }
+
                         Err(e) => {
                             metrics::counter!("push.worker.connect", "result" => "error")
                                 .increment(1);
@@ -154,10 +155,7 @@ impl PushPool {
                             message = receiver.recv_async() => {
                                 let activation = match message {
                                     // Received activation from fetch thread
-                                    Ok(a) => {
-                                        metrics::gauge!("push.queue.depth").set(receiver.len() as f64);
-                                        a
-                                    }
+                                    Ok(a) => a,
 
                                     // Channel closed
                                     Err(_) => break
@@ -181,6 +179,7 @@ impl PushPool {
 
                                         if let Err(e) = store.mark_activation_processing(&id).await {
                                             metrics::counter!("push.mark_activation_processing", "result" => "error").increment(1);
+
                                             error!(
                                                 task_id = %id,
                                                 error = ?e,
@@ -189,16 +188,10 @@ impl PushPool {
                                         }
                                     }
 
-                                    // Once processing deadline expires, status will be set back to pending
+                                    // Once claim expires, status will be set back to pending
                                     Err(e) => {
-                                        let (kind, status) = classify_push_error(&e);
-                                        metrics::counter!(
-                                            "push.delivery",
-                                            "result" => "error",
-                                            "error_kind" => kind,
-                                            "grpc_status" => status
-                                        )
-                                        .increment(1);
+                                        metrics::counter!("push.delivery", "result" => "error").increment(1);
+
                                         error!(
                                             task_id = %id,
                                             error = ?e,
@@ -230,6 +223,7 @@ impl PushPool {
 
                                 if let Err(e) = store.mark_activation_processing(&id).await {
                                     metrics::counter!("push.mark_activation_processing", "result" => "error").increment(1);
+
                                     error!(
                                         task_id = %id,
                                         error = ?e,
@@ -240,14 +234,9 @@ impl PushPool {
 
                             // Once processing deadline expires, status will be set back to pending
                             Err(e) => {
-                                let (kind, status) = classify_push_error(&e);
-                                metrics::counter!(
-                                    "push.delivery",
-                                    "result" => "error",
-                                    "error_kind" => kind,
-                                    "grpc_status" => status
-                                )
-                                .increment(1);
+                                metrics::counter!("push.delivery", "result" => "error")
+                                    .increment(1);
+
                                 error!(
                                     task_id = %id,
                                     error = ?e,
@@ -281,26 +270,24 @@ impl PushPool {
     pub async fn submit(&self, activation: InflightActivation) -> Result<(), PushError> {
         let duration = Duration::from_millis(self.config.push_queue_timeout_ms);
         let start = Instant::now();
+
         metrics::gauge!("push.queue.depth").set(self.sender.len() as f64);
 
         match tokio::time::timeout(duration, self.sender.send_async(activation)).await {
             Ok(Ok(())) => {
                 metrics::histogram!("push.queue.wait_duration").record(start.elapsed());
-                metrics::gauge!("push.queue.depth").set(self.sender.len() as f64);
                 Ok(())
             }
 
             // The channel has a problem
             Ok(Err(e)) => {
                 metrics::histogram!("push.queue.wait_duration").record(start.elapsed());
-                metrics::counter!("push.queue.submit", "result" => "channel_error").increment(1);
                 Err(PushError::Channel(e))
             }
 
             // The channel was full so the send timed out
             Err(_elapsed) => {
                 metrics::histogram!("push.queue.wait_duration").record(start.elapsed());
-                metrics::counter!("push.queue.submit", "result" => "timeout").increment(1);
                 Err(PushError::Timeout)
             }
         }
@@ -316,19 +303,16 @@ async fn push_task<W: WorkerClient + Send>(
     grpc_shared_secret: &[String],
 ) -> Result<()> {
     let start = Instant::now();
-    metrics::counter!("push.rpc.attempt").increment(1);
+    metrics::counter!("push.push_task.attempt").increment(1);
 
     // Try to decode activation (if it fails, we will see the error where `push_task` is called)
     let task = match TaskActivation::decode(&activation.activation as &[u8]) {
         Ok(task) => task,
         Err(err) => {
-            metrics::counter!(
-                "push.rpc.failure",
-                "error_kind" => "decode",
-                "grpc_status" => "none"
-            )
-            .increment(1);
-            metrics::histogram!("push.rpc.duration", "result" => "error").record(start.elapsed());
+            metrics::counter!("push.push_task.failure", "reason" => "decode").increment(1);
+            metrics::histogram!("push.push_task.duration", "result" => "error")
+                .record(start.elapsed());
+
             return Err(err.into());
         }
     };
@@ -340,70 +324,24 @@ async fn push_task<W: WorkerClient + Send>(
 
     let result = match tokio::time::timeout(timeout, worker.send(request, grpc_shared_secret)).await
     {
-        Ok(r) => r,
-        Err(e) => Err(e.into()),
+        Ok(result) => {
+            if result.is_ok() {
+                metrics::counter!("push.push_task.success").increment(1);
+            } else {
+                metrics::counter!("push.push_task.failure", "reason" => "rpc").increment(1);
+            }
+
+            result
+        }
+
+        Err(e) => {
+            metrics::counter!("push.push_task.failure", "reason" => "timeout").increment(1);
+            Err(e.into())
+        }
     };
 
-    match &result {
-        Ok(()) => metrics::counter!("push.rpc.success").increment(1),
-        Err(err) => {
-            let (kind, status) = classify_push_error(err);
-            metrics::counter!(
-                "push.rpc.failure",
-                "error_kind" => kind,
-                "grpc_status" => status
-            )
-            .increment(1);
-        }
-    }
-    metrics::histogram!(
-        "push.rpc.duration",
-        "result" => if result.is_ok() { "ok" } else { "error" }
-    )
-    .record(start.elapsed());
     metrics::histogram!("push.push_task.duration").record(start.elapsed());
     result
-}
-
-fn classify_push_error(error: &anyhow::Error) -> (&'static str, &'static str) {
-    if error
-        .downcast_ref::<tokio::time::error::Elapsed>()
-        .is_some()
-    {
-        return ("timeout", "deadline_exceeded");
-    }
-
-    if let Some(status) = error.downcast_ref::<tonic::Status>() {
-        return ("grpc", tonic_code_name(status.code()));
-    }
-
-    if error.downcast_ref::<prost::DecodeError>().is_some() {
-        return ("decode", "none");
-    }
-
-    ("other", "none")
-}
-
-fn tonic_code_name(code: Code) -> &'static str {
-    match code {
-        Code::Ok => "ok",
-        Code::Cancelled => "cancelled",
-        Code::Unknown => "unknown",
-        Code::InvalidArgument => "invalid_argument",
-        Code::DeadlineExceeded => "deadline_exceeded",
-        Code::NotFound => "not_found",
-        Code::AlreadyExists => "already_exists",
-        Code::PermissionDenied => "permission_denied",
-        Code::ResourceExhausted => "resource_exhausted",
-        Code::FailedPrecondition => "failed_precondition",
-        Code::Aborted => "aborted",
-        Code::OutOfRange => "out_of_range",
-        Code::Unimplemented => "unimplemented",
-        Code::Internal => "internal",
-        Code::Unavailable => "unavailable",
-        Code::DataLoss => "data_loss",
-        Code::Unauthenticated => "unauthenticated",
-    }
 }
 
 #[cfg(test)]

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -48,8 +48,7 @@ pub enum PushError {
 #[async_trait]
 trait WorkerClient {
     /// Send a single `PushTaskRequest` to the worker service.
-    ///
-    /// When `grpc_shared_secret` is non-empty, signs with `grpc_shared_secret[0]` and sets `sentry-signature` metadata (same scheme as Python pull client and broker `AuthLayer`).
+    /// When `grpc_shared_secret` is not empty, it signs the request with `grpc_shared_secret[0]` and sets `sentry-signature` metadata (same scheme as Python pull client and broker `AuthLayer`).
     async fn send(&mut self, request: PushTaskRequest, grpc_shared_secret: &[String])
     -> Result<()>;
 }
@@ -74,6 +73,7 @@ impl WorkerClient for WorkerServiceClient<Channel> {
         self.push_task(req)
             .await
             .map_err(|status| anyhow::anyhow!(status))?;
+
         Ok(())
     }
 }
@@ -309,10 +309,7 @@ async fn push_task<W: WorkerClient + Send>(
     let task = match TaskActivation::decode(&activation.activation as &[u8]) {
         Ok(task) => task,
         Err(err) => {
-            metrics::counter!("push.push_task.failure", "reason" => "decode").increment(1);
-            metrics::histogram!("push.push_task.duration", "result" => "error")
-                .record(start.elapsed());
-
+            metrics::histogram!("push.push_task.duration").record(start.elapsed());
             return Err(err.into());
         }
     };
@@ -324,20 +321,8 @@ async fn push_task<W: WorkerClient + Send>(
 
     let result = match tokio::time::timeout(timeout, worker.send(request, grpc_shared_secret)).await
     {
-        Ok(result) => {
-            if result.is_ok() {
-                metrics::counter!("push.push_task.success").increment(1);
-            } else {
-                metrics::counter!("push.push_task.failure", "reason" => "rpc").increment(1);
-            }
-
-            result
-        }
-
-        Err(e) => {
-            metrics::counter!("push.push_task.failure", "reason" => "timeout").increment(1);
-            Err(e.into())
-        }
+        Ok(r) => r,
+        Err(e) => Err(e.into()),
     };
 
     metrics::histogram!("push.push_task.duration").record(start.elapsed());

--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -1011,10 +1011,14 @@ impl InflightActivationStore for SqliteActivationStore {
         .await?;
 
         if result.rows_affected() == 0 {
+            metrics::counter!("push.mark_activation_processing", "result" => "not_found")
+                .increment(1);
             warn!(
                 task_id = %id,
                 "Activation could not be marked as sent, it may be missing or its status may have already changed"
             );
+        } else {
+            metrics::counter!("push.mark_activation_processing", "result" => "ok").increment(1);
         }
 
         Ok(())

--- a/src/store/inflight_activation.rs
+++ b/src/store/inflight_activation.rs
@@ -1013,6 +1013,7 @@ impl InflightActivationStore for SqliteActivationStore {
         if result.rows_affected() == 0 {
             metrics::counter!("push.mark_activation_processing", "result" => "not_found")
                 .increment(1);
+
             warn!(
                 task_id = %id,
                 "Activation could not be marked as sent, it may be missing or its status may have already changed"

--- a/src/store/postgres_activation_store.rs
+++ b/src/store/postgres_activation_store.rs
@@ -423,6 +423,7 @@ impl InflightActivationStore for PostgresActivationStore {
         if result.rows_affected() == 0 {
             metrics::counter!("push.mark_activation_processing", "result" => "not_found")
                 .increment(1);
+
             warn!(
                 task_id = %id,
                 "Activation could not be marked as processing, it may be missing or its status may have already changed"

--- a/src/store/postgres_activation_store.rs
+++ b/src/store/postgres_activation_store.rs
@@ -421,10 +421,14 @@ impl InflightActivationStore for PostgresActivationStore {
         .await?;
 
         if result.rows_affected() == 0 {
+            metrics::counter!("push.mark_activation_processing", "result" => "not_found")
+                .increment(1);
             warn!(
                 task_id = %id,
                 "Activation could not be marked as processing, it may be missing or its status may have already changed"
             );
+        } else {
+            metrics::counter!("push.mark_activation_processing", "result" => "ok").increment(1);
         }
 
         Ok(())


### PR DESCRIPTION
## Linear
Completes [STREAM-871](https://linear.app/getsentry/issue/STREAM-871/add-useful-metrics)

## Description
Currently, taskworkers pull tasks from taskbrokers via RPC. This approach works, but has some drawbacks. Therefore, we want taskbrokers to push tasks to taskworkers instead. Read [this](https://www.notion.so/sentry/Push-Task-Broker-2c58b10e4b5d8045814fc6aa87491ae5?source=copy_link) page on Notion for more information.

This PR adds metrics around the main push mode handoff points so we can see how the system is behaving in production and tell where work is getting stuck.

Right now, there are some scattered metrics, but they do not make it easy to answer questions like...
* Are fetch loops finding work, or just polling empty?
* Are brokers claiming work successfully but getting stuck on the internal push queue?
* Are pushes to workers succeeding, timing out, or failing with specific gRPC errors?
* Are claimed activations being moved to processing successfully?
* Are workers accepting pushed tasks, or rejecting them because they are busy?
* Are pushed tasks actually closing the loop through `SetTaskStatus`?

This PR fills in those gaps.

## Changes
* Add fetch loop metrics for empty polls, claimed batch sizes, store errors, and submit outcomes
* Add push pool metrics for worker connection attempts, queue depth, queue wait time, RPC attempts, RPC outcomes, and delivery outcomes
* Add `mark_activation_processing` outcome metrics for success vs no-op cases
* Add push mode `SetTaskStatus` metrics for success, not-found, and error outcomes
* Add worker-side `PushTask` ingress metrics for attempt, accept, busy, and request duration
* Tag gRPC middleware request metrics with response status
