### PR TITLE
feat(iswf): Adds silenced_exceptions parameter to tasks, exposes this and report_timeout_errors in task registration

### DIFF
--- a/clients/python/src/examples/tasks.py
+++ b/clients/python/src/examples/tasks.py
@@ -72,3 +72,30 @@ def will_retry(failure: str) -> None:
 def timed_task(sleep_seconds: float | str, *args: list[Any], **kwargs: dict[str, Any]) -> None:
     sleep(float(sleep_seconds))
     logger.debug("timed_task complete")
+
+
+@exampletasks.register(
+    name="examples.will_timeout_without_reporting",
+    processing_deadline_duration=1,
+    report_timeout_errors=False,
+)
+def will_timeout_without_reporting() -> None:
+    timed_task(sleep_seconds=2)
+
+
+@exampletasks.register(
+    name="examples.will_fail_with_expected_exception",
+    retry=Retry(times=2, times_exceeded=LastAction.Discard),
+    expected_exceptions=(RuntimeError,),
+)
+def will_fail_with_expected_exception() -> None:
+    raise RuntimeError("oh no")
+
+
+@exampletasks.register(
+    name="examples.will_fail_with_expected_ignored_exception",
+    retry=Retry(times=2, on=(RuntimeError,), times_exceeded=LastAction.Discard),
+    expected_exceptions=(RuntimeError,),
+)
+def will_fail_with_expected_ignored_exception() -> None:
+    raise RuntimeError("oh no")

--- a/clients/python/src/examples/tasks.py
+++ b/clients/python/src/examples/tasks.py
@@ -13,6 +13,7 @@ from redis import StrictRedis
 from examples.app import app
 from taskbroker_client.retry import LastAction, NoRetriesRemainingError, Retry, RetryTaskError
 from taskbroker_client.retry import retry_task as retry_task_helper
+from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 logger = logging.getLogger(__name__)
 
@@ -99,3 +100,12 @@ def will_fail_with_expected_exception() -> None:
 )
 def will_fail_with_expected_ignored_exception() -> None:
     raise RuntimeError("oh no")
+
+
+@exampletasks.register(
+    name="examples.will_retry_on_deadline_exceeded",
+    processing_deadline_duration=1,
+    retry=Retry(times=2, on=(ProcessingDeadlineExceeded,), times_exceeded=LastAction.Discard),
+)
+def will_retry_on_deadline_exceeded() -> None:
+    timed_task(sleep_seconds=2)

--- a/clients/python/src/examples/tasks.py
+++ b/clients/python/src/examples/tasks.py
@@ -85,20 +85,20 @@ def will_timeout_without_reporting() -> None:
 
 
 @exampletasks.register(
-    name="examples.will_fail_with_expected_exception",
+    name="examples.will_fail_with_silenced_exception",
     retry=Retry(times=2, times_exceeded=LastAction.Discard),
-    expected_exceptions=(RuntimeError,),
+    silenced_exceptions=(RuntimeError,),
 )
-def will_fail_with_expected_exception() -> None:
+def will_fail_with_silenced_exception() -> None:
     raise RuntimeError("oh no")
 
 
 @exampletasks.register(
-    name="examples.will_fail_with_expected_ignored_exception",
+    name="examples.will_fail_with_silenced_ignored_exception",
     retry=Retry(times=2, on=(RuntimeError,), times_exceeded=LastAction.Discard),
-    expected_exceptions=(RuntimeError,),
+    silenced_exceptions=(RuntimeError,),
 )
-def will_fail_with_expected_ignored_exception() -> None:
+def will_fail_with_silenced_ignored_exception() -> None:
     raise RuntimeError("oh no")
 
 

--- a/clients/python/src/taskbroker_client/registry.py
+++ b/clients/python/src/taskbroker_client/registry.py
@@ -89,7 +89,7 @@ class TaskNamespace:
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
         report_timeout_errors: bool = True,
