### PR TITLE
ref(tests): Use tempfile everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,6 +2998,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "sqlx",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ uuid = { version = "1.11.0", features = ["v4"] }
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 rstest = "0.23"
+tempfile = "3"
 
 [[bench]]
 name = "store_bench"

--- a/src/kafka/inflight_activation_batcher.rs
+++ b/src/kafka/inflight_activation_batcher.rs
@@ -239,8 +239,7 @@ demoted_namespaces:
         config_file.flush().unwrap();
 
         let runtime_config = Arc::new(
-            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
-                .await,
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await,
         );
         let config = Arc::new(Config::default());
         let mut batcher = InflightActivationBatcher::new(
@@ -360,8 +359,7 @@ demoted_topic: taskworker-demoted"#;
         config_file.flush().unwrap();
 
         let runtime_config = Arc::new(
-            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
-                .await,
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await,
         );
         let config = Arc::new(Config::default());
         let mut batcher = InflightActivationBatcher::new(

--- a/src/kafka/inflight_activation_batcher.rs
+++ b/src/kafka/inflight_activation_batcher.rs
@@ -213,10 +213,11 @@ impl Reducer for InflightActivationBatcher {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
     use std::sync::Arc;
 
     use chrono::Utc;
-    use tokio::fs;
+    use tempfile::NamedTempFile;
 
     use crate::store::activation::InflightActivationBuilder;
     use crate::test_utils::{TaskActivationBuilder, generate_unique_namespace};
@@ -233,10 +234,14 @@ drop_task_killswitch:
 demoted_namespaces:
   -"#;
 
-        let test_path = "test_drop_task_due_to_killswitch.yaml";
-        fs::write(test_path, test_yaml).await.unwrap();
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
 
-        let runtime_config = Arc::new(RuntimeConfigManager::new(Some(test_path.to_string())).await);
+        let runtime_config = Arc::new(
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
+                .await,
+        );
         let config = Arc::new(Config::default());
         let mut batcher = InflightActivationBatcher::new(
             ActivationBatcherConfig::from_config(&config),
@@ -253,8 +258,6 @@ demoted_namespaces:
 
         batcher.reduce(inflight_activation_0).await.unwrap();
         assert_eq!(batcher.batch.len(), 0);
-
-        fs::remove_file(test_path).await.unwrap();
     }
 
     #[tokio::test]
@@ -352,10 +355,14 @@ demoted_namespaces:
 demoted_topic_cluster: 0.0.0.0:9092
 demoted_topic: taskworker-demoted"#;
 
-        let test_path = "test_forward_task_due_to_demoted_namespace.yaml";
-        fs::write(test_path, test_yaml).await.unwrap();
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
 
-        let runtime_config = Arc::new(RuntimeConfigManager::new(Some(test_path.to_string())).await);
+        let runtime_config = Arc::new(
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
+                .await,
+        );
         let config = Arc::new(Config::default());
         let mut batcher = InflightActivationBatcher::new(
             ActivationBatcherConfig::from_config(&config),
@@ -393,7 +400,5 @@ demoted_topic: taskworker-demoted"#;
         assert_eq!(batcher.batch.len(), 0);
         assert_eq!(batcher.forward_batch.len(), 0);
         assert_eq!(batcher.producer_cluster, "0.0.0.0:9092");
-
-        fs::remove_file(test_path).await.unwrap();
     }
 }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -92,8 +92,12 @@ impl Drop for RuntimeConfigManager {
 
 #[cfg(test)]
 mod tests {
-    use super::RuntimeConfigManager;
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
     use tokio::fs;
+
+    use super::RuntimeConfigManager;
 
     #[tokio::test]
     async fn test_runtime_config_manager() {
@@ -103,15 +107,16 @@ drop_task_killswitch:
 demoted_namespaces:
   -"#;
 
-        let test_path = "test_runtime_config_manager.yaml";
-        fs::write(test_path, test_yaml).await.unwrap();
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
 
-        let runtime_config = RuntimeConfigManager::new(Some(test_path.to_string())).await;
+        let runtime_config =
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
+                .await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 1);
         assert_eq!(config.drop_task_killswitch[0], "test:do_nothing");
-
-        fs::remove_file(test_path).await.unwrap();
     }
 
     #[tokio::test]
@@ -131,14 +136,15 @@ droop_task_killswitch:
 demoted_namespaces:
   -"#;
 
-        let test_path = "test_invalid_runtime_config_file.yaml";
-        fs::write(test_path, test_yaml).await.unwrap();
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
 
-        let runtime_config = RuntimeConfigManager::new(Some(test_path.to_string())).await;
+        let runtime_config =
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
+                .await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 0);
-
-        fs::remove_file(test_path).await.unwrap();
     }
 
     #[tokio::test]
@@ -149,10 +155,12 @@ drop_task_killswitch:
 demoted_namespaces:
   -"#;
 
-        let test_path = "test_preserve_runtime_config_file.yaml";
-        fs::write(test_path, test_yaml).await.unwrap();
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
+        let test_path = config_file.path().to_str().unwrap().to_string();
 
-        let runtime_config = RuntimeConfigManager::new(Some(test_path.to_string())).await;
+        let runtime_config = RuntimeConfigManager::new(Some(test_path.clone())).await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 1);
         assert_eq!(config.drop_task_killswitch[0], "test:do_nothing");
