### PR TITLE
feat(taskbroker): Passthrough/raw mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,6 +2575,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3025,7 @@ dependencies = [
  "sentry",
  "sentry_protos",
  "serde",
+ "serde_bytes",
  "serde_yaml",
  "sha2",
  "sqlx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,6 +2256,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,6 +3010,7 @@ dependencies = [
  "prost-types",
  "rand 0.8.5",
  "rdkafka",
+ "rmp-serde",
  "rstest",
  "sentry",
  "sentry_protos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ prost = "0.14"
 prost-types = "0.14"
 rand = "0.8.5"
 rdkafka = { version = "0.37.0", features = ["cmake-build", "ssl"] }
+rmp-serde = "1.3"
 sentry = { version = "0.41.0", default-features = false, features = [
     # default features, except `release-health` is disabled
     "backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ sentry = { version = "0.41.0", default-features = false, features = [
 ] }
 sentry_protos = "0.8.13"
 serde = "1.0.214"
+serde_bytes = "0.11"
 serde_yaml = "0.9.34"
 sha2 = "0.10.8"
 sqlx = { version = "0.8.3", features = ["sqlite", "runtime-tokio", "chrono", "postgres"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -316,7 +316,10 @@ pub struct Config {
     pub raw_taskname: Option<String>,
 
     /// Processing deadline duration in seconds for raw mode activations.
-    pub raw_processing_deadline_duration: u64,
+    ///
+    /// This is an u16 because 1) we don't want to allow signed numbers 2) it can be cast into i32
+    /// (which we use elsewhere) without error conditions. It doesn't actually have to be that small.
+    pub raw_processing_deadline_duration: u16,
 }
 
 impl Default for Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,6 +301,22 @@ pub struct Config {
 
     /// Maps every application to its worker endpoint, both represented as strings.
     pub worker_map: BTreeMap<String, String>,
+
+    /// Enable passthrough mode for consuming raw bytes from legacy topics.
+    /// In passthrough mode, raw Kafka message bytes are wrapped into TaskActivation.
+    pub passthrough_mode: bool,
+
+    /// The namespace to assign to passthrough activations.
+    pub passthrough_namespace: Option<String>,
+
+    /// The application to assign to passthrough activations.
+    pub passthrough_application: Option<String>,
+
+    /// The taskname to assign to passthrough activations.
+    pub passthrough_taskname: Option<String>,
+
+    /// Processing deadline duration in seconds for passthrough activations.
+    pub passthrough_processing_deadline_duration: u64,
 }
 
 impl Default for Config {
@@ -386,6 +402,11 @@ impl Default for Config {
             callback_addr: "0.0.0.0".into(),
             callback_port: 50051,
             worker_map: [("sentry".into(), "http://127.0.0.1:50052".into())].into(),
+            passthrough_mode: false,
+            passthrough_namespace: None,
+            passthrough_application: None,
+            passthrough_taskname: None,
+            passthrough_processing_deadline_duration: 30,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -302,21 +302,21 @@ pub struct Config {
     /// Maps every application to its worker endpoint, both represented as strings.
     pub worker_map: BTreeMap<String, String>,
 
-    /// Enable passthrough mode for consuming raw bytes from legacy topics.
-    /// In passthrough mode, raw Kafka message bytes are wrapped into TaskActivation.
-    pub passthrough_mode: bool,
+    /// Enable raw mode for consuming unstructured Kafka messages.
+    /// In raw mode, Kafka message bytes are wrapped into TaskActivation.
+    pub raw_mode: bool,
 
-    /// The namespace to assign to passthrough activations.
-    pub passthrough_namespace: Option<String>,
+    /// The namespace to assign to raw mode activations.
+    pub raw_namespace: Option<String>,
 
-    /// The application to assign to passthrough activations.
-    pub passthrough_application: Option<String>,
+    /// The application to assign to raw mode activations.
+    pub raw_application: Option<String>,
 
-    /// The taskname to assign to passthrough activations.
-    pub passthrough_taskname: Option<String>,
+    /// The taskname to assign to raw mode activations.
+    pub raw_taskname: Option<String>,
 
-    /// Processing deadline duration in seconds for passthrough activations.
-    pub passthrough_processing_deadline_duration: u64,
+    /// Processing deadline duration in seconds for raw mode activations.
+    pub raw_processing_deadline_duration: u64,
 }
 
 impl Default for Config {
@@ -402,11 +402,11 @@ impl Default for Config {
             callback_addr: "0.0.0.0".into(),
             callback_port: 50051,
             worker_map: [("sentry".into(), "http://127.0.0.1:50052".into())].into(),
-            passthrough_mode: false,
-            passthrough_namespace: None,
-            passthrough_application: None,
-            passthrough_taskname: None,
-            passthrough_processing_deadline_duration: 30,
+            raw_mode: false,
+            raw_namespace: None,
+            raw_application: None,
+            raw_taskname: None,
+            raw_processing_deadline_duration: 30,
         }
     }
 }

--- a/src/kafka/deserialize.rs
+++ b/src/kafka/deserialize.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use anyhow::Error;
+use rdkafka::message::OwnedMessage;
+
+use crate::config::Config;
+use crate::store::activation::InflightActivation;
+
+use super::deserialize_activation::{self, DeserializeActivationConfig};
+use super::deserialize_passthrough::{self, PassthroughConfig};
+
+pub struct DeserializeConfig {
+    activation_config: DeserializeActivationConfig,
+    passthrough_config: Option<PassthroughConfig>,
+}
+
+impl DeserializeConfig {
+    pub fn from_config(config: &Config) -> Self {
+        Self {
+            activation_config: DeserializeActivationConfig::from_config(config),
+            passthrough_config: PassthroughConfig::from_config(config),
+        }
+    }
+}
+
+/// Create a unified deserializer that handles both normal and passthrough modes.
+/// In passthrough mode, raw Kafka bytes are wrapped into a TaskActivation.
+/// In normal mode, Kafka messages are expected to contain encoded TaskActivation protos.
+pub fn new(
+    config: DeserializeConfig,
+) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightActivation, Error> {
+    let passthrough_deserializer = config.passthrough_config.map(deserialize_passthrough::new);
+    let activation_deserializer = deserialize_activation::new(config.activation_config);
+
+    move |msg: Arc<OwnedMessage>| {
+        if let Some(ref pt_deserializer) = passthrough_deserializer {
+            pt_deserializer(msg)
+        } else {
+            activation_deserializer(msg)
+        }
+    }
+}

--- a/src/kafka/deserialize.rs
+++ b/src/kafka/deserialize.rs
@@ -7,34 +7,34 @@ use crate::config::Config;
 use crate::store::activation::InflightActivation;
 
 use super::deserialize_activation::{self, DeserializeActivationConfig};
-use super::deserialize_passthrough::{self, PassthroughConfig};
+use super::deserialize_raw::{self, RawConfig};
 
 pub struct DeserializeConfig {
     activation_config: DeserializeActivationConfig,
-    passthrough_config: Option<PassthroughConfig>,
+    raw_config: Option<RawConfig>,
 }
 
 impl DeserializeConfig {
     pub fn from_config(config: &Config) -> Self {
         Self {
             activation_config: DeserializeActivationConfig::from_config(config),
-            passthrough_config: PassthroughConfig::from_config(config),
+            raw_config: RawConfig::from_config(config),
         }
     }
 }
 
-/// Create a unified deserializer that handles both normal and passthrough modes.
-/// In passthrough mode, raw Kafka bytes are wrapped into a TaskActivation.
+/// Create a unified deserializer that handles both normal and raw modes.
+/// In raw mode, raw Kafka bytes are wrapped into a TaskActivation.
 /// In normal mode, Kafka messages are expected to contain encoded TaskActivation protos.
 pub fn new(
     config: DeserializeConfig,
 ) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightActivation, Error> {
-    let passthrough_deserializer = config.passthrough_config.map(deserialize_passthrough::new);
+    let raw_deserializer = config.raw_config.map(deserialize_raw::new);
     let activation_deserializer = deserialize_activation::new(config.activation_config);
 
     move |msg: Arc<OwnedMessage>| {
-        if let Some(ref pt_deserializer) = passthrough_deserializer {
-            pt_deserializer(msg)
+        if let Some(ref raw_deserializer) = raw_deserializer {
+            raw_deserializer(msg)
         } else {
             activation_deserializer(msg)
         }

--- a/src/kafka/deserialize_passthrough.rs
+++ b/src/kafka/deserialize_passthrough.rs
@@ -1,0 +1,227 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Error, anyhow};
+use chrono::Utc;
+use prost::Message as _;
+use rdkafka::Message;
+use rdkafka::message::OwnedMessage;
+use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivation};
+use uuid::Uuid;
+
+use crate::config::Config;
+use crate::store::activation::{InflightActivation, InflightActivationStatus};
+
+use super::deserialize_activation::bucket_from_id;
+
+pub struct PassthroughConfig {
+    pub namespace: String,
+    pub application: String,
+    pub taskname: String,
+    pub processing_deadline_duration: u64,
+}
+
+impl PassthroughConfig {
+    pub fn from_config(config: &Config) -> Option<Self> {
+        if !config.passthrough_mode {
+            return None;
+        }
+        Some(Self {
+            namespace: config
+                .passthrough_namespace
+                .clone()
+                .expect("passthrough_namespace required when passthrough_mode is enabled"),
+            application: config
+                .passthrough_application
+                .clone()
+                .expect("passthrough_application required when passthrough_mode is enabled"),
+            taskname: config
+                .passthrough_taskname
+                .clone()
+                .expect("passthrough_taskname required when passthrough_mode is enabled"),
+            processing_deadline_duration: config.passthrough_processing_deadline_duration,
+        })
+    }
+}
+
+/// Encode raw bytes into msgpack format: {"args": [raw_bytes], "kwargs": {}}
+fn encode_passthrough_params(raw_bytes: &[u8]) -> Result<Vec<u8>, Error> {
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct Params<'a> {
+        args: (&'a [u8],),
+        kwargs: HashMap<(), ()>,
+    }
+
+    let params = Params {
+        args: (raw_bytes,),
+        kwargs: HashMap::new(),
+    };
+
+    rmp_serde::to_vec_named(&params).map_err(|e| anyhow!("Failed to encode msgpack: {}", e))
+}
+
+/// Create a deserializer closure for passthrough mode.
+/// Wraps raw Kafka message bytes into a TaskActivation with msgpack-encoded parameters_bytes.
+pub fn new(
+    config: PassthroughConfig,
+) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightActivation, Error> {
+    move |msg: Arc<OwnedMessage>| {
+        let Some(payload) = msg.payload() else {
+            return Err(anyhow!("Message has no payload"));
+        };
+
+        let id = Uuid::new_v4().to_string();
+        let parameters_bytes = encode_passthrough_params(payload)?;
+        let now = Utc::now();
+        let received_at = prost_types::Timestamp {
+            seconds: now.timestamp(),
+            nanos: 0,
+        };
+
+        let activation = TaskActivation {
+            id: id.clone(),
+            application: Some(config.application.clone()),
+            namespace: config.namespace.clone(),
+            taskname: config.taskname.clone(),
+            #[allow(deprecated)]
+            parameters: String::new(),
+            parameters_bytes,
+            headers: HashMap::new(),
+            received_at: Some(received_at),
+            retry_state: None,
+            processing_deadline_duration: config.processing_deadline_duration,
+            expires: None,
+            delay: None,
+        };
+
+        let activation_bytes = activation.encode_to_vec();
+        let bucket = bucket_from_id(&id);
+
+        metrics::histogram!(
+            "consumer.passthrough.payload_size_bytes",
+            "namespace" => config.namespace.clone(),
+            "taskname" => config.taskname.clone()
+        )
+        .record(payload.len() as f64);
+
+        Ok(InflightActivation {
+            id,
+            activation: activation_bytes,
+            status: InflightActivationStatus::Pending,
+            partition: msg.partition(),
+            offset: msg.offset(),
+            added_at: now,
+            received_at: now,
+            processing_deadline: None,
+            claim_expires_at: None,
+            processing_deadline_duration: config.processing_deadline_duration as i32,
+            processing_attempts: 0,
+            expires_at: None,
+            delay_until: None,
+            at_most_once: false,
+            application: config.application.clone(),
+            namespace: config.namespace.clone(),
+            taskname: config.taskname.clone(),
+            on_attempts_exceeded: OnAttemptsExceeded::Discard,
+            bucket,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rdkafka::Timestamp;
+    use rdkafka::message::OwnedMessage;
+
+    use super::*;
+
+    #[test]
+    fn test_encode_passthrough_params() {
+        use serde::Deserialize;
+
+        #[derive(Deserialize, Debug)]
+        struct Params {
+            args: (Vec<u8>,),
+            kwargs: HashMap<(), ()>,
+        }
+
+        let raw_bytes = b"hello world";
+        let encoded = encode_passthrough_params(raw_bytes).unwrap();
+
+        // Decode and verify
+        let decoded: Params = rmp_serde::from_slice(&encoded).unwrap();
+        assert_eq!(decoded.args.0, raw_bytes);
+        assert!(decoded.kwargs.is_empty());
+    }
+
+    #[test]
+    fn test_passthrough_deserializer() {
+        let config = PassthroughConfig {
+            namespace: "test-namespace".to_string(),
+            application: "test-app".to_string(),
+            taskname: "test-task".to_string(),
+            processing_deadline_duration: 60,
+        };
+
+        let deserializer = new(config);
+
+        let raw_payload = b"raw kafka message bytes";
+        let message = OwnedMessage::new(
+            Some(raw_payload.to_vec()),
+            None,
+            "legacy-topic".into(),
+            Timestamp::now(),
+            0,
+            42,
+            None,
+        );
+
+        let result = deserializer(Arc::new(message));
+        assert!(result.is_ok());
+
+        let inflight = result.unwrap();
+        assert_eq!(inflight.namespace, "test-namespace");
+        assert_eq!(inflight.application, "test-app");
+        assert_eq!(inflight.taskname, "test-task");
+        assert_eq!(inflight.processing_deadline_duration, 60);
+        assert_eq!(inflight.offset, 42);
+        assert_eq!(inflight.status, InflightActivationStatus::Pending);
+
+        // Verify the activation can be decoded
+        let activation = TaskActivation::decode(inflight.activation.as_slice()).unwrap();
+        assert_eq!(activation.namespace, "test-namespace");
+        assert_eq!(activation.application, Some("test-app".to_string()));
+        assert_eq!(activation.taskname, "test-task");
+        assert!(!activation.parameters_bytes.is_empty());
+    }
+
+    #[test]
+    fn test_passthrough_deserializer_empty_payload() {
+        let config = PassthroughConfig {
+            namespace: "test-namespace".to_string(),
+            application: "test-app".to_string(),
+            taskname: "test-task".to_string(),
+            processing_deadline_duration: 60,
+        };
+
+        let deserializer = new(config);
+
+        let message = OwnedMessage::new(
+            None, // No payload
+            None,
+            "legacy-topic".into(),
+            Timestamp::now(),
+            0,
+            0,
+            None,
+        );
+
+        let result = deserializer(Arc::new(message));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no payload"));
+    }
+}

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -294,7 +294,13 @@ mod tests {
         let inflight = result.unwrap();
         let activation = TaskActivation::decode(inflight.activation.as_slice()).unwrap();
 
-        assert_eq!(activation.headers.get("trace-id"), Some(&"abc123".to_string()));
-        assert_eq!(activation.headers.get("request-id"), Some(&"req-456".to_string()));
+        assert_eq!(
+            activation.headers.get("trace-id"),
+            Some(&"abc123".to_string())
+        );
+        assert_eq!(
+            activation.headers.get("request-id"),
+            Some(&"req-456".to_string())
+        );
     }
 }

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -77,27 +77,28 @@ fn extract_headers(msg: &OwnedMessage) -> HashMap<String, String> {
 }
 
 /// Encode raw bytes into msgpack format: {"args": [raw_bytes], "kwargs": {}}
-fn encode_raw_params(raw_bytes: &[u8]) -> Result<Vec<u8>, Error> {
+fn encode_raw_params(raw_bytes: &[u8]) -> Vec<u8> {
     let params = RawParams {
         args: (serde_bytes::Bytes::new(raw_bytes),),
         kwargs: HashMap::new(),
     };
 
-    // TODO: send to DLQ instead of skipping
-    rmp_serde::to_vec_named(&params).map_err(|e| anyhow!("Failed to encode msgpack: {}", e))
+    // The only condition where this would fail should be a bug in msgpack or taskbroker. In this
+    // case it's better to stop the world instead of trying to recover externally.
+    rmp_serde::to_vec_named(&params).expect("Failed to encode msgpack")
 }
 
 /// Create a deserializer closure for raw mode.
 /// Wraps raw Kafka message bytes into a TaskActivation with msgpack-encoded parameters_bytes.
 pub fn new(config: RawConfig) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightActivation, Error> {
     move |msg: Arc<OwnedMessage>| {
-        let Some(payload) = msg.payload() else {
-            // TODO: send to DLQ instead of skipping
-            return Err(anyhow!("Message has no payload"));
-        };
+        // Whether a message without payload is valid is technically not up to taskbroker, and we
+        // can't DLQ messages here. It's easier to convert it to an empty bytestring and let the
+        // task fail. Failed tasks can be DLQed in upkeep.rs
+        let payload = msg.payload().unwrap_or(b"");
 
         let id = Uuid::new_v4().to_string();
-        let parameters_bytes = encode_raw_params(payload)?;
+        let parameters_bytes = encode_raw_params(payload);
         let now = Utc::now();
         let received_at_time = msg
             .timestamp()
@@ -239,7 +240,7 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_deserializer_empty_payload() {
+    fn test_raw_deserializer_null_payload() {
         let config = RawConfig {
             namespace: "test-namespace".to_string(),
             application: "test-app".to_string(),
@@ -260,8 +261,19 @@ mod tests {
         );
 
         let result = deserializer(Arc::new(message));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("no payload"));
+        assert!(result.is_ok());
+
+        let inflight = result.unwrap();
+        let activation = TaskActivation::decode(inflight.activation.as_slice()).unwrap();
+
+        // Verify empty payload is encoded as empty bytes
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        struct Params {
+            args: (Vec<u8>,),
+        }
+        let params: Params = rmp_serde::from_slice(&activation.parameters_bytes).unwrap();
+        assert!(params.args.0.is_empty());
     }
 
     #[test]

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -180,7 +180,7 @@ mod tests {
         }
 
         let raw_bytes = b"hello world";
-        let encoded = encode_raw_params(raw_bytes).unwrap();
+        let encoded = encode_raw_params(raw_bytes);
 
         // Verify msgpack uses binary format (0xc4 = bin8), not array format (0x9x). Array format
         // is easy to accidentally serialize to with Vec<u8>.

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -58,9 +58,10 @@ fn extract_headers(msg: &OwnedMessage) -> HashMap<String, String> {
 
     let mut result = HashMap::new();
     for i in 0..headers.count() {
-        if let Some((key, value)) = headers.get(i) {
+        let header = headers.get(i);
+        if let Some(value) = header.value {
             if let Ok(value_str) = std::str::from_utf8(value) {
-                result.insert(key.to_string(), value_str.to_string());
+                result.insert(header.key.to_string(), value_str.to_string());
             }
         }
     }
@@ -155,7 +156,7 @@ mod tests {
     use std::sync::Arc;
 
     use rdkafka::Timestamp;
-    use rdkafka::message::OwnedMessage;
+    use rdkafka::message::{Header, OwnedHeaders, OwnedMessage};
 
     use super::*;
 
@@ -253,5 +254,47 @@ mod tests {
         let result = deserializer(Arc::new(message));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("no payload"));
+    }
+
+    #[test]
+    fn test_raw_deserializer_with_headers() {
+        let config = RawConfig {
+            namespace: "test-namespace".to_string(),
+            application: "test-app".to_string(),
+            taskname: "test-task".to_string(),
+            processing_deadline_duration: 60,
+        };
+
+        let deserializer = new(config);
+
+        let headers = OwnedHeaders::new()
+            .insert(Header {
+                key: "trace-id",
+                value: Some("abc123"),
+            })
+            .insert(Header {
+                key: "request-id",
+                value: Some("req-456"),
+            });
+
+        let raw_payload = b"raw kafka message bytes";
+        let message = OwnedMessage::new(
+            Some(raw_payload.to_vec()),
+            None,
+            "legacy-topic".into(),
+            Timestamp::now(),
+            0,
+            42,
+            Some(headers),
+        );
+
+        let result = deserializer(Arc::new(message));
+        assert!(result.is_ok());
+
+        let inflight = result.unwrap();
+        let activation = TaskActivation::decode(inflight.activation.as_slice()).unwrap();
+
+        assert_eq!(activation.headers.get("trace-id"), Some(&"abc123".to_string()));
+        assert_eq!(activation.headers.get("request-id"), Some(&"req-456".to_string()));
     }
 }

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -5,6 +5,7 @@ use anyhow::{Error, anyhow};
 use chrono::{DateTime, Utc};
 use prost::Message as _;
 use rdkafka::Message;
+use rdkafka::message::Headers;
 use rdkafka::message::OwnedMessage;
 use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivation};
 use uuid::Uuid;
@@ -50,6 +51,22 @@ impl RawConfig {
     }
 }
 
+fn extract_headers(msg: &OwnedMessage) -> HashMap<String, String> {
+    let Some(headers) = msg.headers() else {
+        return HashMap::new();
+    };
+
+    let mut result = HashMap::new();
+    for i in 0..headers.count() {
+        if let Some((key, value)) = headers.get(i) {
+            if let Ok(value_str) = std::str::from_utf8(value) {
+                result.insert(key.to_string(), value_str.to_string());
+            }
+        }
+    }
+    result
+}
+
 /// Encode raw bytes into msgpack format: {"args": [raw_bytes], "kwargs": {}}
 fn encode_raw_params(raw_bytes: &[u8]) -> Result<Vec<u8>, Error> {
     let params = RawParams {
@@ -91,7 +108,7 @@ pub fn new(config: RawConfig) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightAc
             #[allow(deprecated)]
             parameters: String::new(),
             parameters_bytes,
-            headers: HashMap::new(),
+            headers: extract_headers(&msg),
             received_at: Some(received_at),
             retry_state: None,
             processing_deadline_duration: config.processing_deadline_duration,

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -46,7 +46,7 @@ impl RawConfig {
                 .raw_taskname
                 .clone()
                 .expect("raw_taskname required when raw_mode is enabled"),
-            processing_deadline_duration: config.raw_processing_deadline_duration.into(),
+            processing_deadline_duration: config.raw_processing_deadline_duration,
         })
     }
 }

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -33,15 +33,23 @@ impl RawConfig {
         if !config.raw_mode {
             return None;
         }
+        let application = config
+            .raw_application
+            .clone()
+            .expect("raw_application required when raw_mode is enabled");
+
+        assert!(
+            config.worker_map.contains_key(&application),
+            "raw_application '{}' must exist in worker_map",
+            application
+        );
+
         Some(Self {
             namespace: config
                 .raw_namespace
                 .clone()
                 .expect("raw_namespace required when raw_mode is enabled"),
-            application: config
-                .raw_application
-                .clone()
-                .expect("raw_application required when raw_mode is enabled"),
+            application,
             taskname: config
                 .raw_taskname
                 .clone()

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -25,7 +25,7 @@ pub struct RawConfig {
     pub namespace: String,
     pub application: String,
     pub taskname: String,
-    pub processing_deadline_duration: u64,
+    pub processing_deadline_duration: u16,
 }
 
 impl RawConfig {
@@ -46,7 +46,7 @@ impl RawConfig {
                 .raw_taskname
                 .clone()
                 .expect("raw_taskname required when raw_mode is enabled"),
-            processing_deadline_duration: config.raw_processing_deadline_duration,
+            processing_deadline_duration: config.raw_processing_deadline_duration.into(),
         })
     }
 }
@@ -112,7 +112,7 @@ pub fn new(config: RawConfig) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightAc
             headers: extract_headers(&msg),
             received_at: Some(received_at),
             retry_state: None,
-            processing_deadline_duration: config.processing_deadline_duration,
+            processing_deadline_duration: config.processing_deadline_duration.into(),
             expires: None,
             delay: None,
         };
@@ -137,7 +137,7 @@ pub fn new(config: RawConfig) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightAc
             received_at: received_at_time,
             processing_deadline: None,
             claim_expires_at: None,
-            processing_deadline_duration: config.processing_deadline_duration as i32,
+            processing_deadline_duration: config.processing_deadline_duration.into(),
             processing_attempts: 0,
             expires_at: None,
             delay_until: None,

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Error, anyhow};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use prost::Message as _;
 use rdkafka::Message;
 use rdkafka::message::OwnedMessage;
@@ -14,38 +14,38 @@ use crate::store::activation::{InflightActivation, InflightActivationStatus};
 
 use super::deserialize_activation::bucket_from_id;
 
-pub struct PassthroughConfig {
+pub struct RawConfig {
     pub namespace: String,
     pub application: String,
     pub taskname: String,
     pub processing_deadline_duration: u64,
 }
 
-impl PassthroughConfig {
+impl RawConfig {
     pub fn from_config(config: &Config) -> Option<Self> {
-        if !config.passthrough_mode {
+        if !config.raw_mode {
             return None;
         }
         Some(Self {
             namespace: config
-                .passthrough_namespace
+                .raw_namespace
                 .clone()
-                .expect("passthrough_namespace required when passthrough_mode is enabled"),
+                .expect("raw_namespace required when raw_mode is enabled"),
             application: config
-                .passthrough_application
+                .raw_application
                 .clone()
-                .expect("passthrough_application required when passthrough_mode is enabled"),
+                .expect("raw_application required when raw_mode is enabled"),
             taskname: config
-                .passthrough_taskname
+                .raw_taskname
                 .clone()
-                .expect("passthrough_taskname required when passthrough_mode is enabled"),
-            processing_deadline_duration: config.passthrough_processing_deadline_duration,
+                .expect("raw_taskname required when raw_mode is enabled"),
+            processing_deadline_duration: config.raw_processing_deadline_duration,
         })
     }
 }
 
 /// Encode raw bytes into msgpack format: {"args": [raw_bytes], "kwargs": {}}
-fn encode_passthrough_params(raw_bytes: &[u8]) -> Result<Vec<u8>, Error> {
+fn encode_raw_params(raw_bytes: &[u8]) -> Result<Vec<u8>, Error> {
     use serde::Serialize;
 
     #[derive(Serialize)]
@@ -59,25 +59,30 @@ fn encode_passthrough_params(raw_bytes: &[u8]) -> Result<Vec<u8>, Error> {
         kwargs: HashMap::new(),
     };
 
+    // TODO: send to DLQ instead of skipping
     rmp_serde::to_vec_named(&params).map_err(|e| anyhow!("Failed to encode msgpack: {}", e))
 }
 
-/// Create a deserializer closure for passthrough mode.
+/// Create a deserializer closure for raw mode.
 /// Wraps raw Kafka message bytes into a TaskActivation with msgpack-encoded parameters_bytes.
-pub fn new(
-    config: PassthroughConfig,
-) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightActivation, Error> {
+pub fn new(config: RawConfig) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightActivation, Error> {
     move |msg: Arc<OwnedMessage>| {
         let Some(payload) = msg.payload() else {
+            // TODO: send to DLQ instead of skipping
             return Err(anyhow!("Message has no payload"));
         };
 
         let id = Uuid::new_v4().to_string();
-        let parameters_bytes = encode_passthrough_params(payload)?;
+        let parameters_bytes = encode_raw_params(payload)?;
         let now = Utc::now();
+        let received_at_time = msg
+            .timestamp()
+            .to_millis()
+            .and_then(DateTime::from_timestamp_millis)
+            .unwrap_or(now);
         let received_at = prost_types::Timestamp {
-            seconds: now.timestamp(),
-            nanos: 0,
+            seconds: received_at_time.timestamp(),
+            nanos: received_at_time.timestamp_subsec_nanos() as i32,
         };
 
         let activation = TaskActivation {
@@ -100,7 +105,7 @@ pub fn new(
         let bucket = bucket_from_id(&id);
 
         metrics::histogram!(
-            "consumer.passthrough.payload_size_bytes",
+            "consumer.raw.payload_size_bytes",
             "namespace" => config.namespace.clone(),
             "taskname" => config.taskname.clone()
         )
@@ -113,7 +118,7 @@ pub fn new(
             partition: msg.partition(),
             offset: msg.offset(),
             added_at: now,
-            received_at: now,
+            received_at: received_at_time,
             processing_deadline: None,
             claim_expires_at: None,
             processing_deadline_duration: config.processing_deadline_duration as i32,
@@ -140,7 +145,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_encode_passthrough_params() {
+    fn test_encode_raw_params() {
         use serde::Deserialize;
 
         #[derive(Deserialize, Debug)]
@@ -150,7 +155,7 @@ mod tests {
         }
 
         let raw_bytes = b"hello world";
-        let encoded = encode_passthrough_params(raw_bytes).unwrap();
+        let encoded = encode_raw_params(raw_bytes).unwrap();
 
         // Decode and verify
         let decoded: Params = rmp_serde::from_slice(&encoded).unwrap();
@@ -159,8 +164,8 @@ mod tests {
     }
 
     #[test]
-    fn test_passthrough_deserializer() {
-        let config = PassthroughConfig {
+    fn test_raw_deserializer() {
+        let config = RawConfig {
             namespace: "test-namespace".to_string(),
             application: "test-app".to_string(),
             taskname: "test-task".to_string(),
@@ -200,8 +205,8 @@ mod tests {
     }
 
     #[test]
-    fn test_passthrough_deserializer_empty_payload() {
-        let config = PassthroughConfig {
+    fn test_raw_deserializer_empty_payload() {
+        let config = RawConfig {
             namespace: "test-namespace".to_string(),
             application: "test-app".to_string(),
             taskname: "test-task".to_string(),

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use anyhow::{Error, anyhow};
+use anyhow::Error;
 use chrono::{DateTime, Utc};
 use prost::Message as _;
 use rdkafka::Message;

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -14,6 +14,12 @@ use crate::store::activation::{InflightActivation, InflightActivationStatus};
 
 use super::deserialize_activation::bucket_from_id;
 
+#[derive(serde::Serialize)]
+struct RawParams<'a> {
+    args: (&'a serde_bytes::Bytes,),
+    kwargs: HashMap<(), ()>,
+}
+
 pub struct RawConfig {
     pub namespace: String,
     pub application: String,
@@ -46,16 +52,8 @@ impl RawConfig {
 
 /// Encode raw bytes into msgpack format: {"args": [raw_bytes], "kwargs": {}}
 fn encode_raw_params(raw_bytes: &[u8]) -> Result<Vec<u8>, Error> {
-    use serde::Serialize;
-
-    #[derive(Serialize)]
-    struct Params<'a> {
-        args: (&'a [u8],),
-        kwargs: HashMap<(), ()>,
-    }
-
-    let params = Params {
-        args: (raw_bytes,),
+    let params = RawParams {
+        args: (serde_bytes::Bytes::new(raw_bytes),),
         kwargs: HashMap::new(),
     };
 
@@ -156,6 +154,16 @@ mod tests {
 
         let raw_bytes = b"hello world";
         let encoded = encode_raw_params(raw_bytes).unwrap();
+
+        // Verify msgpack uses binary format (0xc4 = bin8), not array format (0x9x). Array format
+        // is easy to accidentally serialize to with Vec<u8>.
+        // Python's msgpack decodes binary to `bytes` but array to `list[int]`.
+        // The encoded format should contain 0xc4 (bin8) followed by length 0x0b (11).
+        assert!(
+            encoded.windows(2).any(|w| w == [0xc4, 0x0b]),
+            "Expected binary format (c4 0b), got: {:02x?}",
+            encoded
+        );
 
         // Decode and verify
         let decoded: Params = rmp_serde::from_slice(&encoded).unwrap();

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -59,10 +59,10 @@ fn extract_headers(msg: &OwnedMessage) -> HashMap<String, String> {
     let mut result = HashMap::new();
     for i in 0..headers.count() {
         let header = headers.get(i);
-        if let Some(value) = header.value {
-            if let Ok(value_str) = std::str::from_utf8(value) {
-                result.insert(header.key.to_string(), value_str.to_string());
-            }
+        if let Some(value) = header.value
+            && let Ok(value_str) = std::str::from_utf8(value)
+        {
+            result.insert(header.key.to_string(), value_str.to_string());
         }
     }
     result

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -2,7 +2,7 @@ pub mod admin;
 pub mod consumer;
 pub mod deserialize;
 pub mod deserialize_activation;
-pub mod deserialize_passthrough;
+pub mod deserialize_raw;
 pub mod inflight_activation_batcher;
 pub mod inflight_activation_writer;
 pub mod os_stream_writer;

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -1,6 +1,8 @@
 pub mod admin;
 pub mod consumer;
+pub mod deserialize;
 pub mod deserialize_activation;
+pub mod deserialize_passthrough;
 pub mod inflight_activation_batcher;
 pub mod inflight_activation_writer;
 pub mod os_stream_writer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,7 @@ use taskbroker::grpc::metrics_middleware::MetricsLayer;
 use taskbroker::grpc::server::TaskbrokerServer;
 use taskbroker::kafka::admin::create_missing_topics;
 use taskbroker::kafka::consumer::start_consumer;
-use taskbroker::kafka::deserialize_activation;
-use taskbroker::kafka::deserialize_activation::DeserializeActivationConfig;
+use taskbroker::kafka::deserialize::{self, DeserializeConfig};
 use taskbroker::kafka::inflight_activation_batcher::{
     ActivationBatcherConfig, InflightActivationBatcher,
 };
@@ -174,7 +173,7 @@ async fn main() -> Result<(), Error> {
                         ),
 
                     map:
-                        deserialize_activation::new(DeserializeActivationConfig::from_config(&consumer_config)),
+                        deserialize::new(DeserializeConfig::from_config(&consumer_config)),
 
                     reduce:
                         InflightActivationBatcher::new(


### PR DESCRIPTION
ref STREAM-882

Introduce passthrough mode, so that a broker can be used to spawn tasks
from any topic with any type of message format. This will make it easier
to migrate existing consumers to be tasks instead, without changing data
layout in prod. For more information refer to the ticket above.