-        exceptions_to_silence: tuple[type[BaseException], ...] | None = None,
+        expected_exceptions: tuple[type[BaseException], ...] | None = None,
     ) -> Callable[[Callable[P, R]], Task[P, R]]:
         """
         Register a task.
@@ -117,6 +117,10 @@ class TaskNamespace:
             before returning.
         compression_type: CompressionType
             The compression type to use to compress the task parameters.
+        report_timeout_errors: bool
+            Enable reporting of ProcessingDeadlineExceededError to Sentry.
+        expected_exceptions: tuple[type[BaseException], ...] | None
+            A tuple of exception types that will not be reported by Sentry.
         """
 
         def wrapped(func: Callable[P, R]) -> Task[P, R]:
@@ -136,7 +140,7 @@ class TaskNamespace:
                 wait_for_delivery=wait_for_delivery,
                 compression_type=compression_type,
                 report_timeout_errors=report_timeout_errors,
-                exceptions_to_silence=exceptions_to_silence,
+                expected_exceptions=expected_exceptions,
             )
             # TODO(taskworker) tasks should be registered into the registry
             # so that we can ensure task names are globally unique
@@ -229,7 +233,7 @@ class ExternalNamespace(TaskNamespace):
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
         report_timeout_errors: bool = True,
-        exceptions_to_silence: tuple[type[BaseException], ...] | None = None,
+        expected_exceptions: tuple[type[BaseException], ...] | None = None,
     ) -> Callable[[Callable[P, R]], ExternalTask[P, R]]:
         """
         Register an external task stub.
@@ -257,6 +261,10 @@ class ExternalNamespace(TaskNamespace):
             before returning.
         compression_type: CompressionType
             The compression type to use to compress the task parameters.
+        report_timeout_errors: bool
+            Enable reporting of ProcessingDeadlineExceededError to Sentry.
+        expected_exceptions: tuple[type[BaseException], ...] | None
+            A tuple of exception types that will not be reported by Sentry.
         """
 
         def wrapped(func: Callable[P, R]) -> ExternalTask[P, R]:
@@ -276,7 +284,7 @@ class ExternalNamespace(TaskNamespace):
                 wait_for_delivery=wait_for_delivery,
                 compression_type=compression_type,
                 report_timeout_errors=report_timeout_errors,
-                exceptions_to_silence=exceptions_to_silence,
+                expected_exceptions=expected_exceptions,
             )
             self._registered_tasks[name] = task
             return task

--- a/clients/python/src/taskbroker_client/registry.py
+++ b/clients/python/src/taskbroker_client/registry.py
@@ -43,6 +43,7 @@ class TaskNamespace:
         processing_deadline_duration: int = DEFAULT_PROCESSING_DEADLINE,
         app_feature: str | None = None,
         context_hooks: list[ContextHook] | None = None,
+        report_timeout_errors: bool = True,
     ):
         self.name = name
         self.application = application
@@ -88,6 +89,8 @@ class TaskNamespace:
         at_most_once: bool = False,
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
+        report_timeout_errors: bool = True,
+        exceptions_to_silence: tuple[type[BaseException], ...] | None = None,
     ) -> Callable[[Callable[P, R]], Task[P, R]]:
         """
         Register a task.
@@ -133,6 +136,8 @@ class TaskNamespace:
                 at_most_once=at_most_once,
                 wait_for_delivery=wait_for_delivery,
                 compression_type=compression_type,
+                report_timeout_errors=report_timeout_errors,
+                exceptions_to_silence=exceptions_to_silence,
             )
             # TODO(taskworker) tasks should be registered into the registry
             # so that we can ensure task names are globally unique
@@ -224,6 +229,8 @@ class ExternalNamespace(TaskNamespace):
         at_most_once: bool = False,
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
+        report_timeout_errors: bool = True,
+        exceptions_to_silence: tuple[type[BaseException], ...] | None = None,
     ) -> Callable[[Callable[P, R]], ExternalTask[P, R]]:
         """
         Register an external task stub.