@@ -163,14 +171,11 @@ droop_task_killswitch:
 demoted_namespaces:
   -"#;
 
-        fs::write(test_path, invalid_yaml).await.unwrap();
-        RuntimeConfigManager::reload_config(&Some(test_path.to_string()), &runtime_config.config)
-            .await;
+        fs::write(&test_path, invalid_yaml).await.unwrap();
+        RuntimeConfigManager::reload_config(&Some(test_path), &runtime_config.config).await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 1);
         assert_eq!(config.drop_task_killswitch[0], "test:do_nothing");
-
-        fs::remove_file(test_path).await.unwrap();
     }
 
     #[tokio::test]
@@ -183,10 +188,13 @@ demoted_namespaces:
 demoted_topic_cluster: kafka:9092
 demoted_topic: taskworker-demoted-topic"#;
 
-        let test_path = "test_demoted_namespaces.yaml";
-        fs::write(test_path, test_yaml).await.unwrap();
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
 
-        let runtime_config = RuntimeConfigManager::new(Some(test_path.to_string())).await;
+        let runtime_config =
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
+                .await;
         let config = runtime_config.read().await;
         assert_eq!(
             config.demoted_topic_cluster.as_deref().unwrap(),
@@ -202,8 +210,6 @@ demoted_topic: taskworker-demoted-topic"#;
             config.demoted_topic.as_deref().unwrap_or("taskworker-long"),
             "taskworker-demoted-topic"
         );
-
-        fs::remove_file(test_path).await.unwrap();
     }
 
     #[tokio::test]
@@ -214,15 +220,17 @@ drop_task_killswitch:
 demoted_namespaces:
   - bad_namespace"#;
 
-        let test_path = "test_killswitch_and_demoted_namespaces.yaml";
-        fs::write(test_path, test_yaml).await.unwrap();
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
 
-        let runtime_config = RuntimeConfigManager::new(Some(test_path.to_string())).await;
+        let runtime_config =
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
+                .await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 1);
         assert_eq!(config.drop_task_killswitch[0], "test:do_nothing");
         assert_eq!(config.demoted_namespaces.len(), 1);
         assert_eq!(config.demoted_namespaces[0], "bad_namespace");
-        fs::remove_file(test_path).await.unwrap();
     }
 }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -112,8 +112,7 @@ demoted_namespaces:
         config_file.flush().unwrap();
 
         let runtime_config =
-            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
-                .await;
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 1);
         assert_eq!(config.drop_task_killswitch[0], "test:do_nothing");
@@ -141,8 +140,7 @@ demoted_namespaces:
         config_file.flush().unwrap();
 
         let runtime_config =
-            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
-                .await;
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 0);
     }
@@ -193,8 +191,7 @@ demoted_topic: taskworker-demoted-topic"#;
         config_file.flush().unwrap();
 
         let runtime_config =
-            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
-                .await;
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await;
         let config = runtime_config.read().await;
         assert_eq!(
             config.demoted_topic_cluster.as_deref().unwrap(),
@@ -225,8 +222,7 @@ demoted_namespaces:
         config_file.flush().unwrap();
 
         let runtime_config =
-            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string()))
-                .await;
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 1);
         assert_eq!(config.drop_task_killswitch[0], "test:do_nothing");

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -1,7 +1,5 @@
 use std::collections::HashSet;
 use std::fs;
-use std::io::Error;
-use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -10,6 +8,7 @@ use rstest::rstest;
 use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, RetryState, TaskActivationStatus};
 use sqlx::postgres::PgSslMode;
 use sqlx::{QueryBuilder, Sqlite};
+use tempfile::TempDir;
 use tokio::sync::broadcast;
 use tokio::task::JoinSet;
 
@@ -1966,53 +1965,14 @@ async fn test_db_status_calls_ok() {
     }
 }
 
