### PR TITLE
fix(ci): fix branch prefix in assemble-taskbroker-image condition

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -38,7 +38,7 @@ jobs:
   assemble-taskbroker-image:
     runs-on: ubuntu-latest
     needs: [build]
-    if: ${{ (github.ref_name == 'main' || startsWith(github.ref_name, 'releases/')) && github.event_name != 'pull_request' }}
+    if: ${{ (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) && github.event_name != 'pull_request' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Fix the release branch prefix check in the `assemble-taskbroker-image` job condition.

The condition was checking for `releases/` but our release branches use the
`release/` prefix (e.g., `release/0.1.0`, `release/25.10.0`). This meant the
image assembly job would never run on release branches.

This is being skipped: https://github.com/getsentry/taskbroker/actions/runs/24468414644/job/71502563907