@@ -269,6 +276,8 @@ class ExternalNamespace(TaskNamespace):
                 at_most_once=at_most_once,
                 wait_for_delivery=wait_for_delivery,
                 compression_type=compression_type,
+                report_timeout_errors=report_timeout_errors,
+                exceptions_to_silence=exceptions_to_silence,
             )
             self._registered_tasks[name] = task
             return task

--- a/clients/python/src/taskbroker_client/registry.py
+++ b/clients/python/src/taskbroker_client/registry.py
@@ -43,7 +43,6 @@ class TaskNamespace:
         processing_deadline_duration: int = DEFAULT_PROCESSING_DEADLINE,
         app_feature: str | None = None,
         context_hooks: list[ContextHook] | None = None,
-        report_timeout_errors: bool = True,
     ):
         self.name = name
         self.application = application

--- a/clients/python/src/taskbroker_client/registry.py
+++ b/clients/python/src/taskbroker_client/registry.py
@@ -89,7 +89,7 @@ class TaskNamespace:
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
         report_timeout_errors: bool = True,
-        expected_exceptions: tuple[type[BaseException], ...] | None = None,
+        silenced_exceptions: tuple[type[BaseException], ...] | None = None,
     ) -> Callable[[Callable[P, R]], Task[P, R]]:
         """
         Register a task.
@@ -119,7 +119,7 @@ class TaskNamespace:
             The compression type to use to compress the task parameters.
         report_timeout_errors: bool
             Enable reporting of ProcessingDeadlineExceededError to Sentry.
-        expected_exceptions: tuple[type[BaseException], ...] | None
+        silenced_exceptions: tuple[type[BaseException], ...] | None
             A tuple of exception types that will not be reported by Sentry.
         """
 
@@ -140,7 +140,7 @@ class TaskNamespace:
                 wait_for_delivery=wait_for_delivery,
                 compression_type=compression_type,
                 report_timeout_errors=report_timeout_errors,
-                expected_exceptions=expected_exceptions,
+                silenced_exceptions=silenced_exceptions,
             )
             # TODO(taskworker) tasks should be registered into the registry
             # so that we can ensure task names are globally unique
@@ -233,7 +233,7 @@ class ExternalNamespace(TaskNamespace):
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
         report_timeout_errors: bool = True,
-        expected_exceptions: tuple[type[BaseException], ...] | None = None,
+        silenced_exceptions: tuple[type[BaseException], ...] | None = None,
     ) -> Callable[[Callable[P, R]], ExternalTask[P, R]]:
         """
         Register an external task stub.
@@ -263,7 +263,7 @@ class ExternalNamespace(TaskNamespace):
             The compression type to use to compress the task parameters.
         report_timeout_errors: bool
             Enable reporting of ProcessingDeadlineExceededError to Sentry.
-        expected_exceptions: tuple[type[BaseException], ...] | None
+        silenced_exceptions: tuple[type[BaseException], ...] | None
             A tuple of exception types that will not be reported by Sentry.
         """
 
@@ -284,7 +284,7 @@ class ExternalNamespace(TaskNamespace):
                 wait_for_delivery=wait_for_delivery,
                 compression_type=compression_type,
                 report_timeout_errors=report_timeout_errors,
-                expected_exceptions=expected_exceptions,
+                silenced_exceptions=silenced_exceptions,
             )
             self._registered_tasks[name] = task
             return task

--- a/clients/python/src/taskbroker_client/task.py
+++ b/clients/python/src/taskbroker_client/task.py
@@ -67,7 +67,7 @@ class Task(Generic[P, R]):
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
         report_timeout_errors: bool = True,
-        expected_exceptions: tuple[type[BaseException], ...] | None = None,
+        silenced_exceptions: tuple[type[BaseException], ...] | None = None,
     ):
         self.name = name
         self._func = func