-struct TestFolders {
-    parent_folder: String,
-    initial_folder: String,
-    other_folder: String,
-}
-
-impl TestFolders {
-    fn new() -> Result<Self, Error> {
-        let parent_folder = "./testmigrations".to_string();
-        let parent = fs::create_dir(&parent_folder);
-        if parent.is_err() {
-            return Err(parent.err().unwrap());
-        }
-
-        let initial_folder = parent_folder.clone() + "/initial_migrations";
-        let other_folder = parent_folder.clone() + "/other_migrations";
-
-        let initial = fs::create_dir(&initial_folder);
-        if initial.is_err() {
-            return Err(initial.err().unwrap());
-        }
-        let other = fs::create_dir(&other_folder);
-        if other.is_err() {
-            return Err(other.err().unwrap());
-        }
-
-        Ok(TestFolders {
-            parent_folder,
-            initial_folder,
-            other_folder,
-        })
-    }
-}
-
-impl Drop for TestFolders {
-    fn drop(&mut self) {
-        let parent = fs::remove_dir_all(Path::new(&self.parent_folder));
-        if parent.is_err() {
-            println!("Could not remove dir {}, {:?}", self.parent_folder, parent);
-        }
-    }
-}
-
 #[tokio::test]
 async fn test_migrations() {
-    // Create the folders that will be used
-    let folders = TestFolders::new().unwrap();
+    // Create temp folders that auto-cleanup on drop
+    let temp_dir = TempDir::new().unwrap();
+    let initial_folder = temp_dir.path().join("initial_migrations");
+    let other_folder = temp_dir.path().join("other_migrations");
+    fs::create_dir(&initial_folder).unwrap();
+    fs::create_dir(&other_folder).unwrap();
 
     // Move migrations to different folders
     let orig = fs::read_dir("./migrations/sqlite");
@@ -2025,20 +1985,17 @@ async fn test_migrations() {
         let filename = entry.file_name().into_string().unwrap();
         // Write the initial migration to a separate folder, so the table can be initialized without any migrations.
         if filename.starts_with("0001") {
-            let result = fs::copy(
-                entry.path(),
-                folders.initial_folder.clone() + "/" + &filename,
-            );
+            let result = fs::copy(entry.path(), initial_folder.join(&filename));
             assert!(result.is_ok(), "{result:?}");
         }
 
-        let result = fs::copy(entry.path(), folders.other_folder.clone() + "/" + &filename);
+        let result = fs::copy(entry.path(), other_folder.join(&filename));
         assert!(result.is_ok(), "{result:?}");
     }
 
     // Run initial migration
     let (_read_pool, write_pool) = create_sqlite_pool(&generate_temp_filename()).await.unwrap();
-    let result = sqlx::migrate::Migrator::new(Path::new(&folders.initial_folder))
+    let result = sqlx::migrate::Migrator::new(initial_folder.as_path())
         .await
         .unwrap()
         .run(&write_pool)
@@ -2092,7 +2049,7 @@ async fn test_migrations() {
     assert_eq!(result.rows_affected(), 2);
 
     // Run other migrations
-    let result = sqlx::migrate::Migrator::new(Path::new(&folders.other_folder))
+    let result = sqlx::migrate::Migrator::new(other_folder.as_path())
         .await
         .unwrap()
         .run(&write_pool)

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -523,6 +523,7 @@ pub async fn check_health(
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
     use std::sync::Arc;
     use std::time::Duration;
     use std::time::Instant;
@@ -532,7 +533,7 @@ mod tests {
     use prost_types::Timestamp;
     use rstest::rstest;
     use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, RetryState, TaskActivation};
-    use tokio::fs;
+    use tempfile::NamedTempFile;
     use tokio::time::sleep;
 
     use crate::config::Config;
@@ -1256,9 +1257,12 @@ demoted_namespaces:
   - bad_namespace1
   - bad_namespace2"#;
 
-        let test_path = "test_forward_demoted_namespaces.yaml";
-        fs::write(test_path, test_yaml).await.unwrap();
-        let runtime_config = Arc::new(RuntimeConfigManager::new(Some(test_path.to_string())).await);
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
+        let runtime_config = Arc::new(
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await,
+        );
         let producer = create_producer(config.clone());
         let store = create_test_store(adapter).await;
         let start_time = Utc::now();
@@ -1297,7 +1301,6 @@ demoted_namespaces:
             2,
             "two tasks should be marked as complete"
         );
-        let _ = fs::remove_file(test_path).await;
     }
 
     #[tokio::test]
@@ -1312,10 +1315,13 @@ drop_task_killswitch:
 demoted_namespaces:
   -"#;
 
-        let test_path = "test_drop_task_due_to_killswitch.yaml";
-        fs::write(test_path, test_yaml).await.unwrap();
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
 
-        let runtime_config = Arc::new(RuntimeConfigManager::new(Some(test_path.to_string())).await);
+        let runtime_config = Arc::new(
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await,
+        );
         let producer = create_producer(config.clone());
         let store = create_test_store(adapter).await;
         let start_time = Utc::now();
@@ -1347,8 +1353,6 @@ demoted_namespaces:
                 .unwrap(),
             3
         );
-
-        let _ = fs::remove_file(test_path).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
The test `test_forward_demoted_namespaces` just created dirty files into
my workspace and then didn't delete them. Other tests have the same
issue when they fail.

Add tempfile crate which is commonly used, remove TestFolders which is
fine but not all that reusable. In some places we now use sync file
operations where previously we used async, but especially during tests
this is fine.
