### PR TITLE
ref(taskbroker): Flatten Imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# Taskbroker Development Guide for Agents
+
+## Overview
+Taskbroker is Sentry's distributed asynchronous task execution system. It consists of taskworkers (an application that executes tasks) and taskbrokers (an application that distributes tasks across workers).
+
+## Formatting
+Run `make format` before you commit. There are some other conventions you should follow that aren't enforced by that command, described below.
+
+### Rust Imports
+
+#### Flatten Imports
+Do not nest braced groups inside other braced groups. Use only one level of nesting per `use` statement. Here is an example.
+
+```rs
+use a::{ b::{c, d}, e::{f, g} }
+```
+
+Breaking apart this single statement into two improves readability.
+
+```rs
+use a::b::{c, d};
+use a::e::{f, g};
+```
+
+#### Group Imports
+
+Grouping is optional if there are **fewer than four** `use` lines. If there are **four or more** use lines, separate groups with a blank line in this order.
+
+  1. Standard library (`std::`)
+  2. External crates
+  3. Internal modules (`crate::`, `taskbroker::`)
+  4. Super modules (`super::`)
+
+If a single external crate needs **more than three** `use` lines, put that crate in its own group before other external crates.
+
+The first block below is **wrong on purpose** (mixed order and no blank lines).
+
+```rs
+use crate::store::adapters::postgres::{PostgresActivationStore, PostgresActivationStoreConfig};
+use crate::store::traits::InflightActivationStore;
+use std::sync::Arc;
+use rdkafka::Message;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
+use rdkafka::producer::FutureProducer;
+use anyhow::{Context, Result};
+use std::time::Duration;
+```
+
+The second block shows the correct layout.
+
+```rs
+use std::sync::Arc;
+use std::time::Duration;
+
+use rdkafka::Message;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
+use rdkafka::producer::FutureProducer;
+
+use anyhow::{Context, Result};
+
+use crate::store::adapters::postgres::{PostgresActivationStore, PostgresActivationStoreConfig};
+use crate::store::traits::InflightActivationStore;
+```

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -3,15 +3,14 @@ use std::sync::Arc;
 use chrono::Utc;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::Rng;
-use taskbroker::{
-    store::activation::InflightActivationStatus,
-    store::adapters::sqlite::{InflightActivationStoreConfig, SqliteActivationStore},
-    store::traits::InflightActivationStore,
-    test_utils::{
-        generate_temp_filename, generate_unique_namespace, make_activations_with_namespace,
-    },
-};
 use tokio::task::JoinSet;
