### PR TITLE
fix(taskbroker-client): Update docstrings to reflect msgpack serialization

### DIFF
--- a/clients/python/src/taskbroker_client/task.py
+++ b/clients/python/src/taskbroker_client/task.py
@@ -112,7 +112,7 @@ class Task(Generic[P, R]):
         """
         Schedule a task to run later with a set of arguments.
 
-        The provided parameters will be JSON encoded and stored within
+        The provided parameters will be msgpack encoded and stored within
         a `TaskActivation` protobuf that is appended to kafka
         """
         self.apply_async(args=args, kwargs=kwargs)
@@ -129,7 +129,7 @@ class Task(Generic[P, R]):
         """
         Schedule a task to run later with a set of arguments.
 
-        The provided parameters will be JSON encoded and stored within
+        The provided parameters will be msgpack encoded and stored within
         a `TaskActivation` protobuf that is appended to kafka.
         """
         if args is None:


### PR DESCRIPTION
## Summary
- Updates `delay()` and `apply_async()` docstrings to correctly state that parameters are msgpack encoded (not JSON)

Fixes STREAM-948

🤖 Generated with [Claude Code](https://claude.com/claude-code)