@@ -87,7 +87,7 @@ class Task(Generic[P, R]):
         self.wait_for_delivery = wait_for_delivery
         self.compression_type = compression_type
         self.report_timeout_errors = report_timeout_errors
-        self.expected_exceptions = expected_exceptions or ()
+        self.silenced_exceptions = silenced_exceptions or ()
         update_wrapper(self, func)
 
     @property

--- a/clients/python/src/taskbroker_client/task.py
+++ b/clients/python/src/taskbroker_client/task.py
@@ -67,7 +67,7 @@ class Task(Generic[P, R]):
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
         report_timeout_errors: bool = True,
-        exceptions_to_silence: tuple[type[BaseException], ...] | None = None,
+        expected_exceptions: tuple[type[BaseException], ...] | None = None,
     ):
         self.name = name
         self._func = func
@@ -87,7 +87,7 @@ class Task(Generic[P, R]):
         self.wait_for_delivery = wait_for_delivery
         self.compression_type = compression_type
         self.report_timeout_errors = report_timeout_errors
-        self.exceptions_to_silence = exceptions_to_silence or ()
+        self.expected_exceptions = expected_exceptions or ()
         update_wrapper(self, func)
 
     @property

--- a/clients/python/src/taskbroker_client/task.py
+++ b/clients/python/src/taskbroker_client/task.py
@@ -67,6 +67,7 @@ class Task(Generic[P, R]):
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
         report_timeout_errors: bool = True,
+        exceptions_to_silence: tuple[type[BaseException], ...] | None = None,
     ):
         self.name = name
         self._func = func
@@ -86,6 +87,7 @@ class Task(Generic[P, R]):
         self.wait_for_delivery = wait_for_delivery
         self.compression_type = compression_type
         self.report_timeout_errors = report_timeout_errors
+        self.exceptions_to_silence = exceptions_to_silence or ()
         update_wrapper(self, func)
 
     @property

