### PR TITLE
fix(iswf): Reverts change to reporting logic that silences NoRetriesRemaining exceptions

### DIFF
--- a/clients/python/src/taskbroker_client/worker/workerchild.py
+++ b/clients/python/src/taskbroker_client/worker/workerchild.py
@@ -281,18 +281,17 @@ def child_process(
                         next_state = TASK_ACTIVATION_STATUS_RETRY
                     elif retry.max_attempts_reached(inflight.activation.retry_state):
                         with sentry_sdk.isolation_scope() as scope:
-                            if should_capture_error:
-                                retry_error = NoRetriesRemainingError(
-                                    f"{inflight.activation.taskname} has consumed all of its retries"
-                                )
-                                retry_error.__cause__ = err
-                                scope.fingerprint = [
-                                    "taskworker.no_retries_remaining",
-                                    inflight.activation.namespace,
-                                    inflight.activation.taskname,
-                                ]
-                                scope.set_transaction_name(inflight.activation.taskname)
-                                sentry_sdk.capture_exception(retry_error)
+                            retry_error = NoRetriesRemainingError(
+                                f"{inflight.activation.taskname} has consumed all of its retries"
+                            )
+                            retry_error.__cause__ = err
+                            scope.fingerprint = [
+                                "taskworker.no_retries_remaining",
+                                inflight.activation.namespace,
+                                inflight.activation.taskname,
+                            ]
+                            scope.set_transaction_name(inflight.activation.taskname)
+                            sentry_sdk.capture_exception(retry_error)
                             # In this branch, all exceptions should be either
                             #  captured or silenced.
                             captured_error = True


### PR DESCRIPTION
This reporting is valuable for other teams to triage issues with their tasks and retries, even through silenced exceptions. Knowing when a task has exceeded its maximum number of retries means that the task has effectively transitioned to a terminal state and will not be reattempted if no deadletter is set. While this will increase a bit of noise, it'll provide better ideas of failure rates in our product.
