### PR TITLE
fix(ci): fix image publishing on release branches

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -38,7 +38,7 @@ jobs:
   assemble-taskbroker-image:
     runs-on: ubuntu-latest
     needs: [build]
-    if: ${{ (github.ref_name == 'main' || startsWith(github.ref_name, 'releases/')) && github.event_name != 'pull_request' }}
+    if: ${{ (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) && github.event_name != 'pull_request' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build and push taskbroker image
-        uses: getsentry/action-build-and-push-images@a53f146fc1ea3cb404f2dcf7378f5b60dd98d3ca
+        uses: getsentry/action-build-and-push-images@8fc75e483c09a68721f2c8951292ee17f8821766
         with:
           image_name: 'taskbroker'
           platforms: linux/${{ matrix.platform }}
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build and push taskbroker image
-        uses: getsentry/action-build-and-push-images@a53f146fc1ea3cb404f2dcf7378f5b60dd98d3ca
+        uses: getsentry/action-build-and-push-images@8fc75e483c09a68721f2c8951292ee17f8821766
         with:
           image_name: 'taskbroker'
           platforms: linux/amd64


### PR DESCRIPTION
## Summary
- Bump `action-build-and-push-images` to include release branch publishing support (the old pinned version hardcoded `releases/*` instead of using the configurable `release_branches` input)

Fixes https://github.com/getsentry/taskbroker/actions/runs/24468414644/job/71502563907