### PR TITLE
feat(client): add TaskProducer

### DIFF
--- a/clients/python/src/taskbroker_client/worker/producer.py
+++ b/clients/python/src/taskbroker_client/worker/producer.py
@@ -1,0 +1,72 @@
+from collections.abc import Callable
+from concurrent.futures import Future
+from typing import Any, Sequence
+
+from arroyo.backends.abstract import ProducerFuture, SimpleProducerFuture
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.types import BrokerValue, Topic
+
+from taskbroker_client.types import ProducerProtocol
+
+# This is global as TaskWorker needs to be able to call TaskProducer.collect_futures()
+# without a reference to a task's specific instance of TaskProducer.
+_pending_futures: set[ProducerFuture[BrokerValue[KafkaPayload]]] = set()
+
+
+class TaskProducer:
+    """
+    TaskProducer is a producer abstraction that should be used by tasks
+    when producing to Kafka is a side effect of a task function.
+    After a TaskWorker child process executes a task function, it will collect all
+    producer futures tracked by TaskProducer, and will only register the activation as
+    a success if all producer futures from that task were successful.
+    Otherwise, the activation will be retried.
+
+    TODO: actually have the TaskWorker child check TaskProducer futures.
+    """
+
+    def __init__(self, producer: ProducerProtocol) -> None:
+        self._inner_producer = producer
+
+    def track_future(self, future: ProducerFuture[BrokerValue[KafkaPayload]]) -> None:
+        _pending_futures.add(future)
+
+    @staticmethod
+    def collect_futures() -> set[ProducerFuture[BrokerValue[KafkaPayload]]]:
+        futures = _pending_futures.copy()
+        _pending_futures.clear()
+        return futures
+
+    def produce(
+        self,
+        topic: Topic,
+        payload: KafkaPayload,
+        callbacks: Sequence[Callable[[Future[BrokerValue[KafkaPayload]]], Any]] = [],
+    ) -> None:
+        """
+        Produces the given payload to the given topic.
+        Since TaskProducer tracks futures internally, it does not return the
+        producer future to the user, but the user can still add callbacks
+        to the future via the `callbacks` arg.
+
+        Args:
+            topic: Topic to produce to.
+            payload: KafkaPayload to produce.
+            callbacks: List of Callables to add to the future as done callbacks. The future itself
+                       is the only arg passed to the callback.
+        """
+        future = self._inner_producer.produce(topic, payload)
+        self.track_future(future)
+        if callbacks:
+            # Arroyo producers can return a SimpleProducerFuture,
+            # which does not accept callbacks.
+            if not isinstance(future, SimpleProducerFuture):
+                for c in callbacks:
+                    future.add_done_callback(c)
+            else:
+                raise RuntimeError(
+                    (
+                        "Cannot add callbacks to SimpleProducerFuture, either remove the callbacks "
+                        "or instantiate your producer with `use_simple_futures=False`."
+                    )
+                )

--- a/clients/python/tests/worker/test_producer.py
+++ b/clients/python/tests/worker/test_producer.py
@@ -1,0 +1,77 @@
+from collections.abc import Iterator
+from concurrent.futures import Future
+from datetime import datetime
+
+import pytest
+from arroyo.backends.abstract import ProducerFuture, SimpleProducerFuture
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.types import BrokerValue, Partition, Topic
+
+from taskbroker_client.worker.producer import TaskProducer, _pending_futures
+
+
+def make_kafka_payload() -> KafkaPayload:
+    """Generates dummy KafkaPayload."""
+    return KafkaPayload(None, b"", [])
+
+
+def make_broker_value() -> BrokerValue[KafkaPayload]:
+    """Generates dummy BrokerValue[KafkaPayload]."""
+    return BrokerValue(make_kafka_payload(), Partition(Topic("test"), 0), 0, datetime(1999, 2, 19))
+
+
+class DummyProducer:
+    def __init__(self, use_simple_futures: bool):
+        self.use_simple_futures = use_simple_futures
+
+    def produce(
+        self, topic: Topic, payload: KafkaPayload
+    ) -> ProducerFuture[BrokerValue[KafkaPayload]]:
+        future: ProducerFuture[BrokerValue[KafkaPayload]]
+        if self.use_simple_futures:
+            future = SimpleProducerFuture()
+        else:
+            future = Future()
+        future.set_result(make_broker_value())
+        return future
+
+
+@pytest.fixture(autouse=True)
+def clear_pending_futures() -> Iterator[None]:
+    _pending_futures.clear()
+    yield
+    _pending_futures.clear()
+
+
+def test_producer_tracks_futures() -> None:
+    producer = TaskProducer(DummyProducer(use_simple_futures=True))
+    producer.produce(Topic("test"), make_kafka_payload())
+    assert len(_pending_futures) == 1
+    future = next(iter(TaskProducer.collect_futures()))
+    assert future.result() == make_broker_value()
+    assert len(_pending_futures) == 0
+
+
+def test_producer_executes_callbacks() -> None:
+    producer = TaskProducer(DummyProducer(use_simple_futures=False))
+    received: list[Future[BrokerValue[KafkaPayload]]] = []
+
+    def callback(future: Future[BrokerValue[KafkaPayload]]) -> None:
+        received.append(future)
+
+    producer.produce(Topic("test"), make_kafka_payload(), callbacks=[callback])
+    tracked_future = next(iter(TaskProducer.collect_futures()))
+
+    assert len(received) == 1
+    assert received[0] is tracked_future
+    assert received[0].done()
+
+
+def test_producer_rejects_callbacks_for_simple_futures() -> None:
+    producer = TaskProducer(DummyProducer(use_simple_futures=True))
+
+    def callback(future: Future[BrokerValue[KafkaPayload]]) -> None:
+        pass
+
+    with pytest.raises(RuntimeError, match="SimpleProducerFuture"):
+        producer.produce(Topic("test"), make_kafka_payload(), callbacks=[callback])


### PR DESCRIPTION
Ticket: https://linear.app/getsentry/issue/STREAM-950/create-the-taskproducer-abstraction-in-taskworker-client

This PR adds a `TaskProducer` class to the taskworker client. It works by taking an arroyo producer as argument, and when `.produce()` is called it tracks the producer future rather than returning it to the user.

Previously we talked about allowing the TaskProducer to use any producer internally (not just an arroyo one), but taskbroker_client already depends on arroyo and it'd be hard to get the typing to work otherwise (since arroyo producers can return `SimpleProducerFuture`, which needs to be handled differently from regular `concurrent.future.Future`'s).