+
+use taskbroker::store::activation::InflightActivationStatus;
+use taskbroker::store::adapters::sqlite::{InflightActivationStoreConfig, SqliteActivationStore};
+use taskbroker::store::traits::InflightActivationStore;
+use taskbroker::test_utils::{
+    generate_temp_filename, generate_unique_namespace, make_activations_with_namespace,
+};
 
 async fn get_pending_activations(num_activations: u32, num_workers: u32) {
     let url = if cfg!(feature = "bench-with-mnt-disk") {

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
-use std::{env, fs, process::Command};
+use std::process::Command;
+use std::{env, fs};
 
 fn emit_version() {
     let package_name = env::var("CARGO_PKG_NAME").unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,14 @@
 #![allow(clippy::result_large_err)]
-use figment::{
-    Figment, Metadata, Profile, Provider,
-    providers::{Env, Format, Yaml},
-};
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+
+use figment::providers::{Env, Format, Yaml};
+use figment::{Figment, Metadata, Profile, Provider};
 use rdkafka::ClientConfig;
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, collections::BTreeMap};
 
-use crate::{Args, logging::LogFormat};
+use crate::Args;
+use crate::logging::LogFormat;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -501,11 +502,15 @@ impl Provider for Config {
 
 #[cfg(test)]
 mod tests {
-    use std::{borrow::Cow, collections::BTreeMap};
+    use std::borrow::Cow;
+    use std::collections::BTreeMap;
+
+    use figment::Jail;
+
+    use crate::Args;
+    use crate::logging::LogFormat;
 
     use super::{Config, DatabaseAdapter, DeliveryMode};
-    use crate::{Args, logging::LogFormat};
-    use figment::Jail;
 
     #[test]
     fn test_default() {

--- a/src/fetch/tests.rs
+++ b/src/fetch/tests.rs
@@ -6,13 +6,14 @@ use tokio::sync::Mutex;
 use tokio::time::{Duration, sleep};
 use tonic::async_trait;
 
-use super::*;
 use crate::config::Config;
 use crate::push::PushError;
 use crate::store::activation::{InflightActivation, InflightActivationStatus};
 use crate::store::traits::InflightActivationStore;
 use crate::store::types::{BucketRange, FailedTasksForwarder};
 use crate::test_utils::make_activations;
+
+use super::*;
 
 /// Store stub that returns one activation once OR is always empty OR always fails.
 struct MockStore {

--- a/src/grpc/auth_middleware.rs
+++ b/src/grpc/auth_middleware.rs
@@ -1,11 +1,12 @@
+use std::mem;
+use std::task::{self, Poll};
+
 use anyhow::Context;
 use bytes::Bytes;
 use futures_util::future::BoxFuture;
 use hmac::{Hmac, Mac};
 use http_body_util::{BodyExt, Full};
 use sha2::Sha256;
-use std::mem;
-use std::task::{self, Poll};
 use tonic::body::Body;
 use tower::{Layer, Service};
 
@@ -146,12 +147,13 @@ fn validate_signature(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use bytes::Bytes;
     use hmac::{Hmac, Mac};
     use http::StatusCode;
     use http::request::Request;
     use sha2::Sha256;
+
+    use super::*;
 
     type Hmac256 = Hmac<Sha256>;
 

--- a/src/grpc/metrics_middleware.rs
+++ b/src/grpc/metrics_middleware.rs
@@ -55,9 +55,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use http::StatusCode;
     use tower::ServiceExt;
+
+    use super::*;
 
     #[tokio::test]
     async fn test_metrics_middleware() {

--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+use std::time::Instant;
+
 use chrono::Utc;
 use prost::Message;
 use sentry_protos::taskbroker::v1::consumer_service_server::ConsumerService;
@@ -5,14 +8,12 @@ use sentry_protos::taskbroker::v1::{
     FetchNextTask, GetTaskRequest, GetTaskResponse, SetTaskStatusRequest, SetTaskStatusResponse,
     TaskActivation, TaskActivationStatus,
 };
-use std::sync::Arc;
-use std::time::Instant;
 use tonic::{Request, Response, Status};
+use tracing::{error, instrument, warn};
 
 use crate::config::{Config, DeliveryMode};
 use crate::store::activation::InflightActivationStatus;
 use crate::store::traits::InflightActivationStore;
-use tracing::{error, instrument, warn};
 
 pub struct TaskbrokerServer {
     pub store: Arc<dyn InflightActivationStore>,

--- a/src/grpc/server_tests.rs
+++ b/src/grpc/server_tests.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-use crate::config::{Config, DeliveryMode};
-use crate::grpc::server::TaskbrokerServer;
-use crate::store::activation::InflightActivationStatus;
 use prost::Message;
 use rstest::rstest;
 use sentry_protos::taskbroker::v1::consumer_service_server::ConsumerService;
@@ -11,6 +8,9 @@ use sentry_protos::taskbroker::v1::{
 };
 use tonic::{Code, Request};
 
+use crate::config::{Config, DeliveryMode};
+use crate::grpc::server::TaskbrokerServer;
+use crate::store::activation::InflightActivationStatus;
 use crate::test_utils::{create_config, create_test_store, make_activations};
 
 #[tokio::test]

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -1,8 +1,6 @@
 use anyhow::Error;
-use rdkafka::{
-    ClientConfig,
-    admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
-};
+use rdkafka::ClientConfig;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
 use tracing::info;
 
 pub async fn create_missing_topics(

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -1,46 +1,34 @@
-use crate::store::traits::InflightActivationStore;
-use anyhow::{Error, anyhow};
-use futures::{
-    Stream, StreamExt,
-    future::{self},
-    pin_mut,
-};
-use rdkafka::{
-    ClientConfig, ClientContext, Message, Offset, TopicPartitionList,
-    consumer::{
-        BaseConsumer, Consumer, ConsumerContext, Rebalance, StreamConsumer,
-        stream_consumer::StreamPartitionQueue,
-    },
-    error::{KafkaError, KafkaResult},
-    message::{BorrowedMessage, OwnedMessage},
-    types::RDKafkaErrorCode,
-};
-use std::{
-    cmp,
-    collections::{BTreeSet, HashMap},
-    fmt::Debug,
-    future::Future,
-    iter,
-    mem::take,
-    sync::{
-        Arc,
-        mpsc::{SyncSender, sync_channel},
-    },
-    time::Duration,
-};
-use tokio::{
-    runtime::Handle,
-    select,
-    sync::{
-        mpsc::{self, UnboundedReceiver, UnboundedSender, unbounded_channel},
-        oneshot,
-    },
-    task::{self, JoinError, JoinSet},
-    time::{self, MissedTickBehavior, sleep},
-};
+use std::collections::{BTreeSet, HashMap};
+use std::fmt::Debug;
+use std::future::Future;
+use std::mem::take;
+use std::sync::Arc;
+use std::sync::mpsc::{SyncSender, sync_channel};
+use std::time::Duration;
+use std::{cmp, iter};
+
+use rdkafka::consumer::stream_consumer::StreamPartitionQueue;
+use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext, Rebalance, StreamConsumer};
+use rdkafka::error::{KafkaError, KafkaResult};
+use rdkafka::message::{BorrowedMessage, OwnedMessage};
+use rdkafka::types::RDKafkaErrorCode;
+use rdkafka::{ClientConfig, ClientContext, Message, Offset, TopicPartitionList};
+
+use tokio::runtime::Handle;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::{JoinError, JoinSet};
+use tokio::time::{MissedTickBehavior, sleep};
+use tokio::{select, task, time};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tokio_util::{either::Either, sync::CancellationToken};
+use tokio_util::either::Either;
+use tokio_util::sync::CancellationToken;
+
+use anyhow::{Error, anyhow};
+use futures::{Stream, StreamExt, future, pin_mut};
 use tracing::{debug, error, info, instrument, warn};
+
+use crate::store::traits::InflightActivationStore;
 
 pub async fn start_consumer(
     topics: &[&str],
@@ -824,37 +812,30 @@ pub async fn commit(
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashMap,
-        iter,
-        marker::PhantomData,
-        mem::take,
-        sync::{Arc, RwLock},
-        time::Duration,
-    };
+    use std::collections::HashMap;
+    use std::iter;
+    use std::marker::PhantomData;
+    use std::mem::take;
+    use std::sync::{Arc, RwLock};
+    use std::time::Duration;
 
     use anyhow::{Error, anyhow};
     use futures::Stream;
-    use rdkafka::{
-        Message, Offset, Timestamp, TopicPartitionList,
-        error::{KafkaError, KafkaResult},
-        message::OwnedMessage,
-    };
-    use tokio::{
-        sync::{broadcast, mpsc, oneshot},
-        time::sleep,
-    };
-    use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
+    use rdkafka::error::{KafkaError, KafkaResult};
+    use rdkafka::message::OwnedMessage;
+    use rdkafka::{Message, Offset, Timestamp, TopicPartitionList};
+    use tokio::sync::{broadcast, mpsc, oneshot};
+    use tokio::time::sleep;
+    use tokio_stream::wrappers::BroadcastStream;
+    use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
     use tokio_util::sync::CancellationToken;
 
-    use crate::kafka::{
-        consumer::{
-            CommitClient, KafkaMessage, MessageQueue, ReduceConfig, ReduceShutdownBehaviour,
-            ReduceShutdownCondition, Reducer, ReducerWhenFullBehaviour, commit, map, reduce,
-            reduce_err,
-        },
-        os_stream_writer::{OsStream, OsStreamWriter},
+    use crate::kafka::consumer::{
+        CommitClient, KafkaMessage, MessageQueue, ReduceConfig, ReduceShutdownBehaviour,
+        ReduceShutdownCondition, Reducer, ReducerWhenFullBehaviour, commit, map, reduce,
+        reduce_err,
     };
+    use crate::kafka::os_stream_writer::{OsStream, OsStreamWriter};
 
     struct MockCommitClient {
         offsets: Arc<RwLock<Vec<TopicPartitionList>>>,

--- a/src/kafka/deserialize_activation.rs
+++ b/src/kafka/deserialize_activation.rs
@@ -1,15 +1,18 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Error, anyhow};
+use chrono::{DateTime, Utc};
+use prost::Message as _;
+use rdkafka::Message;
+use rdkafka::message::OwnedMessage;
+use sentry_protos::taskbroker::v1::OnAttemptsExceeded;
+use sentry_protos::taskbroker::v1::TaskActivation;
+use uuid::Uuid;
 
 use crate::config::Config;
 use crate::fetch::MAX_FETCH_THREADS;
 use crate::store::activation::{InflightActivation, InflightActivationStatus};
-use anyhow::{Error, anyhow};
-use chrono::{DateTime, Utc};
-use prost::Message as _;
-use rdkafka::{Message, message::OwnedMessage};
-use sentry_protos::taskbroker::v1::OnAttemptsExceeded;
-use sentry_protos::taskbroker::v1::TaskActivation;
-use uuid::Uuid;
 
 pub struct DeserializeActivationConfig {
     pub max_delayed_allowed: u64,
@@ -115,16 +118,18 @@ pub fn new(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc, time::Duration};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Duration;
 
     use chrono::Utc;
     use prost::Message as _;
-    use rdkafka::{Timestamp, message::OwnedMessage};
+    use rdkafka::Timestamp;
+    use rdkafka::message::OwnedMessage;
     use sentry_protos::taskbroker::v1::TaskActivation;
 
-    use crate::{
-        store::activation::InflightActivationStatus, test_utils::generate_unique_namespace,
-    };
+    use crate::store::activation::InflightActivationStatus;
+    use crate::test_utils::generate_unique_namespace;
 
     use super::{Config, DeserializeActivationConfig, new};
 

--- a/src/kafka/inflight_activation_batcher.rs
+++ b/src/kafka/inflight_activation_batcher.rs
@@ -1,14 +1,16 @@
-use crate::{
-    config::Config, runtime_config::RuntimeConfigManager, store::activation::InflightActivation,
-};
+use std::mem::replace;
+use std::sync::Arc;
+use std::time::Duration;
+
 use chrono::Utc;
 use futures::future::join_all;
 use rdkafka::config::ClientConfig;
-use rdkafka::{
-    producer::{FutureProducer, FutureRecord},
-    util::Timeout,
-};
-use std::{mem::replace, sync::Arc, time::Duration};
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::util::Timeout;
+
+use crate::config::Config;
+use crate::runtime_config::RuntimeConfigManager;
+use crate::store::activation::InflightActivation;
 
 use super::consumer::{
     ReduceConfig, ReduceShutdownBehaviour, ReduceShutdownCondition, Reducer,
@@ -211,17 +213,16 @@ impl Reducer for InflightActivationBatcher {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        ActivationBatcherConfig, Config, InflightActivationBatcher, Reducer, RuntimeConfigManager,
-    };
+    use std::sync::Arc;
+
     use chrono::Utc;
     use tokio::fs;
 
-    use std::sync::Arc;
+    use crate::store::activation::InflightActivationBuilder;
+    use crate::test_utils::{TaskActivationBuilder, generate_unique_namespace};
 
-    use crate::{
-        store::activation::InflightActivationBuilder,
-        test_utils::{TaskActivationBuilder, generate_unique_namespace},
+    use super::{
+        ActivationBatcherConfig, Config, InflightActivationBatcher, Reducer, RuntimeConfigManager,
     };
 
     #[tokio::test]

--- a/src/kafka/inflight_activation_writer.rs
+++ b/src/kafka/inflight_activation_writer.rs
@@ -1,18 +1,14 @@
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use tokio::time::sleep;
 use tracing::{debug, error, instrument};
 
-use crate::{
-    config::Config,
-    store::activation::{InflightActivation, InflightActivationStatus},
-    store::traits::InflightActivationStore,
-    store::types::DepthCounts,
-};
+use crate::config::Config;
+use crate::store::activation::{InflightActivation, InflightActivationStatus};
+use crate::store::traits::InflightActivationStore;
+use crate::store::types::DepthCounts;
 
 use super::consumer::{
     ReduceConfig, ReduceShutdownBehaviour, ReduceShutdownCondition, Reducer,
@@ -198,13 +194,12 @@ mod tests {
     use chrono::DateTime;
     use rstest::rstest;
 
-    use super::{ActivationWriterConfig, InflightActivationWriter, Reducer};
-    use crate::{
-        store::activation::{InflightActivationBuilder, InflightActivationStatus},
-        test_utils::{
-            TaskActivationBuilder, create_test_store, generate_unique_namespace, make_activations,
-        },
+    use crate::store::activation::{InflightActivationBuilder, InflightActivationStatus};
+    use crate::test_utils::{
+        TaskActivationBuilder, create_test_store, generate_unique_namespace, make_activations,
     };
+
+    use super::{ActivationWriterConfig, InflightActivationWriter, Reducer};
 
     #[tokio::test]
     #[rstest]

--- a/src/kafka/os_stream_writer.rs
+++ b/src/kafka/os_stream_writer.rs
@@ -1,9 +1,13 @@
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::time::Duration;
+
+use tokio::time::sleep;
+
 use crate::kafka::consumer::{
     ReduceConfig, ReduceShutdownBehaviour, ReduceShutdownCondition, Reducer,
     ReducerWhenFullBehaviour,
 };
-use std::{fmt::Debug, marker::PhantomData, time::Duration};
-use tokio::time::sleep;
 
 pub enum OsStream {
     StdOut,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,12 +1,15 @@
-use sentry::{integrations::tracing::EventFilter, types::Dsn};
-use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::str::FromStr;
+
+use sentry::integrations::tracing::EventFilter;
+use sentry::types::Dsn;
+use serde::{Deserialize, Serialize};
 use tracing_subscriber::Layer;
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::prelude::*;
 
-use crate::{config::Config, get_version};
+use crate::config::Config;
+use crate::get_version;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,44 +1,46 @@
+use std::sync::Arc;
+use std::time::Duration;
+
 use anyhow::{Error, anyhow};
 use chrono::Utc;
 use clap::Parser;
-use std::{sync::Arc, time::Duration};
-use taskbroker::fetch::FetchPool;
-use taskbroker::kafka::inflight_activation_batcher::{
-    ActivationBatcherConfig, InflightActivationBatcher,
-};
-use taskbroker::push::PushPool;
-use taskbroker::upkeep::upkeep;
+use sentry_protos::taskbroker::v1::consumer_service_server::ConsumerServiceServer;
 use tokio::signal::unix::SignalKind;
 use tokio::task::JoinHandle;
 use tokio::{select, time};
 use tonic::transport::Server;
+use tonic_health::ServingStatus;
 use tracing::{debug, error, info, warn};
-
-use sentry_protos::taskbroker::v1::consumer_service_server::ConsumerServiceServer;
 
 use taskbroker::SERVICE_NAME;
 use taskbroker::config::{Config, DatabaseAdapter, DeliveryMode};
+use taskbroker::fetch::FetchPool;
 use taskbroker::grpc::auth_middleware::AuthLayer;
 use taskbroker::grpc::metrics_middleware::MetricsLayer;
 use taskbroker::grpc::server::TaskbrokerServer;
-use taskbroker::kafka::{
-    admin::create_missing_topics,
-    consumer::start_consumer,
-    deserialize_activation::{self, DeserializeActivationConfig},
-    inflight_activation_writer::{ActivationWriterConfig, InflightActivationWriter},
-    os_stream_writer::{OsStream, OsStreamWriter},
+use taskbroker::kafka::admin::create_missing_topics;
+use taskbroker::kafka::consumer::start_consumer;
+use taskbroker::kafka::deserialize_activation;
+use taskbroker::kafka::deserialize_activation::DeserializeActivationConfig;
+use taskbroker::kafka::inflight_activation_batcher::{
+    ActivationBatcherConfig, InflightActivationBatcher,
 };
+use taskbroker::kafka::inflight_activation_writer::{
+    ActivationWriterConfig, InflightActivationWriter,
+};
+use taskbroker::kafka::os_stream_writer::{OsStream, OsStreamWriter};
 use taskbroker::logging;
 use taskbroker::metrics;
 use taskbroker::processing_strategy;
+use taskbroker::push::PushPool;
 use taskbroker::runtime_config::RuntimeConfigManager;
 use taskbroker::store::adapters::postgres::{
     PostgresActivationStore, PostgresActivationStoreConfig,
 };
 use taskbroker::store::adapters::sqlite::{InflightActivationStoreConfig, SqliteActivationStore};
 use taskbroker::store::traits::InflightActivationStore;
+use taskbroker::upkeep::upkeep;
 use taskbroker::{Args, get_version};
-use tonic_health::ServingStatus;
 
 async fn log_task_completion<T: AsRef<str>>(name: T, task: JoinHandle<Result<(), Error>>) {
     match task.await {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,9 +1,9 @@
-use crate::config::Config;
+use std::collections::BTreeMap;
+use std::net::{SocketAddr, ToSocketAddrs};
+
 use metrics_exporter_statsd::StatsdBuilder;
-use std::{
-    collections::BTreeMap,
-    net::{SocketAddr, ToSocketAddrs},
-};
+
+use crate::config::Config;
 
 pub struct MetricsConfig {
     pub statsd_addr: SocketAddr,

--- a/src/push/tests.rs
+++ b/src/push/tests.rs
@@ -5,9 +5,10 @@ use sentry_protos::taskbroker::v1::PushTaskRequest;
 use tokio::time::{Duration, timeout};
 use tonic::async_trait;
 
-use super::*;
 use crate::config::Config;
 use crate::test_utils::{create_test_store, make_activations};
+
+use super::*;
 
 /// Fake worker client for unit testing.
 struct MockWorkerClient {

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -1,6 +1,7 @@
-use serde::Deserialize;
 use std::sync::Arc;
 use std::time::Duration;
+
+use serde::Deserialize;
 use tokio::fs;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;

--- a/src/store/activation.rs
+++ b/src/store/activation.rs
@@ -1,9 +1,10 @@
+use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::str::FromStr;
+
 use chrono::{DateTime, Utc};
 use derive_builder::Builder;
 use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivationStatus};
 use sqlx::Type;
-use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::str::FromStr;
 
 /// The members of this enum should be a superset of the members
 /// of `InflightActivationStatus` in `sentry_protos`.

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -1,16 +1,16 @@
+use std::str::FromStr;
+use std::sync::RwLock;
+use std::time::Instant;
+
+use sqlx::ConnectOptions;
+use sqlx::pool::PoolConnection;
+use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
+use sqlx::{FromRow, Pool, Postgres, QueryBuilder};
+
 use anyhow::{Error, anyhow};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sentry_protos::taskbroker::v1::OnAttemptsExceeded;
-use sqlx::ConnectOptions;
-use sqlx::{
-    FromRow, Pool, Postgres, QueryBuilder,
-    pool::PoolConnection,
-    postgres::{PgConnectOptions, PgPool, PgPoolOptions},
-};
-use std::str::FromStr;
-use std::sync::RwLock;
-use std::time::Instant;
 use tracing::{instrument, warn};
 
 use crate::config::Config;

--- a/src/store/adapters/sqlite.rs
+++ b/src/store/adapters/sqlite.rs
@@ -1,3 +1,14 @@
+use std::str::FromStr;
+use std::time::Instant;
+
+use sqlx::migrate::MigrateDatabase;
+use sqlx::pool::{PoolConnection, PoolOptions};
+use sqlx::sqlite::{
+    SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqliteRow,
+    SqliteSynchronous,
+};
+use sqlx::{ConnectOptions, FromRow, Pool, QueryBuilder, Row, Sqlite};
+
 use anyhow::{Error, anyhow};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -11,16 +22,6 @@ use libsqlite3_sys::{
 };
 use sentry_protos::taskbroker::v1::OnAttemptsExceeded;
 use tracing::{instrument, warn};
-
-use sqlx::migrate::MigrateDatabase;
-use sqlx::pool::{PoolConnection, PoolOptions};
-use sqlx::sqlite::{
-    SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqliteRow,
-    SqliteSynchronous,
-};
-use sqlx::{ConnectOptions, FromRow, Pool, QueryBuilder, Row, Sqlite};
-
-use std::{str::FromStr, time::Instant};
 
 use crate::config::Config;
 use crate::store::activation::{InflightActivation, InflightActivationStatus};

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -1,25 +1,30 @@
+use std::collections::HashSet;
+use std::fs;
+use std::io::Error;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
 use chrono::{DateTime, SubsecRound, TimeZone, Utc};
 use rstest::rstest;
 use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, RetryState, TaskActivationStatus};
 use sqlx::postgres::PgSslMode;
 use sqlx::{QueryBuilder, Sqlite};
-use std::{collections::HashSet, fs, io::Error, path::Path, sync::Arc, time::Duration};
-use tokio::{sync::broadcast, task::JoinSet};
+use tokio::sync::broadcast;
+use tokio::task::JoinSet;
 
-use crate::{
-    config::Config,
-    store::activation::{InflightActivationBuilder, InflightActivationStatus},
-    store::adapters::{
-        postgres::PostgresActivationStoreConfig,
-        sqlite::{InflightActivationStoreConfig, SqliteActivationStore, create_sqlite_pool},
-    },
-    store::traits::InflightActivationStore,
-    test_utils::{
-        StatusCount, TaskActivationBuilder, assert_counts, create_integration_config,
-        create_integration_config_with_ssl, create_test_store, generate_temp_filename,
-        generate_unique_namespace, make_activations, make_activations_with_namespace,
-        replace_retry_state,
-    },
+use crate::config::Config;
+use crate::store::activation::{InflightActivationBuilder, InflightActivationStatus};
+use crate::store::adapters::postgres::PostgresActivationStoreConfig;
+use crate::store::adapters::sqlite::{
+    InflightActivationStoreConfig, SqliteActivationStore, create_sqlite_pool,
+};
+use crate::store::traits::InflightActivationStore;
+use crate::test_utils::{
+    StatusCount, TaskActivationBuilder, assert_counts, create_integration_config,
+    create_integration_config_with_ssl, create_test_store, generate_temp_filename,
+    generate_unique_namespace, make_activations, make_activations_with_namespace,
+    replace_retry_state,
 };
 
 #[test]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,28 +1,27 @@
+use std::collections::HashMap;
+use std::env::var;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use rdkafka::Message;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
+use rdkafka::producer::FutureProducer;
+
 use chrono::Utc;
 use futures::StreamExt;
 use prost::Message as ProstMessage;
 use prost_types::Timestamp;
-use rdkafka::{
-    Message,
-    admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
-    consumer::{CommitMode, Consumer, StreamConsumer},
-    producer::FutureProducer,
-};
 use sentry_protos::taskbroker::v1::{self, OnAttemptsExceeded, RetryState, TaskActivation};
-use std::{collections::HashMap, env::var, sync::Arc, time::SystemTime};
 use uuid::Uuid;
 
-use crate::{
-    config::Config,
-    store::{
-        activation::{InflightActivation, InflightActivationBuilder, InflightActivationStatus},
-        adapters::{
-            postgres::{PostgresActivationStore, PostgresActivationStoreConfig},
-            sqlite::{InflightActivationStoreConfig, SqliteActivationStore},
-        },
-        traits::InflightActivationStore,
-    },
+use crate::config::Config;
+use crate::store::activation::{
+    InflightActivation, InflightActivationBuilder, InflightActivationStatus,
 };
+use crate::store::adapters::postgres::{PostgresActivationStore, PostgresActivationStoreConfig};
+use crate::store::adapters::sqlite::{InflightActivationStoreConfig, SqliteActivationStore};
+use crate::store::traits::InflightActivationStore;
 
 /// Builder for `TaskActivation`. We cannot generate a builder automatically because `TaskActivation` is defined in `sentry-protos`.
 pub struct TaskActivationBuilder {

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,5 +1,4 @@
 use std::future::Future;
-
 use tokio::task::JoinSet;
 
 /// Spawns `max(n, 1)` tasks, each running the future produced by `f` with the task's index.

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Timelike, Utc};
-use futures::{StreamExt, stream::FuturesUnordered};
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
 use prost::Message;
 use prost_types::Timestamp;
 use rdkafka::error::KafkaError;
@@ -522,28 +523,27 @@ pub async fn check_health(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+    use std::time::Instant;
+
     use chrono::{DateTime, TimeDelta, TimeZone, Utc};
     use prost::Message;
     use prost_types::Timestamp;
     use rstest::rstest;
     use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, RetryState, TaskActivation};
-    use std::sync::Arc;
-    use std::time::Duration;
-    use std::time::Instant;
     use tokio::fs;
     use tokio::time::sleep;
 
-    use crate::{
-        config::Config,
-        runtime_config::RuntimeConfigManager,
-        store::activation::InflightActivationStatus,
-        test_utils::{
-            StatusCount, assert_counts, consume_topic, create_config, create_integration_config,
-            create_integration_config_with_topic, create_producer, create_test_store,
-            make_activations, replace_retry_state, reset_topic,
-        },
-        upkeep::{create_retry_activation, do_upkeep},
+    use crate::config::Config;
+    use crate::runtime_config::RuntimeConfigManager;
+    use crate::store::activation::InflightActivationStatus;
+    use crate::test_utils::{
+        StatusCount, assert_counts, consume_topic, create_config, create_integration_config,
+        create_integration_config_with_topic, create_producer, create_test_store, make_activations,
+        replace_retry_state, reset_topic,
     };
+    use crate::upkeep::{create_retry_activation, do_upkeep};
 
     #[tokio::test]
     async fn test_retry_activation_sets_delay_with_delay_on_retry() {


### PR DESCRIPTION
## Linear
Completes [STREAM-878](https://linear.app/getsentry/issue/STREAM-878/flatten-imports)
Completes [STREAM-885](https://linear.app/getsentry/issue/STREAM-885/add-agentsmd-file)

## Description
Unfortunately, `rustfmt` combined with autocompleted imports tends to results in massive unreadable `use` statements with multiple layers of nesting, such as this piece of work at the top of main.rs.

```rs
use taskbroker::kafka::{
    admin::create_missing_topics,
    consumer::start_consumer,
    deserialize_activation::{self, DeserializeActivationConfig},
    inflight_activation_writer::{ActivationWriterConfig, InflightActivationWriter},
    os_stream_writer::{OsStream, OsStreamWriter},
};
```

Not very readable. Let's "flatten" these imports to just a single level of nesting.

```rs
use taskbroker::kafka::admin::create_missing_topics;
use taskbroker::kafka::consumer::start_consumer;
use taskbroker::kafka::deserialize_activation::{self, DeserializeActivationConfig};
use taskbroker::kafka::inflight_activation_writer::{ActivationWriterConfig, InflightActivationWriter};
use taskbroker::kafka::os_stream_writer::{OsStream, OsStreamWriter};
```

It's easier to read when every use statement is exactly one line, I think. Many popular Rust projects use this approach, such as `serde`. Here is an example from that crate.

```rs
use crate::internals::ast::{Container, Data, Field, Style};
use crate::internals::attr::{Default, Identifier, TagType};
use crate::internals::{ungroup, Ctxt, Derive};
...
```

It will be better on everyone's eyes to make this change, and it will also bring our codebase formatting closer to the formatting in real and widely used Rust projects.

**There should be no changes to behavior.**