--- a/clients/python/src/taskbroker_client/worker/workerchild.py
+++ b/clients/python/src/taskbroker_client/worker/workerchild.py
@@ -280,17 +280,20 @@ def child_process(
                         next_state = TASK_ACTIVATION_STATUS_RETRY
                     elif retry.max_attempts_reached(inflight.activation.retry_state):
                         with sentry_sdk.isolation_scope() as scope:
-                            retry_error = NoRetriesRemainingError(
-                                f"{inflight.activation.taskname} has consumed all of its retries"
-                            )
-                            retry_error.__cause__ = err
-                            scope.fingerprint = [
-                                "taskworker.no_retries_remaining",
-                                inflight.activation.namespace,
-                                inflight.activation.taskname,
-                            ]
-                            scope.set_transaction_name(inflight.activation.taskname)
-                            sentry_sdk.capture_exception(retry_error)
+                            if not isinstance(err, task_func.exceptions_to_silence):
+                                retry_error = NoRetriesRemainingError(
+                                    f"{inflight.activation.taskname} has consumed all of its retries"
+                                )
+                                retry_error.__cause__ = err
+                                scope.fingerprint = [
+                                    "taskworker.no_retries_remaining",
+                                    inflight.activation.namespace,
+                                    inflight.activation.taskname,
+                                ]
+                                scope.set_transaction_name(inflight.activation.taskname)
+                                sentry_sdk.capture_exception(retry_error)
+                            # In this branch, all exceptions should be either
+                            #  captured or silenced.
                             captured_error = True
 
                 if not captured_error and next_state != TASK_ACTIVATION_STATUS_RETRY:

--- a/clients/python/src/taskbroker_client/worker/workerchild.py
+++ b/clients/python/src/taskbroker_client/worker/workerchild.py
@@ -266,7 +266,7 @@ def child_process(
             except Exception as err:
                 retry = task_func.retry
                 captured_error = False
-                should_capture_error = not isinstance(err, task_func.exceptions_to_silence)
+                should_capture_error = not isinstance(err, task_func.expected_exceptions)
                 if retry:
                     if retry.should_retry(inflight.activation.retry_state, err):
                         logger.info(

--- a/clients/python/src/taskbroker_client/worker/workerchild.py
+++ b/clients/python/src/taskbroker_client/worker/workerchild.py
@@ -266,6 +266,7 @@ def child_process(
             except Exception as err:
                 retry = task_func.retry
                 captured_error = False
+                should_capture_error = not isinstance(err, task_func.exceptions_to_silence)
                 if retry:
                     if retry.should_retry(inflight.activation.retry_state, err):
                         logger.info(
@@ -280,7 +281,7 @@ def child_process(
                         next_state = TASK_ACTIVATION_STATUS_RETRY
                     elif retry.max_attempts_reached(inflight.activation.retry_state):
                         with sentry_sdk.isolation_scope() as scope:
-                            if not isinstance(err, task_func.exceptions_to_silence):
+                            if should_capture_error:
                                 retry_error = NoRetriesRemainingError(
                                     f"{inflight.activation.taskname} has consumed all of its retries"
                                 )
@@ -296,7 +297,11 @@ def child_process(
                             #  captured or silenced.
                             captured_error = True
 
-                if not captured_error and next_state != TASK_ACTIVATION_STATUS_RETRY:
+                if (
+                    should_capture_error
+                    and not captured_error
+                    and next_state != TASK_ACTIVATION_STATUS_RETRY
+                ):
                     sentry_sdk.capture_exception(err)
 
             clear_current_task()

--- a/clients/python/src/taskbroker_client/worker/workerchild.py
+++ b/clients/python/src/taskbroker_client/worker/workerchild.py
@@ -266,7 +266,7 @@ def child_process(
             except Exception as err:
                 retry = task_func.retry
                 captured_error = False
-                should_capture_error = not isinstance(err, task_func.expected_exceptions)
+                should_capture_error = not isinstance(err, task_func.silenced_exceptions)
                 if retry:
                     if retry.should_retry(inflight.activation.retry_state, err):
                         logger.info(

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -193,6 +193,63 @@ LEGACY_COMPRESSED_TASK = InflightTaskActivation(
     ),
 )
 
+# Task with Retry logic, expected exceptions to silence reporting
+RETRY_TASK_WITH_SILENCED_TIMEOUT = InflightTaskActivation(
+    host="localhost:50051",
+    receive_timestamp=0,
+    activation=TaskActivation(
+        id="654",
+        taskname="examples.will_timeout_without_reporting",
+        namespace="examples",
+        parameters_bytes=msgpack.packb({"args": [], "kwargs": {}}, use_bin_type=True),
+        processing_deadline_duration=1,
+        retry_state=RetryState(
+            # no more attempts left
+            attempts=1,
+            max_attempts=2,
+            on_attempts_exceeded=ON_ATTEMPTS_EXCEEDED_DISCARD,
+        ),
+    ),
+)
+
+# Task with Retry logic, expected exceptions to silence reporting
+RETRY_TASK_WITH_EXPECTED_EXCEPTION = InflightTaskActivation(
+    host="localhost:50051",
+    receive_timestamp=0,
+    activation=TaskActivation(
+        id="654",
+        taskname="examples.will_fail_with_expected_exception",
+        namespace="examples",
+        parameters_bytes=msgpack.packb({"args": [], "kwargs": {}}, use_bin_type=True),
+        processing_deadline_duration=2,
+        retry_state=RetryState(
+            # One retry left
+            attempts=0,
+            max_attempts=2,
+            on_attempts_exceeded=ON_ATTEMPTS_EXCEEDED_DISCARD,
+        ),
+    ),
+)
+
+# Task set to retry on deadline exceeded exceptions
+RETRY_TASK_WITH_EXPECTED_IGNORED_EXCEPTION = InflightTaskActivation(
+    host="localhost:50051",
+    receive_timestamp=0,
+    activation=TaskActivation(
+        id="654",
+        taskname="examples.will_fail_with_expected_ignored_exception",
+        namespace="examples",
+        parameters_bytes=msgpack.packb({"args": [], "kwargs": {}}, use_bin_type=True),
+        processing_deadline_duration=2,
+        retry_state=RetryState(
+            # no more attempts left
+            attempts=1,
+            max_attempts=2,
+            on_attempts_exceeded=ON_ATTEMPTS_EXCEEDED_DISCARD,
+        ),
+    ),
+)
+
 
 class TestTaskWorker(TestCase):
     def test_fetch_task(self) -> None:

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -213,12 +213,12 @@ RETRY_TASK_WITH_SILENCED_TIMEOUT = InflightTaskActivation(
 )
 
 # Task with Retry logic, expected exceptions to silence reporting
-RETRY_TASK_WITH_EXPECTED_UNHANDLED_EXCEPTION = InflightTaskActivation(
+RETRY_TASK_WITH_SILENCED_UNHANDLED_EXCEPTION = InflightTaskActivation(
     host="localhost:50051",
     receive_timestamp=0,
     activation=TaskActivation(
         id="654",
-        taskname="examples.will_fail_with_expected_exception",
+        taskname="examples.will_fail_with_silenced_exception",
         namespace="examples",
         parameters_bytes=msgpack.packb({"args": [], "kwargs": {}}, use_bin_type=True),
         processing_deadline_duration=2,
@@ -232,12 +232,12 @@ RETRY_TASK_WITH_EXPECTED_UNHANDLED_EXCEPTION = InflightTaskActivation(
 )
 
 # Task set to retry on deadline exceeded exceptions
-RETRY_TASK_WITH_EXPECTED_IGNORED_EXCEPTION = InflightTaskActivation(
+RETRY_TASK_WITH_SILENCED_IGNORED_EXCEPTION = InflightTaskActivation(
     host="localhost:50051",
     receive_timestamp=0,
     activation=TaskActivation(
         id="654",
-        taskname="examples.will_fail_with_expected_ignored_exception",
+        taskname="examples.will_fail_with_silenced_ignored_exception",
         namespace="examples",
         parameters_bytes=msgpack.packb({"args": [], "kwargs": {}}, use_bin_type=True),
         processing_deadline_duration=2,
@@ -1004,12 +1004,12 @@ def test_child_process_silenced_timeout(mock_capture: mock.Mock) -> None:
 
 
 @mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
-def test_child_process_expected_exception_with_retries(mock_capture: mock.Mock) -> None:
+def test_child_process_silenced_exception_with_retries(mock_capture: mock.Mock) -> None:
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
 
-    todo.put(RETRY_TASK_WITH_EXPECTED_UNHANDLED_EXCEPTION)
+    todo.put(RETRY_TASK_WITH_SILENCED_UNHANDLED_EXCEPTION)
     child_process(
         "examples.app:app",
         todo,
@@ -1022,7 +1022,7 @@ def test_child_process_expected_exception_with_retries(mock_capture: mock.Mock) 
 
     assert todo.empty()
     result = processed.get()
-    assert result.task_id == RETRY_TASK_WITH_EXPECTED_UNHANDLED_EXCEPTION.activation.id
+    assert result.task_id == RETRY_TASK_WITH_SILENCED_UNHANDLED_EXCEPTION.activation.id
 
     # No reporting, but the task still raised an unhandled exception
     assert result.status == TASK_ACTIVATION_STATUS_FAILURE
@@ -1036,7 +1036,7 @@ def test_child_process_expected_ignored_exception_max_attempts(mock_capture: moc
     shutdown = Event()
 
     # Task has more retries left, but is set to ignore the raised error type
-    todo.put(RETRY_TASK_WITH_EXPECTED_IGNORED_EXCEPTION)
+    todo.put(RETRY_TASK_WITH_SILENCED_IGNORED_EXCEPTION)
     child_process(
         "examples.app:app",
         todo,
@@ -1050,7 +1050,7 @@ def test_child_process_expected_ignored_exception_max_attempts(mock_capture: moc
     # No reporting, but exception type is retriable
     assert todo.empty()
     result = processed.get()
-    assert result.task_id == RETRY_TASK_WITH_EXPECTED_IGNORED_EXCEPTION.activation.id
+    assert result.task_id == RETRY_TASK_WITH_SILENCED_IGNORED_EXCEPTION.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_RETRY
     assert mock_capture.call_count == 0
 

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -213,7 +213,7 @@ RETRY_TASK_WITH_SILENCED_TIMEOUT = InflightTaskActivation(
 )
 
 # Task with Retry logic, expected exceptions to silence reporting
-RETRY_TASK_WITH_EXPECTED_EXCEPTION = InflightTaskActivation(
+RETRY_TASK_WITH_EXPECTED_UNHANDLED_EXCEPTION = InflightTaskActivation(
     host="localhost:50051",
     receive_timestamp=0,
     activation=TaskActivation(
@@ -242,8 +242,27 @@ RETRY_TASK_WITH_EXPECTED_IGNORED_EXCEPTION = InflightTaskActivation(
         parameters_bytes=msgpack.packb({"args": [], "kwargs": {}}, use_bin_type=True),
         processing_deadline_duration=2,
         retry_state=RetryState(
-            # no more attempts left
-            attempts=1,
+            # One retry left
+            attempts=0,
+            max_attempts=2,
+            on_attempts_exceeded=ON_ATTEMPTS_EXCEEDED_DISCARD,
+        ),
+    ),
+)
+
+# Task set to retry on deadline exceeded exceptions
+RETRY_TASK_ON_DEADLINE_EXCEEDED = InflightTaskActivation(
+    host="localhost:50051",
+    receive_timestamp=0,
+    activation=TaskActivation(
+        id="654",
+        taskname="examples.will_retry_on_deadline_exceeded",
+        namespace="examples",
+        parameters_bytes=msgpack.packb({"args": [], "kwargs": {}}, use_bin_type=True),
+        processing_deadline_duration=1,
+        retry_state=RetryState(
+            # One retry left
+            attempts=0,
             max_attempts=2,
             on_attempts_exceeded=ON_ATTEMPTS_EXCEEDED_DISCARD,
         ),
@@ -958,3 +977,106 @@ def test_child_process_context_hooks() -> None:
         assert executed_headers[0]["x-viewer-user"] == "7"
     finally:
         app.context_hooks.remove(hook)
+
+
+@mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
+def test_child_process_silenced_timeout(mock_capture: mock.Mock) -> None:
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
+    processed: queue.Queue[ProcessingResult] = queue.Queue()
+    shutdown = Event()
+
+    todo.put(RETRY_TASK_WITH_SILENCED_TIMEOUT)
+    child_process(
+        "examples.app:app",
+        todo,
+        processed,
+        shutdown,
+        max_task_count=1,
+        processing_pool_name="test",
+        process_type="fork",
+    )
+
+    assert todo.empty()
+    result = processed.get()
+    assert result.task_id == RETRY_TASK_WITH_SILENCED_TIMEOUT.activation.id
+    assert result.status == TASK_ACTIVATION_STATUS_FAILURE
+    assert mock_capture.call_count == 0
+
+
+@mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
+def test_child_process_expected_exception_with_retries(mock_capture: mock.Mock) -> None:
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
+    processed: queue.Queue[ProcessingResult] = queue.Queue()
+    shutdown = Event()
+
+    todo.put(RETRY_TASK_WITH_EXPECTED_UNHANDLED_EXCEPTION)
+    child_process(
+        "examples.app:app",
+        todo,
+        processed,
+        shutdown,
+        max_task_count=1,
+        processing_pool_name="test",
+        process_type="fork",
+    )
+
+    assert todo.empty()
+    result = processed.get()
+    assert result.task_id == RETRY_TASK_WITH_EXPECTED_UNHANDLED_EXCEPTION.activation.id
+
+    # No reporting, but the task still raised an unhandled exception
+    assert result.status == TASK_ACTIVATION_STATUS_FAILURE
+    assert mock_capture.call_count == 0
+
+
+@mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
+def test_child_process_expected_ignored_exception_max_attempts(mock_capture: mock.Mock) -> None:
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
+    processed: queue.Queue[ProcessingResult] = queue.Queue()
+    shutdown = Event()
+
+    # Task has more retries left, but is set to ignore the raised error type
+    todo.put(RETRY_TASK_WITH_EXPECTED_IGNORED_EXCEPTION)
+    child_process(
+        "examples.app:app",
+        todo,
+        processed,
+        shutdown,
+        max_task_count=1,
+        processing_pool_name="test",
+        process_type="fork",
+    )
+
+    # No reporting, but exception type is retriable
+    assert todo.empty()
+    result = processed.get()
+    assert result.task_id == RETRY_TASK_WITH_EXPECTED_IGNORED_EXCEPTION.activation.id
+    assert result.status == TASK_ACTIVATION_STATUS_RETRY
+    assert mock_capture.call_count == 0
+
+
+@mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
+def test_child_process_retry_on_deadline_exceeded(mock_capture: mock.Mock) -> None:
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
+    processed: queue.Queue[ProcessingResult] = queue.Queue()
+    shutdown = Event()
+
+    # Task will timeout, but should retry, because ProcessingDeadlineExceeded is
+    # in the Retry.on list
+    todo.put(RETRY_TASK_ON_DEADLINE_EXCEEDED)
+    child_process(
+        "examples.app:app",
+        todo,
+        processed,
+        shutdown,
+        max_task_count=1,
+        processing_pool_name="test",
+        process_type="fork",
+    )
+
+    assert todo.empty()
+    result = processed.get()
+    assert result.task_id == RETRY_TASK_ON_DEADLINE_EXCEEDED.activation.id
+    assert result.status == TASK_ACTIVATION_STATUS_RETRY
+    assert mock_capture.call_count == 1
+    assert type(mock_capture.call_args.args[0]) is ProcessingDeadlineExceeded


### PR DESCRIPTION
Exposes the previously added `report_timeout_errors` via task registration method.

Adds a new `silenced_exceptions` parameter, which _should_ put us at feature parity with the remainder of fields in `@retry`:

    | Parameter          | Retry | Report | Raise | Description |
    |--------------------|-------|--------|-------|-------------|
    | on                 | Yes   | Yes    | No    | Exceptions that will trigger a retry & report to Sentry. |
    | on_silent          | Yes   | No     | No    | Exceptions that will trigger a retry but not be captured to Sentry. |
    | exclude            | No    | No     | Yes   | Exceptions that will not trigger a retry and will be raised. |
    | ignore             | No    | No     | No    | Exceptions that will be ignored and not trigger a retry & not report to Sentry. |
    | ignore_and_capture | No    | Yes    | No    | Exceptions that will not trigger a retry and will be captured to Sentry. |

To emulate each of these previous parameters:
**on**
```python
namespace.register(
    ...,
    retry=Retry(times=3, on=(MyCoolException,)),
)
```

**on_silent**
```python
namespace.register(
    ...,
    retry=Retry(times=3, on=(MyCoolException,)),
    silenced_exceptions(MyCoolException,)
)
```

**exclude**
```python
namespace.register(
    ...,
    retry=Retry(times=3, on=(...), ignore=(IgnoreMeException,)),
)
```

**ignore**
```python
namespace.register(
    ...,
    retry=Retry(times=3, ignore=(IgnoreMeException,)),
    silenced_execptions(IgnoreMeException,)
)
```

**ignore_and_capture**
.... It's actually not entirely clear to me how this is supposed to behave compared to `exclude`