### PR TITLE
ref: Drop "Inflight" prefix from activation types and modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ If a single external crate needs **more than three** `use` lines, put that crate
 The first block below is **wrong on purpose** (mixed order and no blank lines).
 
 ```rs
-use crate::store::adapters::postgres::{PostgresActivationStore, PostgresActivationStoreConfig};
+use crate::store::adapters::postgres::{PostgresStore, PostgresStoreConfig};
 use crate::store::traits::ActivationStore;
 use std::sync::Arc;
 use rdkafka::Message;
@@ -60,6 +60,6 @@ use rdkafka::producer::FutureProducer;
 
 use anyhow::{Context, Result};
 
-use crate::store::adapters::postgres::{PostgresActivationStore, PostgresActivationStoreConfig};
+use crate::store::adapters::postgres::{PostgresStore, PostgresStoreConfig};
 use crate::store::traits::ActivationStore;
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ The first block below is **wrong on purpose** (mixed order and no blank lines).
 
 ```rs
 use crate::store::adapters::postgres::{PostgresActivationStore, PostgresActivationStoreConfig};
-use crate::store::traits::InflightActivationStore;
+use crate::store::traits::ActivationStore;
 use std::sync::Arc;
 use rdkafka::Message;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
@@ -61,5 +61,5 @@ use rdkafka::producer::FutureProducer;
 use anyhow::{Context, Result};
 
 use crate::store::adapters::postgres::{PostgresActivationStore, PostgresActivationStoreConfig};
-use crate::store::traits::InflightActivationStore;
+use crate::store::traits::ActivationStore;
 ```

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -5,9 +5,9 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use rand::Rng;
 use tokio::task::JoinSet;
 
-use taskbroker::store::activation::InflightActivationStatus;
-use taskbroker::store::adapters::sqlite::{InflightActivationStoreConfig, SqliteActivationStore};
-use taskbroker::store::traits::InflightActivationStore;
+use taskbroker::store::activation::ActivationStatus;
+use taskbroker::store::adapters::sqlite::{ActivationStoreConfig, SqliteActivationStore};
+use taskbroker::store::traits::ActivationStore;
 use taskbroker::test_utils::{
     generate_temp_filename, generate_unique_namespace, make_activations_with_namespace,
 };
@@ -26,7 +26,7 @@ async fn get_pending_activations(num_activations: u32, num_workers: u32) {
     let store = Arc::new(
         SqliteActivationStore::new(
             &url,
-            InflightActivationStoreConfig {
+            ActivationStoreConfig {
                 max_processing_attempts: 1,
                 vacuum_page_count: None,
                 processing_deadline_grace_sec: 3,
@@ -91,7 +91,7 @@ async fn set_status(num_activations: u32, num_workers: u32) {
     let store = Arc::new(
         SqliteActivationStore::new(
             &url,
-            InflightActivationStoreConfig {
+            ActivationStoreConfig {
                 max_processing_attempts: 1,
                 vacuum_page_count: None,
                 processing_deadline_grace_sec: 3,
@@ -123,7 +123,7 @@ async fn set_status(num_activations: u32, num_workers: u32) {
                     store
                         .set_status(
                             &format!("id_{task_id}"),
-                            InflightActivationStatus::Complete,
+                            ActivationStatus::Complete,
                             None,
                             None,
                         )
@@ -138,7 +138,7 @@ async fn set_status(num_activations: u32, num_workers: u32) {
 
     assert_eq!(
         store
-            .count_by_status(InflightActivationStatus::Complete)
+            .count_by_status(ActivationStatus::Complete)
             .await
             .unwrap(),
         num_activations as usize
@@ -149,7 +149,7 @@ fn store_bench(c: &mut Criterion) {
     let num_activations: u32 = 4_096;
     let num_workers = 64;
 
-    c.benchmark_group("bench_InflightActivationStore")
+    c.benchmark_group("bench_ActivationStore")
         .sample_size(256)
         .throughput(criterion::Throughput::Elements(num_activations.into()))
         .bench_function("get_pending_activation", |b| {

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -6,7 +6,7 @@ use rand::Rng;
 use tokio::task::JoinSet;
 
 use taskbroker::store::activation::ActivationStatus;
-use taskbroker::store::adapters::sqlite::{ActivationStoreConfig, SqliteActivationStore};
+use taskbroker::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig};
 use taskbroker::store::traits::ActivationStore;
 use taskbroker::test_utils::{
     generate_temp_filename, generate_unique_namespace, make_activations_with_namespace,
@@ -24,9 +24,9 @@ async fn get_pending_activations(num_activations: u32, num_workers: u32) {
         generate_temp_filename()
     };
     let store = Arc::new(
-        SqliteActivationStore::new(
+        SqliteStore::new(
             &url,
-            ActivationStoreConfig {
+            SqliteStoreConfig {
                 max_processing_attempts: 1,
                 vacuum_page_count: None,
                 processing_deadline_grace_sec: 3,
@@ -89,9 +89,9 @@ async fn set_status(num_activations: u32, num_workers: u32) {
     };
 
     let store = Arc::new(
-        SqliteActivationStore::new(
+        SqliteStore::new(
             &url,
-            ActivationStoreConfig {
+            SqliteStoreConfig {
                 max_processing_attempts: 1,
                 vacuum_page_count: None,
                 processing_deadline_grace_sec: 3,

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,7 +149,7 @@ pub struct Config {
     /// The number of ms for timeouts when publishing messages to kafka.
     pub kafka_send_timeout_ms: u64,
 
-    /// The database adapter to use for the inflight activation store.
+    /// The database adapter to use for the activation store.
     pub database_adapter: DatabaseAdapter,
 
     /// Whether to run the migrations on the database.
@@ -157,19 +157,19 @@ pub struct Config {
     /// in production the migrations shouldn't be run by the taskbroker.
     pub run_migrations: bool,
 
-    /// The host of the postgres database to use for the inflight activation store.
+    /// The host of the postgres database to use for the activation store.
     pub pg_host: String,
 
-    /// The port of the postgres database to use for the inflight activation store.
+    /// The port of the postgres database to use for the activation store.
     pub pg_port: u16,
 
-    /// The username of the postgres database to use for the inflight activation store.
+    /// The username of the postgres database to use for the activation store.
     pub pg_username: String,
 
-    /// The password of the postgres database to use for the inflight activation store.
+    /// The password of the postgres database to use for the activation store.
     pub pg_password: String,
 
-    /// The name of the postgres database to use for the inflight activation store.
+    /// The name of the postgres database to use for the activation store.
     pub pg_database_name: String,
 
     /// The default postgres database to use for migrations..
@@ -186,15 +186,15 @@ pub struct Config {
     pub db_write_failure_backoff_ms: u64,
 
     /// The maximum number of tasks that are buffered
-    /// before being written to InflightTaskStore (sqlite).
+    /// before being written to ActivationStore (sqlite).
     pub db_insert_batch_max_len: usize,
 
     /// The maximum number of bytes that are buffered
-    /// before being written to InflightTaskStore (sqlite).
+    /// before being written to ActivationStore (sqlite).
     pub db_insert_batch_max_size: usize,
 
     /// The time in milliseconds to buffer tasks
-    /// before being written to InflightTaskStore (sqlite).
+    /// before being written to ActivationStore (sqlite).
     pub db_insert_batch_max_time_ms: u64,
 
     /// The maximum size of the sqlite database in bytes.
@@ -206,15 +206,15 @@ pub struct Config {
     pub runtime_config_path: Option<String>,
 
     /// The maximum number of pending records that can be
-    /// in the InflightTaskStore (sqlite)
+    /// in the ActivationStore (sqlite)
     pub max_pending_count: usize,
 
     /// The maximum number of delay records that can be
-    /// in the InflightTaskStore (sqlite)
+    /// in the ActivationStore (sqlite)
     pub max_delay_count: usize,
 
     /// The maximum number of processing records that can be
-    /// in the InflightTaskStore (sqlite)
+    /// in the ActivationStore (sqlite)
     pub max_processing_count: usize,
 
     /// The maximum number of times a task can be reset from

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -12,8 +12,8 @@ use tracing::{debug, info, warn};
 
 use crate::config::Config;
 use crate::push::{PushError, PushPool};
-use crate::store::activation::InflightActivation;
-use crate::store::traits::InflightActivationStore;
+use crate::store::activation::Activation;
+use crate::store::traits::ActivationStore;
 use crate::store::types::BucketRange;
 
 /// This value should be a power of two. If it decreases, some ranges will no longer be queried.
@@ -52,29 +52,21 @@ pub fn bucket_range_for_fetch_thread(thread_index: usize, fetch_threads: usize) 
 #[async_trait]
 pub trait TaskPusher {
     /// Submit a single task to the push pool.
-    async fn submit_task(
-        &self,
-        activation: InflightActivation,
-        time: Instant,
-    ) -> Result<(), PushError>;
+    async fn submit_task(&self, activation: Activation, time: Instant) -> Result<(), PushError>;
 }
 
 #[async_trait]
 impl TaskPusher for PushPool {
     #[framed]
-    async fn submit_task(
-        &self,
-        activation: InflightActivation,
-        time: Instant,
-    ) -> Result<(), PushError> {
+    async fn submit_task(&self, activation: Activation, time: Instant) -> Result<(), PushError> {
         self.submit(activation, time).await
     }
 }
 
 /// Wrapper around `config.fetch_threads` asynchronous tasks, each of which fetches batches of pending activations from the store, passes them to the push pool, and repeats.
 pub struct FetchPool<T: TaskPusher> {
-    /// Inflight activation store.
-    store: Arc<dyn InflightActivationStore>,
+    /// Activation store.
+    store: Arc<dyn ActivationStore>,
 
     /// Pool of push threads that push activations to the worker service.
     pusher: Arc<T>,
@@ -85,11 +77,7 @@ pub struct FetchPool<T: TaskPusher> {
 
 impl<T: TaskPusher + Send + Sync + 'static> FetchPool<T> {
     /// Initialize a new fetch pool.
-    pub fn new(
-        store: Arc<dyn InflightActivationStore>,
-        config: Arc<Config>,
-        pusher: Arc<T>,
-    ) -> Self {
+    pub fn new(store: Arc<dyn ActivationStore>, config: Arc<Config>, pusher: Arc<T>) -> Self {
         Self {
             store,
             config,

--- a/src/fetch/tests.rs
+++ b/src/fetch/tests.rs
@@ -8,8 +8,8 @@ use tonic::async_trait;
 
 use crate::config::Config;
 use crate::push::PushError;
-use crate::store::activation::{InflightActivation, InflightActivationStatus};
-use crate::store::traits::InflightActivationStore;
+use crate::store::activation::{Activation, ActivationStatus};
+use crate::store::traits::ActivationStore;
 use crate::store::types::{BucketRange, FailedTasksForwarder};
 use crate::test_utils::make_activations;
 
@@ -18,7 +18,7 @@ use super::*;
 /// Store stub that returns one activation once OR is always empty OR always fails.
 struct MockStore {
     /// A single (optional) pending activation.
-    pending: Mutex<Option<InflightActivation>>,
+    pending: Mutex<Option<Activation>>,
 
     /// Should operations fail?
     fail: bool,
@@ -32,7 +32,7 @@ impl MockStore {
         }
     }
 
-    fn one(activation: InflightActivation) -> Self {
+    fn one(activation: Activation) -> Self {
         Self {
             pending: Mutex::new(Some(activation)),
             fail: false,
@@ -48,7 +48,7 @@ impl MockStore {
 }
 
 #[async_trait]
-impl InflightActivationStore for MockStore {
+impl ActivationStore for MockStore {
     fn assign_partitions(&self, _partitions: Vec<i32>) -> Result<(), Error> {
         Ok(())
     }
@@ -65,11 +65,11 @@ impl InflightActivationStore for MockStore {
         unimplemented!()
     }
 
-    async fn get_by_id(&self, _id: &str) -> Result<Option<InflightActivation>, Error> {
+    async fn get_by_id(&self, _id: &str) -> Result<Option<Activation>, Error> {
         unimplemented!()
     }
 
-    async fn store(&self, _batch: Vec<InflightActivation>) -> Result<u64, Error> {
+    async fn store(&self, _batch: Vec<Activation>) -> Result<u64, Error> {
         unimplemented!()
     }
 
@@ -80,7 +80,7 @@ impl InflightActivationStore for MockStore {
         _limit: Option<i32>,
         _bucket: Option<BucketRange>,
         mark_processing: bool,
-    ) -> Result<Vec<InflightActivation>, Error> {
+    ) -> Result<Vec<Activation>, Error> {
         if self.fail {
             return Err(anyhow!("mock store error"));
         }
@@ -88,9 +88,9 @@ impl InflightActivationStore for MockStore {
         Ok(match self.pending.lock().await.take() {
             Some(mut a) => {
                 a.status = if mark_processing {
-                    InflightActivationStatus::Processing
+                    ActivationStatus::Processing
                 } else {
-                    InflightActivationStatus::Claimed
+                    ActivationStatus::Claimed
                 };
                 vec![a]
             }
@@ -106,7 +106,7 @@ impl InflightActivationStore for MockStore {
         unimplemented!()
     }
 
-    async fn count_by_status(&self, _status: InflightActivationStatus) -> Result<usize, Error> {
+    async fn count_by_status(&self, _status: ActivationStatus) -> Result<usize, Error> {
         unimplemented!()
     }
 
@@ -117,17 +117,17 @@ impl InflightActivationStore for MockStore {
     async fn set_status(
         &self,
         _id: &str,
-        _status: InflightActivationStatus,
+        _status: ActivationStatus,
         _max_attempts: Option<u32>,
         _delay_on_retry: Option<u64>,
-    ) -> Result<Option<InflightActivation>, Error> {
+    ) -> Result<Option<Activation>, Error> {
         unimplemented!()
     }
 
     async fn set_status_batch(
         &self,
         _ids: &[String],
-        _status: InflightActivationStatus,
+        _status: ActivationStatus,
     ) -> Result<u64, Error> {
         unimplemented!()
     }
@@ -144,7 +144,7 @@ impl InflightActivationStore for MockStore {
         unimplemented!()
     }
 
-    async fn get_retry_activations(&self) -> Result<Vec<InflightActivation>, Error> {
+    async fn get_retry_activations(&self) -> Result<Vec<Activation>, Error> {
         unimplemented!()
     }
 
@@ -207,11 +207,7 @@ impl RecordingPusher {
 
 #[async_trait]
 impl TaskPusher for RecordingPusher {
-    async fn submit_task(
-        &self,
-        activation: InflightActivation,
-        _time: Instant,
-    ) -> Result<(), PushError> {
+    async fn submit_task(&self, activation: Activation, _time: Instant) -> Result<(), PushError> {
         self.pushed_ids.lock().await.push(activation.id.clone());
 
         if self.fail {
@@ -233,7 +229,7 @@ fn test_config() -> Arc<Config> {
 #[tokio::test]
 async fn fetch_pool_delivers_activation_to_pusher() {
     let activation = make_activations(1).remove(0);
-    let store: Arc<dyn InflightActivationStore> = Arc::new(MockStore::one(activation.clone()));
+    let store: Arc<dyn ActivationStore> = Arc::new(MockStore::one(activation.clone()));
     let pusher = Arc::new(RecordingPusher::new(false));
 
     let pool = FetchPool::new(store, test_config(), pusher.clone());
@@ -248,7 +244,7 @@ async fn fetch_pool_delivers_activation_to_pusher() {
 #[tokio::test]
 async fn fetch_pool_calls_pusher_once_when_push_errors() {
     let activation = make_activations(1).remove(0);
-    let store: Arc<dyn InflightActivationStore> = Arc::new(MockStore::one(activation));
+    let store: Arc<dyn ActivationStore> = Arc::new(MockStore::one(activation));
     let pusher = Arc::new(RecordingPusher::new(true));
 
     let pool = FetchPool::new(store, test_config(), pusher.clone());
@@ -262,7 +258,7 @@ async fn fetch_pool_calls_pusher_once_when_push_errors() {
 
 #[tokio::test]
 async fn fetch_pool_skips_pusher_when_store_errors() {
-    let store: Arc<dyn InflightActivationStore> = Arc::new(MockStore::error());
+    let store: Arc<dyn ActivationStore> = Arc::new(MockStore::error());
     let pusher = Arc::new(RecordingPusher::new(false));
 
     let pool = FetchPool::new(store, test_config(), pusher.clone());
@@ -276,7 +272,7 @@ async fn fetch_pool_skips_pusher_when_store_errors() {
 
 #[tokio::test]
 async fn fetch_pool_skips_pusher_when_no_pending() {
-    let store: Arc<dyn InflightActivationStore> = Arc::new(MockStore::empty());
+    let store: Arc<dyn ActivationStore> = Arc::new(MockStore::empty());
     let pusher = Arc::new(RecordingPusher::new(false));
 
     let pool = FetchPool::new(store, test_config(), pusher.clone());

--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -15,11 +15,11 @@ use tonic::{Request, Response, Status};
 use tracing::{debug, error, instrument, warn};
 
 use crate::config::{Config, DeliveryMode};
-use crate::store::activation::InflightActivationStatus;
-use crate::store::traits::InflightActivationStore;
+use crate::store::activation::ActivationStatus;
+use crate::store::traits::ActivationStore;
 
 pub struct TaskbrokerServer {
-    pub store: Arc<dyn InflightActivationStore>,
+    pub store: Arc<dyn ActivationStore>,
     pub config: Arc<Config>,
     pub update_tx: Option<Sender<StatusUpdate>>,
 }
@@ -89,12 +89,9 @@ impl ConsumerService for TaskbrokerServer {
         let start_time = Instant::now();
         let id = request.get_ref().id.clone();
 
-        let status: InflightActivationStatus =
-            TaskActivationStatus::try_from(request.get_ref().status)
-                .map_err(|e| {
-                    Status::invalid_argument(format!("Unable to deserialize status: {e:?}"))
-                })?
-                .into();
+        let status: ActivationStatus = TaskActivationStatus::try_from(request.get_ref().status)
+            .map_err(|e| Status::invalid_argument(format!("Unable to deserialize status: {e:?}")))?
+            .into();
 
         if !status.is_conclusion() {
             return Err(Status::invalid_argument(format!(
@@ -102,7 +99,7 @@ impl ConsumerService for TaskbrokerServer {
             )));
         }
 
-        if status == InflightActivationStatus::Failure {
+        if status == ActivationStatus::Failure {
             metrics::counter!("grpc_server.set_status.failure").increment(1);
         }
 
@@ -222,17 +219,14 @@ impl ConsumerService for TaskbrokerServer {
     }
 }
 
-pub type StatusUpdate = (String, InflightActivationStatus);
+pub type StatusUpdate = (String, ActivationStatus);
 
-pub async fn flush_updates(
-    store: Arc<dyn InflightActivationStore>,
-    buffer: &mut Vec<StatusUpdate>,
-) {
+pub async fn flush_updates(store: Arc<dyn ActivationStore>, buffer: &mut Vec<StatusUpdate>) {
     if buffer.is_empty() {
         return;
     }
 
-    let mut by_status: HashMap<InflightActivationStatus, Vec<String>> = HashMap::new();
+    let mut by_status: HashMap<ActivationStatus, Vec<String>> = HashMap::new();
 
     for (id, status) in buffer.drain(..) {
         by_status.entry(status).or_default().push(id);

--- a/src/grpc/server_tests.rs
+++ b/src/grpc/server_tests.rs
@@ -11,7 +11,7 @@ use tonic::{Code, Request};
 
 use crate::config::{Config, DeliveryMode};
 use crate::grpc::server::{StatusUpdate, TaskbrokerServer};
-use crate::store::activation::InflightActivationStatus;
+use crate::store::activation::ActivationStatus;
 use crate::test_utils::{create_config, create_test_store, make_activations};
 
 #[tokio::test]
@@ -160,7 +160,7 @@ async fn test_get_task_success(#[case] adapter: &str) {
     assert!(task.id == "id_0");
 
     let row = store.get_by_id("id_0").await.unwrap().expect("claimed row");
-    assert_eq!(row.status, InflightActivationStatus::Processing);
+    assert_eq!(row.status, ActivationStatus::Processing);
 }
 
 #[tokio::test]
@@ -458,12 +458,12 @@ async fn test_set_task_status_forwards_to_update_channel(#[case] adapter: &str) 
 
     let (id, status) = update_rx.recv().await.expect("status update on channel");
     assert_eq!(id, "id_0");
-    assert_eq!(status, InflightActivationStatus::Complete);
+    assert_eq!(status, ActivationStatus::Complete);
 
     let row = store.get_by_id("id_0").await.unwrap().expect("row exists");
     assert_eq!(
         row.status,
-        InflightActivationStatus::Processing,
+        ActivationStatus::Processing,
         "handler does not write status; flush_updates applies channel batches"
     );
 }

--- a/src/kafka/activation_batcher.rs
+++ b/src/kafka/activation_batcher.rs
@@ -10,7 +10,7 @@ use rdkafka::util::Timeout;
 
 use crate::config::Config;
 use crate::runtime_config::RuntimeConfigManager;
-use crate::store::activation::InflightActivation;
+use crate::store::activation::Activation;
 
 use super::consumer::{
     ReduceConfig, ReduceShutdownBehaviour, ReduceShutdownCondition, Reducer,
@@ -44,8 +44,8 @@ impl ActivationBatcherConfig {
     }
 }
 
-pub struct InflightActivationBatcher {
-    batch: Vec<InflightActivation>,
+pub struct ActivationBatcher {
+    batch: Vec<Activation>,
     batch_size: usize,
     forward_batch: Vec<Vec<u8>>, // payload
     config: ActivationBatcherConfig,
@@ -54,7 +54,7 @@ pub struct InflightActivationBatcher {
     producer_cluster: String,
 }
 
-impl InflightActivationBatcher {
+impl ActivationBatcher {
     pub fn new(
         config: ActivationBatcherConfig,
         runtime_config_manager: Arc<RuntimeConfigManager>,
@@ -63,7 +63,7 @@ impl InflightActivationBatcher {
             config
                 .producer_config
                 .create()
-                .expect("Could not create kafka producer in inflight activation batcher"),
+                .expect("Could not create kafka producer in activation batcher"),
         );
         let producer_cluster = config
             .producer_config
@@ -82,10 +82,10 @@ impl InflightActivationBatcher {
     }
 }
 
-impl Reducer for InflightActivationBatcher {
-    type Input = InflightActivation;
+impl Reducer for ActivationBatcher {
+    type Input = Activation;
 
-    type Output = Vec<InflightActivation>;
+    type Output = Vec<Activation>;
 
     async fn reduce(&mut self, t: Self::Input) -> Result<(), anyhow::Error> {
         let runtime_config = self.runtime_config_manager.read().await;
@@ -156,7 +156,7 @@ impl Reducer for InflightActivationBatcher {
                 self.producer = Arc::new(
                     new_config
                         .create()
-                        .expect("Could not create kafka producer in inflight activation batcher"),
+                        .expect("Could not create kafka producer in activation batcher"),
                 );
                 self.producer_cluster = forward_cluster;
             }
@@ -219,11 +219,11 @@ mod tests {
     use chrono::Utc;
     use tempfile::NamedTempFile;
 
-    use crate::store::activation::InflightActivationBuilder;
+    use crate::store::activation::ActivationBuilder;
     use crate::test_utils::{TaskActivationBuilder, generate_unique_namespace};
 
     use super::{
-        ActivationBatcherConfig, Config, InflightActivationBatcher, Reducer, RuntimeConfigManager,
+        ActivationBatcher, ActivationBatcherConfig, Config, Reducer, RuntimeConfigManager,
     };
 
     #[tokio::test]
@@ -242,20 +242,20 @@ demoted_namespaces:
             RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await,
         );
         let config = Arc::new(Config::default());
-        let mut batcher = InflightActivationBatcher::new(
+        let mut batcher = ActivationBatcher::new(
             ActivationBatcherConfig::from_config(&config),
             runtime_config,
         );
 
         let namespace = generate_unique_namespace();
 
-        let inflight_activation_0 = InflightActivationBuilder::new()
+        let activation_0 = ActivationBuilder::new()
             .id("0")
             .taskname("task_to_be_filtered")
             .namespace(&namespace)
             .build(TaskActivationBuilder::new());
 
-        batcher.reduce(inflight_activation_0).await.unwrap();
+        batcher.reduce(activation_0).await.unwrap();
         assert_eq!(batcher.batch.len(), 0);
     }
 
@@ -263,21 +263,21 @@ demoted_namespaces:
     async fn test_drop_task_due_to_expiry() {
         let runtime_config = Arc::new(RuntimeConfigManager::new(None).await);
         let config = Arc::new(Config::default());
-        let mut batcher = InflightActivationBatcher::new(
+        let mut batcher = ActivationBatcher::new(
             ActivationBatcherConfig::from_config(&config),
             runtime_config,
         );
 
         let namespace = generate_unique_namespace();
 
-        let inflight_activation_0 = InflightActivationBuilder::new()
+        let activation_0 = ActivationBuilder::new()
             .id("0")
             .taskname("task_to_be_filtered")
             .namespace(&namespace)
             .expires_at(Utc::now())
             .build(TaskActivationBuilder::new());
 
-        batcher.reduce(inflight_activation_0).await.unwrap();
+        batcher.reduce(activation_0).await.unwrap();
         assert_eq!(batcher.batch.len(), 0);
     }
 
@@ -290,20 +290,20 @@ demoted_namespaces:
             ..Default::default()
         });
 
-        let mut batcher = InflightActivationBatcher::new(
+        let mut batcher = ActivationBatcher::new(
             ActivationBatcherConfig::from_config(&config),
             runtime_config,
         );
 
         let namespace = generate_unique_namespace();
 
-        let inflight_activation_0 = InflightActivationBuilder::new()
+        let activation_0 = ActivationBuilder::new()
             .id("0")
             .taskname("taskname")
             .namespace(&namespace)
             .build(TaskActivationBuilder::new());
 
-        batcher.reduce(inflight_activation_0).await.unwrap();
+        batcher.reduce(activation_0).await.unwrap();
         assert!(batcher.is_full().await);
         batcher.flush().await.unwrap();
         assert!(!batcher.is_full().await)
@@ -318,27 +318,27 @@ demoted_namespaces:
             ..Default::default()
         });
 
-        let mut batcher = InflightActivationBatcher::new(
+        let mut batcher = ActivationBatcher::new(
             ActivationBatcherConfig::from_config(&config),
             runtime_config,
         );
 
         let namespace = generate_unique_namespace();
 
-        let inflight_activation_0 = InflightActivationBuilder::new()
+        let activation_0 = ActivationBuilder::new()
             .id("0")
             .taskname("taskname")
             .namespace(&namespace)
             .build(TaskActivationBuilder::new());
 
-        let inflight_activation_1 = InflightActivationBuilder::new()
+        let activation_1 = ActivationBuilder::new()
             .id("1")
             .taskname("taskname")
             .namespace(&namespace)
             .build(TaskActivationBuilder::new());
 
-        batcher.reduce(inflight_activation_0).await.unwrap();
-        batcher.reduce(inflight_activation_1).await.unwrap();
+        batcher.reduce(activation_0).await.unwrap();
+        batcher.reduce(activation_1).await.unwrap();
         assert!(batcher.is_full().await);
         batcher.flush().await.unwrap();
         assert!(!batcher.is_full().await)
@@ -362,27 +362,27 @@ demoted_topic: taskworker-demoted"#;
             RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await,
         );
         let config = Arc::new(Config::default());
-        let mut batcher = InflightActivationBatcher::new(
+        let mut batcher = ActivationBatcher::new(
             ActivationBatcherConfig::from_config(&config),
             runtime_config,
         );
 
         assert_eq!(batcher.producer_cluster, config.kafka_cluster.clone());
 
-        let inflight_activation_0 = InflightActivationBuilder::new()
+        let activation_0 = ActivationBuilder::new()
             .id("0")
             .taskname("task_to_be_filtered")
             .namespace("bad_namespace")
             .build(TaskActivationBuilder::new());
 
-        let inflight_activation_1 = InflightActivationBuilder::new()
+        let activation_1 = ActivationBuilder::new()
             .id("1")
             .taskname("good_task")
             .namespace("good_namespace")
             .build(TaskActivationBuilder::new());
 
-        batcher.reduce(inflight_activation_0).await.unwrap();
-        batcher.reduce(inflight_activation_1).await.unwrap();
+        batcher.reduce(activation_0).await.unwrap();
+        batcher.reduce(activation_1).await.unwrap();
 
         assert_eq!(batcher.batch.len(), 1);
         assert_eq!(batcher.forward_batch.len(), 1);

--- a/src/kafka/activation_writer.rs
+++ b/src/kafka/activation_writer.rs
@@ -6,8 +6,8 @@ use tokio::time::sleep;
 use tracing::{debug, error, instrument};
 
 use crate::config::Config;
-use crate::store::activation::{InflightActivation, InflightActivationStatus};
-use crate::store::traits::InflightActivationStore;
+use crate::store::activation::{Activation, ActivationStatus};
+use crate::store::traits::ActivationStore;
 use crate::store::types::DepthCounts;
 
 use super::consumer::{
@@ -25,7 +25,7 @@ pub struct ActivationWriterConfig {
 }
 
 impl ActivationWriterConfig {
-    /// Convert from application configuration into InflightActivationWriter config.
+    /// Convert from application configuration into ActivationWriter config.
     pub fn from_config(config: &Config) -> Self {
         Self {
             db_max_size: config.db_max_size,
@@ -38,14 +38,14 @@ impl ActivationWriterConfig {
     }
 }
 
-pub struct InflightActivationWriter {
+pub struct ActivationWriter {
     config: ActivationWriterConfig,
-    store: Arc<dyn InflightActivationStore>,
-    batch: Option<Vec<InflightActivation>>,
+    store: Arc<dyn ActivationStore>,
+    batch: Option<Vec<Activation>>,
 }
 
-impl InflightActivationWriter {
-    pub fn new(store: Arc<dyn InflightActivationStore>, config: ActivationWriterConfig) -> Self {
+impl ActivationWriter {
+    pub fn new(store: Arc<dyn ActivationStore>, config: ActivationWriterConfig) -> Self {
         Self {
             config,
             store,
@@ -54,8 +54,8 @@ impl InflightActivationWriter {
     }
 }
 
-impl Reducer for InflightActivationWriter {
-    type Input = Vec<InflightActivation>;
+impl Reducer for ActivationWriter {
+    type Input = Vec<Activation>;
 
     type Output = ();
 
@@ -106,10 +106,10 @@ impl Reducer for InflightActivationWriter {
         // Check if the entire batch is either pending or delay
         let has_delay = batch
             .iter()
-            .any(|activation| activation.status == InflightActivationStatus::Delay);
+            .any(|activation| activation.status == ActivationStatus::Delay);
         let has_pending = batch
             .iter()
-            .any(|activation| activation.status == InflightActivationStatus::Pending);
+            .any(|activation| activation.status == ActivationStatus::Pending);
 
         // Backpressure if any of these conditions are met:
         // 1. The processing limit is exceeded
@@ -202,12 +202,12 @@ mod tests {
     use chrono::DateTime;
     use rstest::rstest;
 
-    use crate::store::activation::{InflightActivationBuilder, InflightActivationStatus};
+    use crate::store::activation::{ActivationBuilder, ActivationStatus};
     use crate::test_utils::{
         TaskActivationBuilder, create_test_store, generate_unique_namespace, make_activations,
     };
 
-    use super::{ActivationWriterConfig, InflightActivationWriter, Reducer};
+    use super::{ActivationWriter, ActivationWriterConfig, Reducer};
 
     #[tokio::test]
     #[rstest]
@@ -223,19 +223,19 @@ mod tests {
             max_delay_activations: 10,
             write_failure_backoff_ms: 4000,
         };
-        let mut writer = InflightActivationWriter::new(store, writer_config);
+        let mut writer = ActivationWriter::new(store, writer_config);
 
         let received_at = DateTime::from_timestamp_nanos(0);
         let namespace = generate_unique_namespace();
 
         let batch = vec![
-            InflightActivationBuilder::new()
+            ActivationBuilder::new()
                 .id("0")
                 .taskname("pending_task")
                 .namespace(&namespace)
                 .received_at(received_at)
                 .build(TaskActivationBuilder::new()),
-            InflightActivationBuilder::new()
+            ActivationBuilder::new()
                 .id("1")
                 .taskname("delay_task")
                 .namespace(&namespace)
@@ -248,7 +248,7 @@ mod tests {
         let count_pending = writer.store.count_pending_activations().await.unwrap();
         let count_delay = writer
             .store
-            .count_by_status(InflightActivationStatus::Delay)
+            .count_by_status(ActivationStatus::Delay)
             .await
             .unwrap();
         assert_eq!(count_pending + count_delay, 2);
@@ -269,13 +269,13 @@ mod tests {
             max_delay_activations: 10,
             write_failure_backoff_ms: 4000,
         };
-        let mut writer = InflightActivationWriter::new(store, writer_config);
+        let mut writer = ActivationWriter::new(store, writer_config);
 
         let received_at = DateTime::from_timestamp_nanos(0);
         let namespace = generate_unique_namespace();
 
         let batch = vec![
-            InflightActivationBuilder::new()
+            ActivationBuilder::new()
                 .id("0")
                 .taskname("pending_task")
                 .namespace(&namespace)
@@ -304,18 +304,18 @@ mod tests {
             max_delay_activations: 10,
             write_failure_backoff_ms: 4000,
         };
-        let mut writer = InflightActivationWriter::new(store, writer_config);
+        let mut writer = ActivationWriter::new(store, writer_config);
 
         let received_at = DateTime::from_timestamp_nanos(0);
         let namespace = generate_unique_namespace();
 
         let batch = vec![
-            InflightActivationBuilder::new()
+            ActivationBuilder::new()
                 .id("0")
                 .taskname("pending_task")
                 .namespace(&namespace)
                 .received_at(received_at)
-                .status(InflightActivationStatus::Delay)
+                .status(ActivationStatus::Delay)
                 .build(TaskActivationBuilder::new()),
         ];
 
@@ -323,7 +323,7 @@ mod tests {
         writer.flush().await.unwrap();
         let count_delay = writer
             .store
-            .count_by_status(InflightActivationStatus::Delay)
+            .count_by_status(ActivationStatus::Delay)
             .await
             .unwrap();
         assert_eq!(count_delay, 1);
@@ -344,19 +344,19 @@ mod tests {
             max_delay_activations: 0,
             write_failure_backoff_ms: 4000,
         };
-        let mut writer = InflightActivationWriter::new(store, writer_config);
+        let mut writer = ActivationWriter::new(store, writer_config);
 
         let received_at = DateTime::from_timestamp_nanos(0);
         let namespace = generate_unique_namespace();
 
         let batch = vec![
-            InflightActivationBuilder::new()
+            ActivationBuilder::new()
                 .id("0")
                 .taskname("pending_task")
                 .namespace(&namespace)
                 .received_at(received_at)
                 .build(TaskActivationBuilder::new()),
-            InflightActivationBuilder::new()
+            ActivationBuilder::new()
                 .id("1")
                 .taskname("delay_task")
                 .namespace(&namespace)
@@ -370,7 +370,7 @@ mod tests {
         assert_eq!(count_pending, 0);
         let count_delay = writer
             .store
-            .count_by_status(InflightActivationStatus::Delay)
+            .count_by_status(ActivationStatus::Delay)
             .await
             .unwrap();
         assert_eq!(count_delay, 0);
@@ -393,19 +393,19 @@ mod tests {
             max_delay_activations: 0,
             write_failure_backoff_ms: 4000,
         };
-        let mut writer = InflightActivationWriter::new(store, writer_config);
+        let mut writer = ActivationWriter::new(store, writer_config);
 
         let received_at = DateTime::from_timestamp_nanos(0);
         let namespace = generate_unique_namespace();
 
         let batch = vec![
-            InflightActivationBuilder::new()
+            ActivationBuilder::new()
                 .id("0")
                 .taskname("pending_task")
                 .namespace(&namespace)
                 .received_at(received_at)
                 .build(TaskActivationBuilder::new()),
-            InflightActivationBuilder::new()
+            ActivationBuilder::new()
                 .id("1")
                 .taskname("pending_task")
                 .namespace(&namespace)
@@ -419,7 +419,7 @@ mod tests {
         assert_eq!(count_pending, 2);
         let count_delay = writer
             .store
-            .count_by_status(InflightActivationStatus::Delay)
+            .count_by_status(ActivationStatus::Delay)
             .await
             .unwrap();
         assert_eq!(count_delay, 0);
@@ -444,25 +444,25 @@ mod tests {
         let received_at = DateTime::from_timestamp_nanos(0);
         let namespace = generate_unique_namespace();
 
-        let existing_activation = InflightActivationBuilder::new()
+        let existing_activation = ActivationBuilder::new()
             .id("existing")
             .taskname("existing_task")
             .namespace(&namespace)
             .received_at(received_at)
-            .status(InflightActivationStatus::Processing)
+            .status(ActivationStatus::Processing)
             .build(TaskActivationBuilder::new());
 
         store.store(vec![existing_activation]).await.unwrap();
 
-        let mut writer = InflightActivationWriter::new(store.clone(), writer_config);
+        let mut writer = ActivationWriter::new(store.clone(), writer_config);
         let batch = vec![
-            InflightActivationBuilder::new()
+            ActivationBuilder::new()
                 .id("0")
                 .taskname("pending_task")
                 .namespace(&namespace)
                 .received_at(received_at)
                 .build(TaskActivationBuilder::new()),
-            InflightActivationBuilder::new()
+            ActivationBuilder::new()
                 .id("1")
                 .taskname("delay_task")
                 .namespace(&namespace)
@@ -479,13 +479,13 @@ mod tests {
         assert_eq!(count_pending, 0);
         let count_delay = writer
             .store
-            .count_by_status(InflightActivationStatus::Delay)
+            .count_by_status(ActivationStatus::Delay)
             .await
             .unwrap();
         assert_eq!(count_delay, 0);
         let count_processing = writer
             .store
-            .count_by_status(InflightActivationStatus::Processing)
+            .count_by_status(ActivationStatus::Processing)
             .await
             .unwrap();
         // Only the existing processing activation should remain, new ones should be blocked
@@ -517,7 +517,7 @@ mod tests {
         // Make more activations that won't be stored.
         let second_round = make_activations(10);
 
-        let mut writer = InflightActivationWriter::new(store.clone(), writer_config);
+        let mut writer = ActivationWriter::new(store.clone(), writer_config);
         writer.reduce(second_round).await.unwrap();
         let flush_result = writer.flush().await.unwrap();
         assert!(flush_result.is_none());
@@ -541,7 +541,7 @@ mod tests {
             max_delay_activations: 10,
             write_failure_backoff_ms: 4000,
         };
-        let mut writer = InflightActivationWriter::new(store.clone(), writer_config);
+        let mut writer = ActivationWriter::new(store.clone(), writer_config);
         writer.reduce(vec![]).await.unwrap();
         let flush_result = writer.flush().await.unwrap();
         assert!(flush_result.is_some());

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -28,12 +28,12 @@ use anyhow::{Error, anyhow};
 use futures::{Stream, StreamExt, future, pin_mut};
 use tracing::{debug, error, info, instrument, warn};
 
-use crate::store::traits::InflightActivationStore;
+use crate::store::traits::ActivationStore;
 
 pub async fn start_consumer(
     topics: &[&str],
     kafka_client_config: &ClientConfig,
-    activation_store: Arc<dyn InflightActivationStore>,
+    activation_store: Arc<dyn ActivationStore>,
     spawn_actors: impl FnMut(
         Arc<StreamConsumer<KafkaContext>>,
         &BTreeSet<(String, i32)>,
@@ -331,7 +331,7 @@ enum ConsumerState {
 pub async fn handle_events(
     consumer: Arc<StreamConsumer<KafkaContext>>,
     events: UnboundedReceiver<(Event, SyncSender<()>)>,
-    activation_store: Arc<dyn InflightActivationStore>,
+    activation_store: Arc<dyn ActivationStore>,
     shutdown_client: oneshot::Sender<()>,
     mut spawn_actors: impl FnMut(
         Arc<StreamConsumer<KafkaContext>>,

--- a/src/kafka/deserialize.rs
+++ b/src/kafka/deserialize.rs
@@ -5,7 +5,7 @@ use rdkafka::Message;
 use rdkafka::message::OwnedMessage;
 
 use crate::config::Config;
-use crate::store::activation::InflightActivation;
+use crate::store::activation::Activation;
 
 use super::deserialize_activation::{self, DeserializeActivationConfig};
 use super::deserialize_raw::{self, RawConfig};
@@ -31,9 +31,7 @@ impl DeserializeConfig {
 /// In raw mode, raw Kafka bytes are wrapped into a TaskActivation.
 /// In normal mode, Kafka messages are expected to contain encoded TaskActivation protos.
 /// Messages from the retry topic are always deserialized as activations.
-pub fn new(
-    config: DeserializeConfig,
-) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightActivation, Error> {
+pub fn new(config: DeserializeConfig) -> impl Fn(Arc<OwnedMessage>) -> Result<Activation, Error> {
     let raw_deserializer = config.raw_config.map(deserialize_raw::new);
     let activation_deserializer = deserialize_activation::new(config.activation_config);
     let retry_topic = config.retry_topic;

--- a/src/kafka/deserialize_activation.rs
+++ b/src/kafka/deserialize_activation.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::config::Config;
 use crate::fetch::MAX_FETCH_THREADS;
-use crate::store::activation::{InflightActivation, InflightActivationStatus};
+use crate::store::activation::{Activation, ActivationStatus};
 
 pub struct DeserializeActivationConfig {
     pub max_delayed_allowed: u64,
@@ -35,7 +35,7 @@ pub fn bucket_from_id(id: &str) -> i16 {
 
 pub fn new(
     config: DeserializeActivationConfig,
-) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightActivation, Error> {
+) -> impl Fn(Arc<OwnedMessage>) -> Result<Activation, Error> {
     move |msg: Arc<OwnedMessage>| {
         let Some(payload) = msg.payload() else {
             return Err(anyhow!("Message has no payload"));
@@ -75,11 +75,11 @@ pub fn new(
             activation_time + delay
         });
 
-        let status = delay_until.map_or(InflightActivationStatus::Pending, |delay_until| {
+        let status = delay_until.map_or(ActivationStatus::Pending, |delay_until| {
             if Utc::now() > delay_until {
-                InflightActivationStatus::Pending
+                ActivationStatus::Pending
             } else {
-                InflightActivationStatus::Delay
+                ActivationStatus::Delay
             }
         });
 
@@ -92,7 +92,7 @@ pub fn new(
 
         let bucket = bucket_from_id(&activation.id);
 
-        Ok(InflightActivation {
+        Ok(Activation {
             id: activation.id.clone(),
             activation: payload.to_vec(),
             status,
@@ -128,7 +128,7 @@ mod tests {
     use rdkafka::message::OwnedMessage;
     use sentry_protos::taskbroker::v1::TaskActivation;
 
-    use crate::store::activation::InflightActivationStatus;
+    use crate::store::activation::ActivationStatus;
     use crate::test_utils::generate_unique_namespace;
 
     use super::{Config, DeserializeActivationConfig, new};
@@ -271,7 +271,7 @@ mod tests {
             delta.num_seconds() >= 99,
             "Should have ~100 seconds of delay from received_at"
         );
-        assert_eq!(inflight.status, InflightActivationStatus::Pending)
+        assert_eq!(inflight.status, ActivationStatus::Pending)
     }
 
     #[test]
@@ -318,7 +318,7 @@ mod tests {
             delta.num_seconds() >= 99,
             "Should have ~100 seconds of delay from received_at"
         );
-        assert_eq!(inflight.status, InflightActivationStatus::Delay)
+        assert_eq!(inflight.status, ActivationStatus::Delay)
     }
 
     #[test]
@@ -366,6 +366,6 @@ mod tests {
             delta.num_seconds() <= (config.max_delayed_task_allowed_sec as f64 * 1.1) as i64,
             "Should have approxmiately max_delayed_task_allowed_sec of delay from received_at"
         );
-        assert_eq!(inflight.status, InflightActivationStatus::Delay)
+        assert_eq!(inflight.status, ActivationStatus::Delay)
     }
 }

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -11,7 +11,7 @@ use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivation};
 use uuid::Uuid;
 
 use crate::config::Config;
-use crate::store::activation::{InflightActivation, InflightActivationStatus};
+use crate::store::activation::{Activation, ActivationStatus};
 
 use super::deserialize_activation::bucket_from_id;
 
@@ -97,7 +97,7 @@ fn encode_raw_params(raw_bytes: &[u8]) -> Vec<u8> {
 
 /// Create a deserializer closure for raw mode.
 /// Wraps raw Kafka message bytes into a TaskActivation with msgpack-encoded parameters_bytes.
-pub fn new(config: RawConfig) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightActivation, Error> {
+pub fn new(config: RawConfig) -> impl Fn(Arc<OwnedMessage>) -> Result<Activation, Error> {
     move |msg: Arc<OwnedMessage>| {
         // Whether a message without payload is valid is technically not up to taskbroker, and we
         // can't DLQ messages here. It's easier to convert it to an empty bytestring and let the
@@ -143,10 +143,10 @@ pub fn new(config: RawConfig) -> impl Fn(Arc<OwnedMessage>) -> Result<InflightAc
         )
         .record(payload.len() as f64);
 
-        Ok(InflightActivation {
+        Ok(Activation {
             id,
             activation: activation_bytes,
-            status: InflightActivationStatus::Pending,
+            status: ActivationStatus::Pending,
             partition: msg.partition(),
             offset: msg.offset(),
             added_at: now,
@@ -236,7 +236,7 @@ mod tests {
         assert_eq!(inflight.taskname, "test-task");
         assert_eq!(inflight.processing_deadline_duration, 60);
         assert_eq!(inflight.offset, 42);
-        assert_eq!(inflight.status, InflightActivationStatus::Pending);
+        assert_eq!(inflight.status, ActivationStatus::Pending);
 
         // Verify the activation can be decoded
         let activation = TaskActivation::decode(inflight.activation.as_slice()).unwrap();

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -1,8 +1,8 @@
+pub mod activation_batcher;
+pub mod activation_writer;
 pub mod admin;
 pub mod consumer;
 pub mod deserialize;
 pub mod deserialize_activation;
 pub mod deserialize_raw;
-pub mod inflight_activation_batcher;
-pub mod inflight_activation_writer;
 pub mod os_stream_writer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,10 +28,8 @@ use taskbroker::metrics;
 use taskbroker::processing_strategy;
 use taskbroker::push::PushPool;
 use taskbroker::runtime_config::RuntimeConfigManager;
-use taskbroker::store::adapters::postgres::{
-    PostgresActivationStore, PostgresActivationStoreConfig,
-};
-use taskbroker::store::adapters::sqlite::{ActivationStoreConfig, SqliteActivationStore};
+use taskbroker::store::adapters::postgres::{PostgresStore, PostgresStoreConfig};
+use taskbroker::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig};
 use taskbroker::store::traits::ActivationStore;
 use taskbroker::upkeep::upkeep;
 use taskbroker::{Args, get_version};
@@ -66,16 +64,11 @@ async fn main() -> Result<(), Error> {
 
     let store: Arc<dyn ActivationStore> = match config.database_adapter {
         DatabaseAdapter::Sqlite => Arc::new(
-            SqliteActivationStore::new(
-                &config.db_path,
-                ActivationStoreConfig::from_config(&config),
-            )
-            .await?,
+            SqliteStore::new(&config.db_path, SqliteStoreConfig::from_config(&config)).await?,
         ),
-        DatabaseAdapter::Postgres => Arc::new(
-            PostgresActivationStore::new(PostgresActivationStoreConfig::from_config(&config))
-                .await?,
-        ),
+        DatabaseAdapter::Postgres => {
+            Arc::new(PostgresStore::new(PostgresStoreConfig::from_config(&config)).await?)
+        }
     };
 
     // If this is an environment where the topics might not exist, check and create them.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,15 +17,11 @@ use taskbroker::fetch::FetchPool;
 use taskbroker::grpc::auth_middleware::AuthLayer;
 use taskbroker::grpc::metrics_middleware::MetricsLayer;
 use taskbroker::grpc::server::{TaskbrokerServer, flush_updates};
+use taskbroker::kafka::activation_batcher::{ActivationBatcher, ActivationBatcherConfig};
+use taskbroker::kafka::activation_writer::{ActivationWriter, ActivationWriterConfig};
 use taskbroker::kafka::admin::create_missing_topics;
 use taskbroker::kafka::consumer::start_consumer;
 use taskbroker::kafka::deserialize::{self, DeserializeConfig};
-use taskbroker::kafka::inflight_activation_batcher::{
-    ActivationBatcherConfig, InflightActivationBatcher,
-};
-use taskbroker::kafka::inflight_activation_writer::{
-    ActivationWriterConfig, InflightActivationWriter,
-};
 use taskbroker::kafka::os_stream_writer::{OsStream, OsStreamWriter};
 use taskbroker::logging;
 use taskbroker::metrics;
@@ -35,8 +31,8 @@ use taskbroker::runtime_config::RuntimeConfigManager;
 use taskbroker::store::adapters::postgres::{
     PostgresActivationStore, PostgresActivationStoreConfig,
 };
-use taskbroker::store::adapters::sqlite::{InflightActivationStoreConfig, SqliteActivationStore};
-use taskbroker::store::traits::InflightActivationStore;
+use taskbroker::store::adapters::sqlite::{ActivationStoreConfig, SqliteActivationStore};
+use taskbroker::store::traits::ActivationStore;
 use taskbroker::upkeep::upkeep;
 use taskbroker::{Args, get_version};
 use taskbroker::{SERVICE_NAME, flusher};
@@ -68,11 +64,11 @@ async fn main() -> Result<(), Error> {
     logging::init(logging::LoggingConfig::from_config(&config));
     metrics::init(metrics::MetricsConfig::from_config(&config));
 
-    let store: Arc<dyn InflightActivationStore> = match config.database_adapter {
+    let store: Arc<dyn ActivationStore> = match config.database_adapter {
         DatabaseAdapter::Sqlite => Arc::new(
             SqliteActivationStore::new(
                 &config.db_path,
-                InflightActivationStoreConfig::from_config(&config),
+                ActivationStoreConfig::from_config(&config),
             )
             .await?,
         ),
@@ -194,11 +190,11 @@ async fn main() -> Result<(), Error> {
                         deserialize::new(DeserializeConfig::from_config(&consumer_config)),
 
                     reduce:
-                        InflightActivationBatcher::new(
+                        ActivationBatcher::new(
                             ActivationBatcherConfig::from_config(&consumer_config),
                             runtime_config_manager.clone()
                         ),
-                        InflightActivationWriter::new(
+                        ActivationWriter::new(
                             consumer_store.clone(),
                             ActivationWriterConfig::from_config(&consumer_config)
                         ),

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -22,8 +22,8 @@ use tonic::transport::Channel;
 use tracing::{debug, error, info};
 
 use crate::config::Config;
-use crate::store::activation::InflightActivation;
-use crate::store::traits::InflightActivationStore;
+use crate::store::activation::Activation;
+use crate::store::traits::ActivationStore;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -54,7 +54,7 @@ pub enum PushError {
     Timeout,
 
     /// Channel disconnected (no receivers) or another failure.
-    Channel(SendError<(InflightActivation, Instant)>),
+    Channel(SendError<(Activation, Instant)>),
 }
 
 /// Thin interface for the worker client. It mostly serves to enable proper unit testing, but it also decouples the actual client implementation from our pushing logic.
@@ -95,23 +95,23 @@ impl WorkerClient for WorkerServiceClient<Channel> {
 /// Wrapper around `config.push_threads` asynchronous tasks, each of which receives an activation from the channel, sends it to the worker service, and repeats.
 pub struct PushPool {
     /// The sending end of a channel that accepts task activations.
-    sender: Sender<(InflightActivation, Instant)>,
+    sender: Sender<(Activation, Instant)>,
 
     /// The receiving end of a channel that accepts task activations.
-    receiver: Receiver<(InflightActivation, Instant)>,
+    receiver: Receiver<(Activation, Instant)>,
 
     /// Taskbroker configuration.
     config: Arc<Config>,
 
     /// Activation store, which we need for marking tasks as sent.
-    store: Arc<dyn InflightActivationStore>,
+    store: Arc<dyn ActivationStore>,
 
     worker_factory: WorkerFactory,
 }
 
 impl PushPool {
     /// Initialize a new push pool.
-    pub fn new(config: Arc<Config>, store: Arc<dyn InflightActivationStore>) -> Self {
+    pub fn new(config: Arc<Config>, store: Arc<dyn ActivationStore>) -> Self {
         let worker_factory: WorkerFactory = Arc::new(|endpoint: String| {
             Box::pin(async move {
                 let client = WorkerServiceClient::connect(endpoint).await?;
@@ -123,7 +123,7 @@ impl PushPool {
 
     fn new_with_factory(
         config: Arc<Config>,
-        store: Arc<dyn InflightActivationStore>,
+        store: Arc<dyn ActivationStore>,
         worker_factory: WorkerFactory,
     ) -> Self {
         let (sender, receiver) = flume::bounded(config.push_queue_size);
@@ -355,11 +355,7 @@ impl PushPool {
 
     /// Send an activation to the internal asynchronous MPMC channel used by all running push threads. Times out after `config.push_queue_timeout_ms` milliseconds.
     #[framed]
-    pub async fn submit(
-        &self,
-        activation: InflightActivation,
-        time: Instant,
-    ) -> Result<(), PushError> {
+    pub async fn submit(&self, activation: Activation, time: Instant) -> Result<(), PushError> {
         let duration = Duration::from_millis(self.config.push_queue_timeout_ms);
         let start = Instant::now();
 
@@ -390,7 +386,7 @@ impl PushPool {
 #[framed]
 async fn push_task(
     worker: &mut (dyn WorkerClient + Send),
-    activation: InflightActivation,
+    activation: Activation,
     callback_url: String,
     timeout: Duration,
     grpc_shared_secret: &[String],

--- a/src/push/tests.rs
+++ b/src/push/tests.rs
@@ -8,8 +8,8 @@ use tokio::sync::Notify;
 use tokio::time::{Duration, timeout};
 
 use crate::config::Config;
-use crate::store::activation::{InflightActivation, InflightActivationStatus};
-use crate::store::traits::InflightActivationStore;
+use crate::store::activation::{Activation, ActivationStatus};
+use crate::store::traits::ActivationStore;
 use crate::store::types::FailedTasksForwarder;
 use crate::test_utils::{create_test_store, make_activations};
 
@@ -75,8 +75,8 @@ impl MockStore {
 }
 
 #[async_trait]
-impl InflightActivationStore for MockStore {
-    async fn store(&self, _batch: Vec<InflightActivation>) -> anyhow::Result<u64> {
+impl ActivationStore for MockStore {
+    async fn store(&self, _batch: Vec<Activation>) -> anyhow::Result<u64> {
         Ok(0)
     }
     fn assign_partitions(&self, _partitions: Vec<i32>) -> anyhow::Result<()> {
@@ -89,7 +89,7 @@ impl InflightActivationStore for MockStore {
         _limit: Option<i32>,
         _bucket: Option<crate::store::types::BucketRange>,
         _mark_processing: bool,
-    ) -> anyhow::Result<Vec<InflightActivation>> {
+    ) -> anyhow::Result<Vec<Activation>> {
         Ok(vec![])
     }
     async fn mark_activation_processing(&self, id: &str) -> anyhow::Result<()> {
@@ -99,29 +99,29 @@ impl InflightActivationStore for MockStore {
     async fn set_status(
         &self,
         _id: &str,
-        _status: InflightActivationStatus,
+        _status: ActivationStatus,
         _max_attempts: Option<u32>,
         _delay_on_retry: Option<u64>,
-    ) -> anyhow::Result<Option<InflightActivation>> {
+    ) -> anyhow::Result<Option<Activation>> {
         Ok(None)
     }
     async fn set_status_batch(
         &self,
         _ids: &[String],
-        _status: InflightActivationStatus,
+        _status: ActivationStatus,
     ) -> anyhow::Result<u64> {
         Ok(0)
     }
     async fn pending_activation_max_lag(&self, _now: &DateTime<Utc>) -> f64 {
         0.0
     }
-    async fn count_by_status(&self, _status: InflightActivationStatus) -> anyhow::Result<usize> {
+    async fn count_by_status(&self, _status: ActivationStatus) -> anyhow::Result<usize> {
         Ok(0)
     }
     async fn count(&self) -> anyhow::Result<usize> {
         Ok(0)
     }
-    async fn get_by_id(&self, _id: &str) -> anyhow::Result<Option<InflightActivation>> {
+    async fn get_by_id(&self, _id: &str) -> anyhow::Result<Option<Activation>> {
         Ok(None)
     }
     async fn set_processing_deadline(
@@ -143,7 +143,7 @@ impl InflightActivationStore for MockStore {
     async fn db_size(&self) -> anyhow::Result<u64> {
         Ok(0)
     }
-    async fn get_retry_activations(&self) -> anyhow::Result<Vec<InflightActivation>> {
+    async fn get_retry_activations(&self) -> anyhow::Result<Vec<Activation>> {
         Ok(vec![])
     }
     async fn handle_claim_expiration(&self) -> anyhow::Result<u64> {

--- a/src/store/activation.rs
+++ b/src/store/activation.rs
@@ -7,9 +7,9 @@ use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivationStatus};
 use sqlx::Type;
 
 /// The members of this enum should be a superset of the members
-/// of `InflightActivationStatus` in `sentry_protos`.
+/// of `ActivationStatus` in `sentry_protos`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Type, Hash)]
-pub enum InflightActivationStatus {
+pub enum ActivationStatus {
     /// Unused but necessary to align with sentry-protos
     Unspecified,
     Pending,
@@ -21,59 +21,57 @@ pub enum InflightActivationStatus {
     Delay,
 }
 
-impl Display for InflightActivationStatus {
+impl Display for ActivationStatus {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{:?}", self)
     }
 }
 
-impl FromStr for InflightActivationStatus {
+impl FromStr for ActivationStatus {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s == "Unspecified" {
-            Ok(InflightActivationStatus::Unspecified)
+            Ok(ActivationStatus::Unspecified)
         } else if s == "Pending" {
-            Ok(InflightActivationStatus::Pending)
+            Ok(ActivationStatus::Pending)
         } else if s == "Claimed" {
-            Ok(InflightActivationStatus::Claimed)
+            Ok(ActivationStatus::Claimed)
         } else if s == "Processing" {
-            Ok(InflightActivationStatus::Processing)
+            Ok(ActivationStatus::Processing)
         } else if s == "Failure" {
-            Ok(InflightActivationStatus::Failure)
+            Ok(ActivationStatus::Failure)
         } else if s == "Retry" {
-            Ok(InflightActivationStatus::Retry)
+            Ok(ActivationStatus::Retry)
         } else if s == "Complete" {
-            Ok(InflightActivationStatus::Complete)
+            Ok(ActivationStatus::Complete)
         } else if s == "Delay" {
-            Ok(InflightActivationStatus::Delay)
+            Ok(ActivationStatus::Delay)
         } else {
-            Err(format!("Unknown inflight activation status string: {}", s))
+            Err(format!("Unknown activation status string: {}", s))
         }
     }
 }
 
-impl InflightActivationStatus {
+impl ActivationStatus {
     /// Is the current value a 'conclusion' status that can be supplied over GRPC.
     pub fn is_conclusion(&self) -> bool {
         matches!(
             self,
-            InflightActivationStatus::Complete
-                | InflightActivationStatus::Retry
-                | InflightActivationStatus::Failure
+            ActivationStatus::Complete | ActivationStatus::Retry | ActivationStatus::Failure
         )
     }
 }
 
-impl From<TaskActivationStatus> for InflightActivationStatus {
+impl From<TaskActivationStatus> for ActivationStatus {
     fn from(item: TaskActivationStatus) -> Self {
         match item {
-            TaskActivationStatus::Unspecified => InflightActivationStatus::Unspecified,
-            TaskActivationStatus::Pending => InflightActivationStatus::Pending,
-            TaskActivationStatus::Processing => InflightActivationStatus::Processing,
-            TaskActivationStatus::Failure => InflightActivationStatus::Failure,
-            TaskActivationStatus::Retry => InflightActivationStatus::Retry,
-            TaskActivationStatus::Complete => InflightActivationStatus::Complete,
+            TaskActivationStatus::Unspecified => ActivationStatus::Unspecified,
+            TaskActivationStatus::Pending => ActivationStatus::Pending,
+            TaskActivationStatus::Processing => ActivationStatus::Processing,
+            TaskActivationStatus::Failure => ActivationStatus::Failure,
+            TaskActivationStatus::Retry => ActivationStatus::Retry,
+            TaskActivationStatus::Complete => ActivationStatus::Complete,
         }
     }
 }
@@ -82,7 +80,7 @@ impl From<TaskActivationStatus> for InflightActivationStatus {
 #[builder(pattern = "owned")]
 #[builder(build_fn(name = "_build"))]
 #[builder(field(public))]
-pub struct InflightActivation {
+pub struct Activation {
     #[builder(setter(into))]
     pub id: String,
 
@@ -103,8 +101,8 @@ pub struct InflightActivation {
     pub activation: Vec<u8>,
 
     /// The current status of the activation
-    #[builder(default = InflightActivationStatus::Pending)]
-    pub status: InflightActivationStatus,
+    #[builder(default = ActivationStatus::Pending)]
+    pub status: ActivationStatus,
 
     /// The partition the activation was received from
     #[builder(default = 0)]
@@ -134,7 +132,7 @@ pub struct InflightActivation {
     #[builder(default = 0)]
     pub processing_deadline_duration: i32,
 
-    /// If the task has specified an expiry, this is the timestamp after which the task should be removed from inflight store
+    /// If the task has specified an expiry, this is the timestamp after which the task should be removed from the activation store
     #[builder(default = None, setter(strip_option))]
     pub expires_at: Option<DateTime<Utc>>,
 
@@ -165,7 +163,7 @@ pub struct InflightActivation {
     pub bucket: i16,
 }
 
-impl InflightActivation {
+impl Activation {
     /// The number of milliseconds between an activation's received timestamp and the provided datetime.
     pub fn received_latency(&self, now: DateTime<Utc>) -> i64 {
         now.signed_duration_since(self.received_at)

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -129,7 +129,7 @@ pub async fn create_default_postgres_pool(
     Ok(default_pool)
 }
 
-pub struct PostgresActivationStoreConfig {
+pub struct PostgresStoreConfig {
     pub pg_connection: PgConnectOptions,
     pub pg_database_name: String,
     pub pg_default_database_name: String,
@@ -142,7 +142,7 @@ pub struct PostgresActivationStoreConfig {
     pub enable_sqlite_status_metrics: bool,
 }
 
-impl PostgresActivationStoreConfig {
+impl PostgresStoreConfig {
     pub fn from_config(config: &Config) -> Self {
         let mut conn_opts = PgConnectOptions::new()
             .username(&config.pg_username)
@@ -169,14 +169,14 @@ impl PostgresActivationStoreConfig {
     }
 }
 
-pub struct PostgresActivationStore {
+pub struct PostgresStore {
     read_pool: PgPool,
     write_pool: PgPool,
-    config: PostgresActivationStoreConfig,
+    config: PostgresStoreConfig,
     partitions: RwLock<Vec<i32>>,
 }
 
-impl PostgresActivationStore {
+impl PostgresStore {
     #[framed]
     async fn acquire_write_conn_metric(
         &self,
@@ -202,7 +202,7 @@ impl PostgresActivationStore {
     }
 
     #[framed]
-    pub async fn new(config: PostgresActivationStoreConfig) -> Result<Self, Error> {
+    pub async fn new(config: PostgresStoreConfig) -> Result<Self, Error> {
         if config.run_migrations {
             let default_pool = create_default_postgres_pool(
                 &config.pg_connection,
@@ -269,7 +269,7 @@ impl PostgresActivationStore {
 }
 
 #[async_trait]
-impl ActivationStore for PostgresActivationStore {
+impl ActivationStore for PostgresStore {
     /// Trigger incremental vacuum to reclaim free pages in the database.
     /// Depending on config data, will either vacuum a set number of
     /// pages or attempt to reclaim all free pages.
@@ -570,10 +570,6 @@ impl ActivationStore for PostgresActivationStore {
 
         query_builder.push(" ORDER BY received_at ASC LIMIT 1");
 
-        let _ = query_builder
-            .build_query_as::<(DateTime<Utc>, Option<DateTime<Utc>>)>()
-            .fetch_one(&self.read_pool)
-            .await;
         let result = query_builder
             .build_query_as::<(DateTime<Utc>, Option<DateTime<Utc>>)>()
             .fetch_one(&self.read_pool)

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -16,8 +16,8 @@ use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivation};
 use tracing::{instrument, warn};
 
 use crate::config::Config;
-use crate::store::activation::{InflightActivation, InflightActivationStatus};
-use crate::store::traits::InflightActivationStore;
+use crate::store::activation::{Activation, ActivationStatus};
+use crate::store::traits::ActivationStore;
 use crate::store::types::{BucketRange, DepthCounts, FailedTasksForwarder};
 
 #[derive(Debug, FromRow)]
@@ -44,10 +44,10 @@ struct TableRow {
     pub bucket: i16,
 }
 
-impl TryFrom<InflightActivation> for TableRow {
+impl TryFrom<Activation> for TableRow {
     type Error = anyhow::Error;
 
-    fn try_from(value: InflightActivation) -> Result<Self, Self::Error> {
+    fn try_from(value: Activation) -> Result<Self, Self::Error> {
         Ok(Self {
             id: value.id,
             activation: value.activation,
@@ -72,12 +72,12 @@ impl TryFrom<InflightActivation> for TableRow {
     }
 }
 
-impl From<TableRow> for InflightActivation {
+impl From<TableRow> for Activation {
     fn from(value: TableRow) -> Self {
         Self {
             id: value.id,
             activation: value.activation,
-            status: InflightActivationStatus::from_str(&value.status).unwrap(),
+            status: ActivationStatus::from_str(&value.status).unwrap(),
             partition: value.partition,
             offset: value.offset,
             added_at: value.added_at,
@@ -269,7 +269,7 @@ impl PostgresActivationStore {
 }
 
 #[async_trait]
-impl InflightActivationStore for PostgresActivationStore {
+impl ActivationStore for PostgresActivationStore {
     /// Trigger incremental vacuum to reclaim free pages in the database.
     /// Depending on config data, will either vacuum a set number of
     /// pages or attempt to reclaim all free pages.
@@ -302,7 +302,7 @@ impl InflightActivationStore for PostgresActivationStore {
 
     /// Get an activation by id. Primarily used for testing
     #[framed]
-    async fn get_by_id(&self, id: &str) -> Result<Option<InflightActivation>, Error> {
+    async fn get_by_id(&self, id: &str) -> Result<Option<Activation>, Error> {
         let row_result: Option<TableRow> = sqlx::query_as(
             "
             SELECT id,
@@ -348,7 +348,7 @@ impl InflightActivationStore for PostgresActivationStore {
 
     #[instrument(skip_all)]
     #[framed]
-    async fn store(&self, batch: Vec<InflightActivation>) -> Result<u64, Error> {
+    async fn store(&self, batch: Vec<Activation>) -> Result<u64, Error> {
         if batch.is_empty() {
             return Ok(0);
         }
@@ -432,7 +432,7 @@ impl InflightActivationStore for PostgresActivationStore {
         limit: Option<i32>,
         bucket: Option<BucketRange>,
         mark_processing: bool,
-    ) -> Result<Vec<InflightActivation>, Error> {
+    ) -> Result<Vec<Activation>, Error> {
         let now = Utc::now();
 
         let grace_period = self.config.processing_deadline_grace_sec;
@@ -444,7 +444,7 @@ impl InflightActivationStore for PostgresActivationStore {
                 FROM inflight_taskactivations
                 WHERE status = ",
         );
-        query_builder.push_bind(InflightActivationStatus::Pending.to_string());
+        query_builder.push_bind(ActivationStatus::Pending.to_string());
         query_builder.push(" AND (expires_at IS NULL OR expires_at > ");
         query_builder.push_bind(now);
         query_builder.push(")");
@@ -490,7 +490,7 @@ impl InflightActivationStore for PostgresActivationStore {
                      status = "
             ));
 
-            query_builder.push_bind(InflightActivationStatus::Processing.to_string());
+            query_builder.push_bind(ActivationStatus::Processing.to_string());
         } else {
             query_builder.push(format!(
                 "UPDATE inflight_taskactivations
@@ -499,7 +499,7 @@ impl InflightActivationStore for PostgresActivationStore {
                      status = "
             ));
 
-            query_builder.push_bind(InflightActivationStatus::Claimed.to_string());
+            query_builder.push_bind(ActivationStatus::Claimed.to_string());
         }
 
         query_builder.push(" FROM selected_activations ");
@@ -530,9 +530,9 @@ impl InflightActivationStore for PostgresActivationStore {
                 claim_expires_at = NULL
             WHERE id = $2 AND status = $3",
         ))
-        .bind(InflightActivationStatus::Processing.to_string())
+        .bind(ActivationStatus::Processing.to_string())
         .bind(id)
-        .bind(InflightActivationStatus::Claimed.to_string())
+        .bind(ActivationStatus::Claimed.to_string())
         .execute(&mut *conn)
         .await?;
 
@@ -563,13 +563,17 @@ impl InflightActivationStore for PostgresActivationStore {
             FROM inflight_taskactivations
             WHERE status = ",
         );
-        query_builder.push_bind(InflightActivationStatus::Pending.to_string());
+        query_builder.push_bind(ActivationStatus::Pending.to_string());
         query_builder.push(" AND processing_attempts = 0");
 
         self.add_partition_condition(&mut query_builder, false);
 
         query_builder.push(" ORDER BY received_at ASC LIMIT 1");
 
+        let _ = query_builder
+            .build_query_as::<(DateTime<Utc>, Option<DateTime<Utc>>)>()
+            .fetch_one(&self.read_pool)
+            .await;
         let result = query_builder
             .build_query_as::<(DateTime<Utc>, Option<DateTime<Utc>>)>()
             .fetch_one(&self.read_pool)
@@ -592,7 +596,7 @@ impl InflightActivationStore for PostgresActivationStore {
 
     #[instrument(skip_all)]
     #[framed]
-    async fn count_by_status(&self, status: InflightActivationStatus) -> Result<usize, Error> {
+    async fn count_by_status(&self, status: ActivationStatus) -> Result<usize, Error> {
         let mut query_builder = QueryBuilder::new(
             "SELECT COUNT(*) as count FROM inflight_taskactivations WHERE status = ",
         );
@@ -651,10 +655,10 @@ impl InflightActivationStore for PostgresActivationStore {
     async fn set_status(
         &self,
         id: &str,
-        status: InflightActivationStatus,
+        status: ActivationStatus,
         max_attempts: Option<u32>,
         delay_on_retry: Option<u64>,
-    ) -> Result<Option<InflightActivation>, Error> {
+    ) -> Result<Option<Activation>, Error> {
         let mut tx = self.begin_write_tx_metric("set_status").await?;
 
         let result: Option<TableRow> = sqlx::query_as(
@@ -712,7 +716,7 @@ impl InflightActivationStore for PostgresActivationStore {
     async fn set_status_batch(
         &self,
         ids: &[String],
-        status: InflightActivationStatus,
+        status: ActivationStatus,
     ) -> Result<u64, Error> {
         if ids.is_empty() {
             return Ok(0);
@@ -761,7 +765,7 @@ impl InflightActivationStore for PostgresActivationStore {
 
     #[instrument(skip_all)]
     #[framed]
-    async fn get_retry_activations(&self) -> Result<Vec<InflightActivation>, Error> {
+    async fn get_retry_activations(&self) -> Result<Vec<Activation>, Error> {
         let mut query_builder = QueryBuilder::new(
             "SELECT id,
                 activation,
@@ -785,7 +789,7 @@ impl InflightActivationStore for PostgresActivationStore {
             FROM inflight_taskactivations
             WHERE status = ",
         );
-        query_builder.push_bind(InflightActivationStatus::Retry.to_string());
+        query_builder.push_bind(ActivationStatus::Retry.to_string());
         self.add_partition_condition(&mut query_builder, false);
 
         Ok(query_builder
@@ -822,14 +826,14 @@ impl InflightActivationStore for PostgresActivationStore {
              SET claim_expires_at = null,
                  status = ",
         );
-        query_builder.push_bind(InflightActivationStatus::Pending.to_string());
+        query_builder.push_bind(ActivationStatus::Pending.to_string());
         query_builder.push(
             " WHERE claim_expires_at IS NOT NULL
                  AND claim_expires_at < ",
         );
         query_builder.push_bind(now);
         query_builder.push(" AND status = ");
-        query_builder.push_bind(InflightActivationStatus::Claimed.to_string());
+        query_builder.push_bind(ActivationStatus::Claimed.to_string());
         self.add_partition_condition(&mut query_builder, false);
 
         let released = query_builder.build().execute(&mut *conn).await?;
@@ -852,11 +856,11 @@ impl InflightActivationStore for PostgresActivationStore {
             "UPDATE inflight_taskactivations
             SET processing_deadline = null, status = ",
         );
-        query_builder.push_bind(InflightActivationStatus::Failure.to_string());
+        query_builder.push_bind(ActivationStatus::Failure.to_string());
         query_builder.push(" WHERE processing_deadline < ");
         query_builder.push_bind(now);
         query_builder.push(" AND at_most_once = TRUE AND status = ");
-        query_builder.push_bind(InflightActivationStatus::Processing.to_string());
+        query_builder.push_bind(ActivationStatus::Processing.to_string());
 
         self.add_partition_condition(&mut query_builder, false);
 
@@ -873,12 +877,12 @@ impl InflightActivationStore for PostgresActivationStore {
             "UPDATE inflight_taskactivations
             SET processing_deadline = null, status = ",
         );
-        query_builder.push_bind(InflightActivationStatus::Pending.to_string());
+        query_builder.push_bind(ActivationStatus::Pending.to_string());
         query_builder.push(", processing_attempts = processing_attempts + 1");
         query_builder.push(" WHERE processing_deadline < ");
         query_builder.push_bind(now);
         query_builder.push(" AND status = ");
-        query_builder.push_bind(InflightActivationStatus::Processing.to_string());
+        query_builder.push_bind(ActivationStatus::Processing.to_string());
         self.add_partition_condition(&mut query_builder, false);
 
         let result = query_builder.build().execute(&mut *atomic).await;
@@ -905,11 +909,11 @@ impl InflightActivationStore for PostgresActivationStore {
             "UPDATE inflight_taskactivations
             SET status = ",
         );
-        query_builder.push_bind(InflightActivationStatus::Failure.to_string());
+        query_builder.push_bind(ActivationStatus::Failure.to_string());
         query_builder.push(" WHERE processing_attempts >= ");
         query_builder.push_bind(self.config.max_processing_attempts as i32);
         query_builder.push(" AND status = ");
-        query_builder.push_bind(InflightActivationStatus::Pending.to_string());
+        query_builder.push_bind(ActivationStatus::Pending.to_string());
         self.add_partition_condition(&mut query_builder, false);
         let processing_attempts_result = query_builder.build().execute(&mut *conn).await;
 
@@ -933,7 +937,7 @@ impl InflightActivationStore for PostgresActivationStore {
         let mut conn = self.acquire_write_conn_metric("handle_expires_at").await?;
         let mut query_builder =
             QueryBuilder::new("DELETE FROM inflight_taskactivations WHERE status = ");
-        query_builder.push_bind(InflightActivationStatus::Pending.to_string());
+        query_builder.push_bind(ActivationStatus::Pending.to_string());
         query_builder.push(" AND expires_at IS NOT NULL AND expires_at < ");
         query_builder.push_bind(now);
         self.add_partition_condition(&mut query_builder, false);
@@ -958,11 +962,11 @@ impl InflightActivationStore for PostgresActivationStore {
             "UPDATE inflight_taskactivations
             SET status = ",
         );
-        query_builder.push_bind(InflightActivationStatus::Pending.to_string());
+        query_builder.push_bind(ActivationStatus::Pending.to_string());
         query_builder.push(" WHERE delay_until IS NOT NULL AND delay_until < ");
         query_builder.push_bind(now);
         query_builder.push(" AND status = ");
-        query_builder.push_bind(InflightActivationStatus::Delay.to_string());
+        query_builder.push_bind(ActivationStatus::Delay.to_string());
         self.add_partition_condition(&mut query_builder, false);
         let update_result = query_builder.build().execute(&mut *conn).await?;
 
@@ -983,7 +987,7 @@ impl InflightActivationStore for PostgresActivationStore {
         let mut query_builder = QueryBuilder::new(
             "SELECT id, activation, on_attempts_exceeded FROM inflight_taskactivations WHERE status = ",
         );
-        query_builder.push_bind(InflightActivationStatus::Failure.to_string());
+        query_builder.push_bind(ActivationStatus::Failure.to_string());
         self.add_partition_condition(&mut query_builder, false);
         let failed_tasks = query_builder
             .build_query_as::<(String, Vec<u8>, i32)>()
@@ -1014,7 +1018,7 @@ impl InflightActivationStore for PostgresActivationStore {
             let mut query_builder = QueryBuilder::new("UPDATE inflight_taskactivations ");
             query_builder
                 .push("SET status = ")
-                .push_bind(InflightActivationStatus::Complete.to_string())
+                .push_bind(ActivationStatus::Complete.to_string())
                 .push(" WHERE id IN (");
 
             let mut separated = query_builder.separated(", ");
@@ -1038,7 +1042,7 @@ impl InflightActivationStore for PostgresActivationStore {
         let mut query_builder = QueryBuilder::new("UPDATE inflight_taskactivations ");
         query_builder
             .push("SET status = ")
-            .push_bind(InflightActivationStatus::Complete.to_string())
+            .push_bind(ActivationStatus::Complete.to_string())
             .push(" WHERE id IN (");
 
         let mut separated = query_builder.separated(", ");
@@ -1053,14 +1057,14 @@ impl InflightActivationStore for PostgresActivationStore {
     }
 
     /// Remove completed tasks.
-    /// This method is a garbage collector for the inflight task store.
+    /// This method is a garbage collector for the activation store.
     #[instrument(skip_all)]
     #[framed]
     async fn remove_completed(&self) -> Result<u64, Error> {
         let mut conn = self.acquire_write_conn_metric("remove_completed").await?;
         let mut query_builder =
             QueryBuilder::new("DELETE FROM inflight_taskactivations WHERE status = ");
-        query_builder.push_bind(InflightActivationStatus::Complete.to_string());
+        query_builder.push_bind(ActivationStatus::Complete.to_string());
         self.add_partition_condition(&mut query_builder, false);
         let result = query_builder.build().execute(&mut *conn).await?;
 

--- a/src/store/adapters/sqlite.rs
+++ b/src/store/adapters/sqlite.rs
@@ -137,7 +137,7 @@ pub async fn create_sqlite_pool(url: &str) -> Result<(Pool<Sqlite>, Pool<Sqlite>
     Ok((read_pool, write_pool))
 }
 
-pub struct ActivationStoreConfig {
+pub struct SqliteStoreConfig {
     pub max_processing_attempts: usize,
     pub processing_deadline_grace_sec: u64,
     /// Milliseconds added to `claim_expires_at` before grace: `fetch_batch_size * push_queue_timeout_ms`.
@@ -146,7 +146,7 @@ pub struct ActivationStoreConfig {
     pub enable_sqlite_status_metrics: bool,
 }
 
-impl ActivationStoreConfig {
+impl SqliteStoreConfig {
     pub fn from_config(config: &Config) -> Self {
         Self {
             max_processing_attempts: config.max_processing_attempts,
@@ -158,14 +158,14 @@ impl ActivationStoreConfig {
     }
 }
 
-pub struct SqliteActivationStore {
+pub struct SqliteStore {
     read_pool: SqlitePool,
     write_pool: SqlitePool,
-    config: ActivationStoreConfig,
+    config: SqliteStoreConfig,
 }
 
-impl SqliteActivationStore {
-    pub async fn new(url: &str, config: ActivationStoreConfig) -> Result<Self, Error> {
+impl SqliteStore {
+    pub async fn new(url: &str, config: SqliteStoreConfig) -> Result<Self, Error> {
         let (read_pool, write_pool) = create_sqlite_pool(url).await?;
 
         sqlx::migrate!("./migrations/sqlite")
@@ -348,7 +348,7 @@ impl SqliteActivationStore {
 }
 
 #[async_trait]
-impl ActivationStore for SqliteActivationStore {
+impl ActivationStore for SqliteStore {
     /// Trigger incremental vacuum to reclaim free pages in the database.
     /// Depending on config data, will either vacuum a set number of
     /// pages or attempt to reclaim all free pages.

--- a/src/store/adapters/sqlite.rs
+++ b/src/store/adapters/sqlite.rs
@@ -25,8 +25,8 @@ use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivation};
 use tracing::{instrument, warn};
 
 use crate::config::Config;
-use crate::store::activation::{InflightActivation, InflightActivationStatus};
-use crate::store::traits::InflightActivationStore;
+use crate::store::activation::{Activation, ActivationStatus};
+use crate::store::traits::ActivationStore;
 use crate::store::types::{BucketRange, FailedTasksForwarder};
 
 #[derive(Debug, FromRow)]
@@ -53,10 +53,10 @@ pub struct TableRow {
     pub bucket: i16,
 }
 
-impl TryFrom<InflightActivation> for TableRow {
+impl TryFrom<Activation> for TableRow {
     type Error = anyhow::Error;
 
-    fn try_from(value: InflightActivation) -> Result<Self, Self::Error> {
+    fn try_from(value: Activation) -> Result<Self, Self::Error> {
         Ok(Self {
             id: value.id,
             activation: value.activation,
@@ -81,12 +81,12 @@ impl TryFrom<InflightActivation> for TableRow {
     }
 }
 
-impl From<TableRow> for InflightActivation {
+impl From<TableRow> for Activation {
     fn from(value: TableRow) -> Self {
         Self {
             id: value.id,
             activation: value.activation,
-            status: InflightActivationStatus::from_str(&value.status).unwrap(),
+            status: ActivationStatus::from_str(&value.status).unwrap(),
             partition: value.partition,
             offset: value.offset,
             added_at: value.added_at,
@@ -137,7 +137,7 @@ pub async fn create_sqlite_pool(url: &str) -> Result<(Pool<Sqlite>, Pool<Sqlite>
     Ok((read_pool, write_pool))
 }
 
-pub struct InflightActivationStoreConfig {
+pub struct ActivationStoreConfig {
     pub max_processing_attempts: usize,
     pub processing_deadline_grace_sec: u64,
     /// Milliseconds added to `claim_expires_at` before grace: `fetch_batch_size * push_queue_timeout_ms`.
@@ -146,7 +146,7 @@ pub struct InflightActivationStoreConfig {
     pub enable_sqlite_status_metrics: bool,
 }
 
-impl InflightActivationStoreConfig {
+impl ActivationStoreConfig {
     pub fn from_config(config: &Config) -> Self {
         Self {
             max_processing_attempts: config.max_processing_attempts,
@@ -161,11 +161,11 @@ impl InflightActivationStoreConfig {
 pub struct SqliteActivationStore {
     read_pool: SqlitePool,
     write_pool: SqlitePool,
-    config: InflightActivationStoreConfig,
+    config: ActivationStoreConfig,
 }
 
 impl SqliteActivationStore {
-    pub async fn new(url: &str, config: InflightActivationStoreConfig) -> Result<Self, Error> {
+    pub async fn new(url: &str, config: ActivationStoreConfig) -> Result<Self, Error> {
         let (read_pool, write_pool) = create_sqlite_pool(url).await?;
 
         sqlx::migrate!("./migrations/sqlite")
@@ -348,7 +348,7 @@ impl SqliteActivationStore {
 }
 
 #[async_trait]
-impl InflightActivationStore for SqliteActivationStore {
+impl ActivationStore for SqliteActivationStore {
     /// Trigger incremental vacuum to reclaim free pages in the database.
     /// Depending on config data, will either vacuum a set number of
     /// pages or attempt to reclaim all free pages.
@@ -398,7 +398,7 @@ impl InflightActivationStore for SqliteActivationStore {
     }
 
     /// Get an activation by id. Primarily used for testing
-    async fn get_by_id(&self, id: &str) -> Result<Option<InflightActivation>, Error> {
+    async fn get_by_id(&self, id: &str) -> Result<Option<Activation>, Error> {
         let row_result: Option<TableRow> = sqlx::query_as(
             "
             SELECT id,
@@ -441,7 +441,7 @@ impl InflightActivationStore for SqliteActivationStore {
     }
 
     #[instrument(skip_all)]
-    async fn store(&self, batch: Vec<InflightActivation>) -> Result<u64, Error> {
+    async fn store(&self, batch: Vec<Activation>) -> Result<u64, Error> {
         if batch.is_empty() {
             return Ok(0);
         }
@@ -546,7 +546,7 @@ impl InflightActivationStore for SqliteActivationStore {
         limit: Option<i32>,
         bucket: Option<BucketRange>,
         mark_processing: bool,
-    ) -> Result<Vec<InflightActivation>, Error> {
+    ) -> Result<Vec<Activation>, Error> {
         let now = Utc::now();
         let grace_period = self.config.processing_deadline_grace_sec;
 
@@ -557,18 +557,18 @@ impl InflightActivationStore for SqliteActivationStore {
                 "processing_deadline = unixepoch('now', '+' || (processing_deadline_duration + {grace_period}) || ' seconds'), claim_expires_at = NULL, status = "
             ));
 
-            query_builder.push_bind(InflightActivationStatus::Processing);
+            query_builder.push_bind(ActivationStatus::Processing);
         } else {
             query_builder.push(format!(
                 "claim_expires_at = unixepoch('now', '+' || {:.3} || ' seconds', '+' || {grace_period} || ' seconds'), processing_deadline = NULL, status = ",
                 self.config.claim_lease_ms as f64 / 1000.0,
             ));
 
-            query_builder.push_bind(InflightActivationStatus::Claimed);
+            query_builder.push_bind(ActivationStatus::Claimed);
         }
 
         query_builder.push(" WHERE id IN (SELECT id FROM inflight_taskactivations WHERE status = ");
-        query_builder.push_bind(InflightActivationStatus::Pending);
+        query_builder.push_bind(ActivationStatus::Pending);
         query_builder.push(" AND (expires_at IS NULL OR expires_at > ");
         query_builder.push_bind(now.timestamp());
         query_builder.push(")");
@@ -623,9 +623,9 @@ impl InflightActivationStore for SqliteActivationStore {
                 claim_expires_at = NULL
             WHERE id = $2 AND status = $3",
         ))
-        .bind(InflightActivationStatus::Processing)
+        .bind(ActivationStatus::Processing)
         .bind(id)
-        .bind(InflightActivationStatus::Claimed)
+        .bind(ActivationStatus::Claimed)
         .execute(&mut *conn)
         .await?;
 
@@ -659,7 +659,7 @@ impl InflightActivationStore for SqliteActivationStore {
             LIMIT 1
             ",
         )
-        .bind(InflightActivationStatus::Pending)
+        .bind(ActivationStatus::Pending)
         .fetch_one(&self.read_pool)
         .await;
 
@@ -680,7 +680,7 @@ impl InflightActivationStore for SqliteActivationStore {
     }
 
     #[instrument(skip_all)]
-    async fn count_by_status(&self, status: InflightActivationStatus) -> Result<usize, Error> {
+    async fn count_by_status(&self, status: ActivationStatus) -> Result<usize, Error> {
         let result =
             sqlx::query("SELECT COUNT(*) as count FROM inflight_taskactivations WHERE status = $1")
                 .bind(status)
@@ -702,10 +702,10 @@ impl InflightActivationStore for SqliteActivationStore {
     async fn set_status(
         &self,
         id: &str,
-        status: InflightActivationStatus,
+        status: ActivationStatus,
         max_attempts: Option<u32>,
         delay_on_retry: Option<u64>,
-    ) -> Result<Option<InflightActivation>, Error> {
+    ) -> Result<Option<Activation>, Error> {
         let mut tx = self.begin_write_tx_metric("set_status").await?;
 
         let result: Option<TableRow> = sqlx::query_as(
@@ -762,7 +762,7 @@ impl InflightActivationStore for SqliteActivationStore {
     async fn set_status_batch(
         &self,
         ids: &[String],
-        status: InflightActivationStatus,
+        status: ActivationStatus,
     ) -> Result<u64, Error> {
         if ids.is_empty() {
             return Ok(0);
@@ -817,7 +817,7 @@ impl InflightActivationStore for SqliteActivationStore {
     }
 
     #[instrument(skip_all)]
-    async fn get_retry_activations(&self) -> Result<Vec<InflightActivation>, Error> {
+    async fn get_retry_activations(&self) -> Result<Vec<Activation>, Error> {
         Ok(sqlx::query_as(
             "
             SELECT id,
@@ -843,7 +843,7 @@ impl InflightActivationStore for SqliteActivationStore {
             WHERE status = $1
             ",
         )
-        .bind(InflightActivationStatus::Retry)
+        .bind(ActivationStatus::Retry)
         .fetch_all(&self.read_pool)
         .await?
         .into_iter()
@@ -875,9 +875,9 @@ impl InflightActivationStore for SqliteActivationStore {
                  AND claim_expires_at < $2
                  AND status = $3",
         )
-        .bind(InflightActivationStatus::Pending)
+        .bind(ActivationStatus::Pending)
         .bind(now.timestamp())
-        .bind(InflightActivationStatus::Claimed)
+        .bind(ActivationStatus::Claimed)
         .execute(&mut *conn)
         .await?;
 
@@ -899,9 +899,9 @@ impl InflightActivationStore for SqliteActivationStore {
             SET processing_deadline = null, status = $1
             WHERE processing_deadline < $2 AND at_most_once = TRUE AND status = $3",
         )
-        .bind(InflightActivationStatus::Failure)
+        .bind(ActivationStatus::Failure)
         .bind(now.timestamp())
-        .bind(InflightActivationStatus::Processing)
+        .bind(ActivationStatus::Processing)
         .execute(&mut *atomic)
         .await;
 
@@ -917,9 +917,9 @@ impl InflightActivationStore for SqliteActivationStore {
             SET processing_deadline = null, status = $1, processing_attempts = processing_attempts + 1
             WHERE processing_deadline < $2 AND status = $3",
         )
-        .bind(InflightActivationStatus::Pending)
+        .bind(ActivationStatus::Pending)
         .bind(now.timestamp())
-        .bind(InflightActivationStatus::Processing)
+        .bind(ActivationStatus::Processing)
         .execute(&mut *atomic)
         .await;
 
@@ -945,9 +945,9 @@ impl InflightActivationStore for SqliteActivationStore {
             SET status = $1
             WHERE processing_attempts >= $2 AND status = $3",
         )
-        .bind(InflightActivationStatus::Failure)
+        .bind(ActivationStatus::Failure)
         .bind(self.config.max_processing_attempts as i32)
-        .bind(InflightActivationStatus::Pending)
+        .bind(ActivationStatus::Pending)
         .execute(&mut *conn)
         .await;
 
@@ -971,7 +971,7 @@ impl InflightActivationStore for SqliteActivationStore {
         let query = sqlx::query(
             "DELETE FROM inflight_taskactivations WHERE status = $1 AND expires_at IS NOT NULL AND expires_at < $2",
         )
-        .bind(InflightActivationStatus::Pending)
+        .bind(ActivationStatus::Pending)
         .bind(now.timestamp())
         .execute(&mut *conn)
         .await?;
@@ -995,9 +995,9 @@ impl InflightActivationStore for SqliteActivationStore {
             WHERE delay_until IS NOT NULL AND delay_until < $2 AND status = $3
             "#,
         )
-        .bind(InflightActivationStatus::Pending)
+        .bind(ActivationStatus::Pending)
         .bind(now.timestamp())
-        .bind(InflightActivationStatus::Delay)
+        .bind(ActivationStatus::Delay)
         .execute(&mut *conn)
         .await?;
 
@@ -1016,7 +1016,7 @@ impl InflightActivationStore for SqliteActivationStore {
 
         let failed_tasks: Vec<SqliteRow> =
             sqlx::query("SELECT id, activation, on_attempts_exceeded FROM inflight_taskactivations WHERE status = $1")
-                .bind(InflightActivationStatus::Failure)
+                .bind(ActivationStatus::Failure)
                 .fetch_all(&mut *atomic)
                 .await?
                 .into_iter()
@@ -1048,7 +1048,7 @@ impl InflightActivationStore for SqliteActivationStore {
             let mut query_builder = QueryBuilder::new("UPDATE inflight_taskactivations ");
             query_builder
                 .push("SET status = ")
-                .push_bind(InflightActivationStatus::Complete)
+                .push_bind(ActivationStatus::Complete)
                 .push(" WHERE id IN (");
 
             let mut separated = query_builder.separated(", ");
@@ -1071,7 +1071,7 @@ impl InflightActivationStore for SqliteActivationStore {
         let mut query_builder = QueryBuilder::new("UPDATE inflight_taskactivations ");
         query_builder
             .push("SET status = ")
-            .push_bind(InflightActivationStatus::Complete)
+            .push_bind(ActivationStatus::Complete)
             .push(" WHERE id IN (");
 
         let mut separated = query_builder.separated(", ");
@@ -1086,12 +1086,12 @@ impl InflightActivationStore for SqliteActivationStore {
     }
 
     /// Remove completed tasks.
-    /// This method is a garbage collector for the inflight task store.
+    /// This method is a garbage collector for the activation store.
     #[instrument(skip_all)]
     async fn remove_completed(&self) -> Result<u64, Error> {
         let mut conn = self.acquire_write_conn_metric("remove_completed").await?;
         let query = sqlx::query("DELETE FROM inflight_taskactivations WHERE status = $1")
-            .bind(InflightActivationStatus::Complete)
+            .bind(ActivationStatus::Complete)
             .execute(&mut *conn)
             .await?;
 

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -14,10 +14,8 @@ use tokio::task::JoinSet;
 
 use crate::config::Config;
 use crate::store::activation::{ActivationBuilder, ActivationStatus};
-use crate::store::adapters::postgres::PostgresActivationStoreConfig;
-use crate::store::adapters::sqlite::{
-    ActivationStoreConfig, SqliteActivationStore, create_sqlite_pool,
-};
+use crate::store::adapters::postgres::PostgresStoreConfig;
+use crate::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig, create_sqlite_pool};
 use crate::store::traits::ActivationStore;
 use crate::test_utils::{
     StatusCount, TaskActivationBuilder, assert_counts, create_integration_config,
@@ -68,9 +66,9 @@ fn test_activation_status_from() {
 #[tokio::test]
 async fn test_sqlite_create_db() {
     assert!(
-        SqliteActivationStore::new(
+        SqliteStore::new(
             &generate_temp_filename(),
-            ActivationStoreConfig::from_config(&create_integration_config())
+            SqliteStoreConfig::from_config(&create_integration_config())
         )
         .await
         .is_ok()
@@ -80,7 +78,7 @@ async fn test_sqlite_create_db() {
 #[test]
 fn test_connect_opts_preserves_sslmode_query_param() {
     let config = create_integration_config_with_ssl();
-    let opts = PostgresActivationStoreConfig::from_config(&config).pg_connection;
+    let opts = PostgresStoreConfig::from_config(&config).pg_connection;
     assert!(matches!(opts.get_ssl_mode(), PgSslMode::Require));
     assert_eq!(opts.get_host(), "localhost");
 }
@@ -1783,9 +1781,9 @@ async fn test_vacuum_db_incremental() {
         vacuum_page_count: Some(10),
         ..Config::default()
     };
-    let store = SqliteActivationStore::new(
+    let store = SqliteStore::new(
         &generate_temp_filename(),
-        ActivationStoreConfig::from_config(&config),
+        SqliteStoreConfig::from_config(&config),
     )
     .await
     .expect("could not create store");
@@ -1911,9 +1909,9 @@ async fn test_db_status_calls_ok() {
     let url = format!("sqlite:{db_path}");
 
     // Initialize a store to create the database and run migrations
-    SqliteActivationStore::new(
+    SqliteStore::new(
         &url,
-        ActivationStoreConfig {
+        SqliteStoreConfig {
             max_processing_attempts: 3,
             processing_deadline_grace_sec: 0,
             claim_lease_ms: 5000,

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -13,12 +13,12 @@ use tokio::sync::broadcast;
 use tokio::task::JoinSet;
 
 use crate::config::Config;
-use crate::store::activation::{InflightActivationBuilder, InflightActivationStatus};
+use crate::store::activation::{ActivationBuilder, ActivationStatus};
 use crate::store::adapters::postgres::PostgresActivationStoreConfig;
 use crate::store::adapters::sqlite::{
-    InflightActivationStoreConfig, SqliteActivationStore, create_sqlite_pool,
+    ActivationStoreConfig, SqliteActivationStore, create_sqlite_pool,
 };
-use crate::store::traits::InflightActivationStore;
+use crate::store::traits::ActivationStore;
 use crate::test_utils::{
     StatusCount, TaskActivationBuilder, assert_counts, create_integration_config,
     create_integration_config_with_ssl, create_test_store, generate_temp_filename,
@@ -27,42 +27,42 @@ use crate::test_utils::{
 };
 
 #[test]
-fn test_inflightactivation_status_is_completion() {
-    let mut value = InflightActivationStatus::Unspecified;
+fn test_activation_status_is_completion() {
+    let mut value = ActivationStatus::Unspecified;
     assert!(!value.is_conclusion());
 
-    value = InflightActivationStatus::Pending;
+    value = ActivationStatus::Pending;
     assert!(!value.is_conclusion());
 
-    value = InflightActivationStatus::Processing;
+    value = ActivationStatus::Processing;
     assert!(!value.is_conclusion());
 
-    value = InflightActivationStatus::Retry;
+    value = ActivationStatus::Retry;
     assert!(value.is_conclusion());
 
-    value = InflightActivationStatus::Failure;
+    value = ActivationStatus::Failure;
     assert!(value.is_conclusion());
 
-    value = InflightActivationStatus::Complete;
+    value = ActivationStatus::Complete;
     assert!(value.is_conclusion());
 }
 
 #[test]
-fn test_inflightactivation_status_from() {
-    let mut value: InflightActivationStatus = TaskActivationStatus::Pending.into();
-    assert_eq!(value, InflightActivationStatus::Pending);
+fn test_activation_status_from() {
+    let mut value: ActivationStatus = TaskActivationStatus::Pending.into();
+    assert_eq!(value, ActivationStatus::Pending);
 
     value = TaskActivationStatus::Processing.into();
-    assert_eq!(value, InflightActivationStatus::Processing);
+    assert_eq!(value, ActivationStatus::Processing);
 
     value = TaskActivationStatus::Retry.into();
-    assert_eq!(value, InflightActivationStatus::Retry);
+    assert_eq!(value, ActivationStatus::Retry);
 
     value = TaskActivationStatus::Failure.into();
-    assert_eq!(value, InflightActivationStatus::Failure);
+    assert_eq!(value, ActivationStatus::Failure);
 
     value = TaskActivationStatus::Complete.into();
-    assert_eq!(value, InflightActivationStatus::Complete);
+    assert_eq!(value, ActivationStatus::Complete);
 }
 
 #[tokio::test]
@@ -70,7 +70,7 @@ async fn test_sqlite_create_db() {
     assert!(
         SqliteActivationStore::new(
             &generate_temp_filename(),
-            InflightActivationStoreConfig::from_config(&create_integration_config())
+            ActivationStoreConfig::from_config(&create_integration_config())
         )
         .await
         .is_ok()
@@ -109,15 +109,15 @@ async fn test_count_depths(#[case] adapter: &str) {
 
     // Check counts for an empty store
     let pending = store
-        .count_by_status(InflightActivationStatus::Pending)
+        .count_by_status(ActivationStatus::Pending)
         .await
         .unwrap();
     let delay = store
-        .count_by_status(InflightActivationStatus::Delay)
+        .count_by_status(ActivationStatus::Delay)
         .await
         .unwrap();
     let processing = store
-        .count_by_status(InflightActivationStatus::Processing)
+        .count_by_status(ActivationStatus::Processing)
         .await
         .unwrap();
 
@@ -132,28 +132,28 @@ async fn test_count_depths(#[case] adapter: &str) {
     assert!(store.store(batch).await.is_ok());
 
     store
-        .set_status("id_0", InflightActivationStatus::Processing, None, None)
+        .set_status("id_0", ActivationStatus::Processing, None, None)
         .await
         .unwrap();
     store
-        .set_status("id_1", InflightActivationStatus::Delay, None, None)
+        .set_status("id_1", ActivationStatus::Delay, None, None)
         .await
         .unwrap();
     store
-        .set_status("id_2", InflightActivationStatus::Complete, None, None)
+        .set_status("id_2", ActivationStatus::Complete, None, None)
         .await
         .unwrap();
 
     let pending = store
-        .count_by_status(InflightActivationStatus::Pending)
+        .count_by_status(ActivationStatus::Pending)
         .await
         .unwrap();
     let delay = store
-        .count_by_status(InflightActivationStatus::Delay)
+        .count_by_status(ActivationStatus::Delay)
         .await
         .unwrap();
     let processing = store
-        .count_by_status(InflightActivationStatus::Processing)
+        .count_by_status(ActivationStatus::Processing)
         .await
         .unwrap();
 
@@ -233,7 +233,7 @@ async fn test_get_pending_activation(#[case] adapter: &str) {
         .expect("expected one activation");
 
     assert_eq!(result.id, "id_0");
-    assert_eq!(result.status, InflightActivationStatus::Processing);
+    assert_eq!(result.status, ActivationStatus::Processing);
     assert_eq!(result.processing_deadline_duration, 10);
     assert!(
         result.processing_deadline.unwrap().timestamp() >= Utc::now().timestamp() + 13,
@@ -361,7 +361,7 @@ async fn test_get_pending_activation_with_namespace(#[case] adapter: &str) {
         .unwrap()
         .expect("expected one activation");
     assert_eq!(result.id, "id_1");
-    assert_eq!(result.status, InflightActivationStatus::Processing);
+    assert_eq!(result.status, ActivationStatus::Processing);
     assert!(result.processing_deadline.unwrap() > Utc::now());
     assert_eq!(result.namespace, "other_namespace");
     store.remove_db().await.unwrap();
@@ -392,10 +392,10 @@ async fn test_get_pending_activation_from_multiple_namespaces(#[case] adapter: &
     assert_eq!(result.len(), 2);
     assert_eq!(result[1].id, "id_2");
     assert_eq!(result[1].namespace, "ns3");
-    assert_eq!(result[1].status, InflightActivationStatus::Claimed);
+    assert_eq!(result[1].status, ActivationStatus::Claimed);
     assert_eq!(result[0].id, "id_1");
     assert_eq!(result[0].namespace, "ns2");
-    assert_eq!(result[0].status, InflightActivationStatus::Claimed);
+    assert_eq!(result[0].status, ActivationStatus::Claimed);
     store.remove_db().await.unwrap();
 }
 
@@ -511,7 +511,7 @@ async fn test_get_pending_activation_fetches_application(#[case] adapter: &str) 
         .unwrap()
         .expect("expected one activation");
     assert_eq!(result.id, "id_0");
-    assert_eq!(result.status, InflightActivationStatus::Processing);
+    assert_eq!(result.status, ActivationStatus::Processing);
     assert!(result.processing_deadline.unwrap() > Utc::now());
     assert_eq!(result.application, "hammers");
     store.remove_db().await.unwrap();
@@ -535,7 +535,7 @@ async fn test_get_pending_activation_with_application(#[case] adapter: &str) {
         .unwrap()
         .expect("expected one activation");
     assert_eq!(result.id, "id_1");
-    assert_eq!(result.status, InflightActivationStatus::Processing);
+    assert_eq!(result.status, ActivationStatus::Processing);
     assert!(result.processing_deadline.unwrap() > Utc::now());
     assert_eq!(result.application, "hammers");
 
@@ -578,7 +578,7 @@ async fn test_get_pending_activation_with_application_and_namespace(#[case] adap
         .unwrap()
         .expect("expected one activation");
     assert_eq!(result.id, "id_1");
-    assert_eq!(result.status, InflightActivationStatus::Processing);
+    assert_eq!(result.status, ActivationStatus::Processing);
     assert!(result.processing_deadline.unwrap() > Utc::now());
     assert_eq!(result.application, "hammers");
     assert_eq!(result.namespace, "target");
@@ -607,10 +607,7 @@ async fn test_get_pending_activations_no_limit(#[case] adapter: &str) {
 
     let got = store.claim_activations_for_push(None, None).await.unwrap();
     assert_eq!(got.len(), N);
-    assert!(
-        got.iter()
-            .all(|a| a.status == InflightActivationStatus::Claimed)
-    );
+    assert!(got.iter().all(|a| a.status == ActivationStatus::Claimed));
     assert_eq!(store.count_pending_activations().await.unwrap(), 0);
     assert_counts(
         StatusCount {
@@ -641,10 +638,7 @@ async fn test_get_pending_activations_limit_below_pending(#[case] adapter: &str)
         .await
         .unwrap();
     assert_eq!(got.len(), X as usize);
-    assert!(
-        got.iter()
-            .all(|a| a.status == InflightActivationStatus::Claimed)
-    );
+    assert!(got.iter().all(|a| a.status == ActivationStatus::Claimed));
     assert_eq!(
         store.count_pending_activations().await.unwrap(),
         N - X as usize
@@ -678,10 +672,7 @@ async fn test_get_pending_activations_limit_above_pending(#[case] adapter: &str)
         .await
         .unwrap();
     assert_eq!(got.len(), Y);
-    assert!(
-        got.iter()
-            .all(|a| a.status == InflightActivationStatus::Claimed)
-    );
+    assert!(got.iter().all(|a| a.status == ActivationStatus::Claimed));
     assert_eq!(store.count_pending_activations().await.unwrap(), 0);
     assert_counts(
         StatusCount {
@@ -703,7 +694,7 @@ async fn test_count_pending_activations(#[case] adapter: &str) {
     let store = create_test_store(adapter).await;
 
     let mut batch = make_activations(3);
-    batch[0].status = InflightActivationStatus::Processing;
+    batch[0].status = ActivationStatus::Processing;
     assert!(store.store(batch).await.is_ok());
 
     assert_eq!(store.count_pending_activations().await.unwrap(), 2);
@@ -739,7 +730,7 @@ async fn test_set_activation_status(#[case] adapter: &str) {
 
     assert!(
         store
-            .set_status("id_0", InflightActivationStatus::Failure, None, None)
+            .set_status("id_0", ActivationStatus::Failure, None, None)
             .await
             .is_ok()
     );
@@ -755,7 +746,7 @@ async fn test_set_activation_status(#[case] adapter: &str) {
 
     assert!(
         store
-            .set_status("id_0", InflightActivationStatus::Pending, None, None)
+            .set_status("id_0", ActivationStatus::Pending, None, None)
             .await
             .is_ok()
     );
@@ -769,13 +760,13 @@ async fn test_set_activation_status(#[case] adapter: &str) {
     .await;
     assert!(
         store
-            .set_status("id_0", InflightActivationStatus::Failure, None, None)
+            .set_status("id_0", ActivationStatus::Failure, None, None)
             .await
             .is_ok()
     );
     assert!(
         store
-            .set_status("id_1", InflightActivationStatus::Failure, None, None)
+            .set_status("id_1", ActivationStatus::Failure, None, None)
             .await
             .is_ok()
     );
@@ -797,7 +788,7 @@ async fn test_set_activation_status(#[case] adapter: &str) {
     );
 
     let result = store
-        .set_status("not_there", InflightActivationStatus::Complete, None, None)
+        .set_status("not_there", ActivationStatus::Complete, None, None)
         .await;
     assert!(result.is_ok(), "no query error");
 
@@ -805,7 +796,7 @@ async fn test_set_activation_status(#[case] adapter: &str) {
     assert!(activation.is_none(), "no activation found");
 
     let result = store
-        .set_status("id_0", InflightActivationStatus::Complete, None, None)
+        .set_status("id_0", ActivationStatus::Complete, None, None)
         .await;
     assert!(result.is_ok(), "no query error");
 
@@ -813,7 +804,7 @@ async fn test_set_activation_status(#[case] adapter: &str) {
     assert!(result_opt.is_some(), "activation should be returned");
     let inflight = result_opt.unwrap();
     assert_eq!(inflight.id, "id_0");
-    assert_eq!(inflight.status, InflightActivationStatus::Complete);
+    assert_eq!(inflight.status, ActivationStatus::Complete);
     store.remove_db().await.unwrap();
 }
 
@@ -837,7 +828,7 @@ async fn test_set_activation_status_with_partitions(#[case] adapter: &str) {
 
     assert!(
         store
-            .set_status("id_0", InflightActivationStatus::Failure, None, None)
+            .set_status("id_0", ActivationStatus::Failure, None, None)
             .await
             .is_ok()
     );
@@ -852,7 +843,7 @@ async fn test_set_activation_status_with_partitions(#[case] adapter: &str) {
 
     assert!(
         store
-            .set_status("id_0", InflightActivationStatus::Pending, None, None)
+            .set_status("id_0", ActivationStatus::Pending, None, None)
             .await
             .is_ok()
     );
@@ -866,13 +857,13 @@ async fn test_set_activation_status_with_partitions(#[case] adapter: &str) {
     .await;
     assert!(
         store
-            .set_status("id_0", InflightActivationStatus::Failure, None, None)
+            .set_status("id_0", ActivationStatus::Failure, None, None)
             .await
             .is_ok()
     );
     assert!(
         store
-            .set_status("id_1", InflightActivationStatus::Failure, None, None)
+            .set_status("id_1", ActivationStatus::Failure, None, None)
             .await
             .is_ok()
     );
@@ -896,7 +887,7 @@ async fn test_set_activation_status_with_partitions(#[case] adapter: &str) {
     );
 
     let result = store
-        .set_status("not_there", InflightActivationStatus::Complete, None, None)
+        .set_status("not_there", ActivationStatus::Complete, None, None)
         .await;
     assert!(result.is_ok(), "no query error");
 
@@ -904,7 +895,7 @@ async fn test_set_activation_status_with_partitions(#[case] adapter: &str) {
     assert!(activation.is_none(), "no activation found");
 
     let result = store
-        .set_status("id_0", InflightActivationStatus::Complete, None, None)
+        .set_status("id_0", ActivationStatus::Complete, None, None)
         .await;
     assert!(result.is_ok(), "no query error");
 
@@ -912,7 +903,7 @@ async fn test_set_activation_status_with_partitions(#[case] adapter: &str) {
     assert!(result_opt.is_some(), "activation should be returned");
     let inflight = result_opt.unwrap();
     assert_eq!(inflight.id, "id_0");
-    assert_eq!(inflight.status, InflightActivationStatus::Complete);
+    assert_eq!(inflight.status, ActivationStatus::Complete);
     store.remove_db().await.unwrap();
 }
 
@@ -985,7 +976,7 @@ async fn test_get_retry_activations(#[case] adapter: &str) {
 
     assert!(
         store
-            .set_status("id_0", InflightActivationStatus::Retry, None, None)
+            .set_status("id_0", ActivationStatus::Retry, None, None)
             .await
             .is_ok()
     );
@@ -1001,7 +992,7 @@ async fn test_get_retry_activations(#[case] adapter: &str) {
 
     assert!(
         store
-            .set_status("id_1", InflightActivationStatus::Retry, None, None)
+            .set_status("id_1", ActivationStatus::Retry, None, None)
             .await
             .is_ok()
     );
@@ -1009,7 +1000,7 @@ async fn test_get_retry_activations(#[case] adapter: &str) {
     let retries = store.get_retry_activations().await.unwrap();
     assert_eq!(retries.len(), 2);
     for record in retries.iter() {
-        assert_eq!(record.status, InflightActivationStatus::Retry);
+        assert_eq!(record.status, ActivationStatus::Retry);
     }
     store.remove_db().await.unwrap();
 }
@@ -1022,7 +1013,7 @@ async fn test_handle_processing_deadline(#[case] adapter: &str) {
     let store = create_test_store(adapter).await;
 
     let mut batch = make_activations(2);
-    batch[1].status = InflightActivationStatus::Processing;
+    batch[1].status = ActivationStatus::Processing;
     batch[1].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
 
     assert!(store.store(batch.clone()).await.is_ok());
@@ -1066,9 +1057,9 @@ async fn test_handle_processing_deadline_multiple_tasks(#[case] adapter: &str) {
     let store = create_test_store(adapter).await;
 
     let mut batch = make_activations(2);
-    batch[0].status = InflightActivationStatus::Processing;
+    batch[0].status = ActivationStatus::Processing;
     batch[0].processing_deadline = Some(Utc.with_ymd_and_hms(2020, 1, 1, 1, 1, 1).unwrap());
-    batch[1].status = InflightActivationStatus::Claimed;
+    batch[1].status = ActivationStatus::Claimed;
     batch[1].processing_deadline = Some(Utc::now() + chrono::Duration::days(30));
     assert!(store.store(batch).await.is_ok());
     assert_counts(
@@ -1105,10 +1096,10 @@ async fn test_handle_processing_at_most_once(#[case] adapter: &str) {
 
     // Both records are past processing deadlines
     let mut batch = make_activations(2);
-    batch[0].status = InflightActivationStatus::Processing;
+    batch[0].status = ActivationStatus::Processing;
     batch[0].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
 
-    batch[1].status = InflightActivationStatus::Processing;
+    batch[1].status = ActivationStatus::Processing;
 
     replace_retry_state(
         &mut batch[1],
@@ -1147,7 +1138,7 @@ async fn test_handle_processing_at_most_once(#[case] adapter: &str) {
     .await;
 
     let task = store.get_by_id(&batch[1].id).await.unwrap().unwrap();
-    assert_eq!(task.status, InflightActivationStatus::Failure);
+    assert_eq!(task.status, ActivationStatus::Failure);
     store.remove_db().await.unwrap();
 }
 
@@ -1159,7 +1150,7 @@ async fn test_handle_processing_deadline_discard_after(#[case] adapter: &str) {
     let store = create_test_store(adapter).await;
 
     let mut batch = make_activations(2);
-    batch[1].status = InflightActivationStatus::Processing;
+    batch[1].status = ActivationStatus::Processing;
     batch[1].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
     replace_retry_state(
         &mut batch[1],
@@ -1205,7 +1196,7 @@ async fn test_handle_processing_deadline_deadletter_after(#[case] adapter: &str)
     let store = create_test_store(adapter).await;
 
     let mut batch = make_activations(2);
-    batch[1].status = InflightActivationStatus::Processing;
+    batch[1].status = ActivationStatus::Processing;
     batch[1].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
     replace_retry_state(
         &mut batch[1],
@@ -1251,7 +1242,7 @@ async fn test_handle_processing_deadline_no_retries_remaining(#[case] adapter: &
     let store = create_test_store(adapter).await;
 
     let mut batch = make_activations(2);
-    batch[1].status = InflightActivationStatus::Processing;
+    batch[1].status = ActivationStatus::Processing;
     batch[1].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
     replace_retry_state(
         &mut batch[1],
@@ -1296,13 +1287,13 @@ async fn test_handle_processing_deadline_no_retries_remaining(#[case] adapter: &
 async fn test_handle_claim_expiration_unsent_no_attempt_increment(#[case] adapter: &str) {
     let store = create_test_store(adapter).await;
     let mut batch = make_activations(1);
-    batch[0].status = InflightActivationStatus::Claimed;
+    batch[0].status = ActivationStatus::Claimed;
     batch[0].claim_expires_at = Some(Utc.with_ymd_and_hms(2020, 1, 1, 1, 1, 1).unwrap());
     assert!(store.store(batch.clone()).await.is_ok());
     let count = store.handle_claim_expiration().await.unwrap();
     assert_eq!(count, 1);
     let task = store.get_by_id(&batch[0].id).await.unwrap().unwrap();
-    assert_eq!(task.status, InflightActivationStatus::Pending);
+    assert_eq!(task.status, ActivationStatus::Pending);
     assert_eq!(task.processing_attempts, 0);
     store.remove_db().await.unwrap();
 }
@@ -1314,14 +1305,14 @@ async fn test_handle_claim_expiration_unsent_no_attempt_increment(#[case] adapte
 async fn test_handle_claim_expiration_at_most_once_reverts_to_pending(#[case] adapter: &str) {
     let store = create_test_store(adapter).await;
     let mut batch = make_activations(1);
-    batch[0].status = InflightActivationStatus::Claimed;
+    batch[0].status = ActivationStatus::Claimed;
     batch[0].at_most_once = true;
     batch[0].claim_expires_at = Some(Utc.with_ymd_and_hms(2020, 1, 1, 1, 1, 1).unwrap());
     assert!(store.store(batch.clone()).await.is_ok());
     let count = store.handle_claim_expiration().await.unwrap();
     assert_eq!(count, 1);
     let task = store.get_by_id(&batch[0].id).await.unwrap().unwrap();
-    assert_eq!(task.status, InflightActivationStatus::Pending);
+    assert_eq!(task.status, ActivationStatus::Pending);
     assert_eq!(task.processing_attempts, 0);
     store.remove_db().await.unwrap();
 }
@@ -1335,14 +1326,14 @@ async fn test_processing_attempts_exceeded(#[case] adapter: &str) {
     let store = create_test_store(adapter).await;
 
     let mut batch = make_activations(3);
-    batch[0].status = InflightActivationStatus::Pending;
+    batch[0].status = ActivationStatus::Pending;
     batch[0].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
     batch[0].processing_attempts = config.max_processing_attempts as i32;
 
-    batch[1].status = InflightActivationStatus::Complete;
+    batch[1].status = ActivationStatus::Complete;
     batch[1].added_at += Duration::from_secs(1);
 
-    batch[2].status = InflightActivationStatus::Pending;
+    batch[2].status = ActivationStatus::Pending;
     batch[2].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
     batch[2].processing_attempts = config.max_processing_attempts as i32;
 
@@ -1380,10 +1371,10 @@ async fn test_remove_completed(#[case] adapter: &str) {
     let store = create_test_store(adapter).await;
 
     let mut records = make_activations(3);
-    records[0].status = InflightActivationStatus::Complete;
-    records[1].status = InflightActivationStatus::Pending;
+    records[0].status = ActivationStatus::Complete;
+    records[1].status = ActivationStatus::Pending;
     records[1].added_at += Duration::from_secs(1);
-    records[2].status = InflightActivationStatus::Complete;
+    records[2].status = ActivationStatus::Complete;
     records[2].added_at += Duration::from_secs(2);
 
     assert!(store.store(records.clone()).await.is_ok());
@@ -1442,14 +1433,14 @@ async fn test_remove_completed_multiple_gaps(#[case] adapter: &str) {
 
     let mut records = make_activations(4);
     // only record 1 can be removed
-    records[0].status = InflightActivationStatus::Complete;
-    records[1].status = InflightActivationStatus::Failure;
+    records[0].status = ActivationStatus::Complete;
+    records[1].status = ActivationStatus::Failure;
     records[1].added_at += Duration::from_secs(1);
 
-    records[2].status = InflightActivationStatus::Complete;
+    records[2].status = ActivationStatus::Complete;
     records[2].added_at += Duration::from_secs(2);
 
-    records[3].status = InflightActivationStatus::Processing;
+    records[3].status = ActivationStatus::Processing;
     records[3].added_at += Duration::from_secs(3);
 
     assert!(store.store(records.clone()).await.is_ok());
@@ -1517,7 +1508,7 @@ async fn test_handle_failed_tasks(#[case] adapter: &str) {
 
     let mut records = make_activations(4);
     // deadletter
-    records[0].status = InflightActivationStatus::Failure;
+    records[0].status = ActivationStatus::Failure;
     replace_retry_state(
         &mut records[0],
         Some(RetryState {
@@ -1529,7 +1520,7 @@ async fn test_handle_failed_tasks(#[case] adapter: &str) {
         }),
     );
     // discard
-    records[1].status = InflightActivationStatus::Failure;
+    records[1].status = ActivationStatus::Failure;
     replace_retry_state(
         &mut records[1],
         Some(RetryState {
@@ -1541,11 +1532,11 @@ async fn test_handle_failed_tasks(#[case] adapter: &str) {
         }),
     );
     // no retry state = discard
-    records[2].status = InflightActivationStatus::Failure;
+    records[2].status = ActivationStatus::Failure;
     replace_retry_state(&mut records[2], None);
 
     // Another deadletter
-    records[3].status = InflightActivationStatus::Failure;
+    records[3].status = ActivationStatus::Failure;
     replace_retry_state(
         &mut records[3],
         Some(RetryState {
@@ -1730,7 +1721,7 @@ async fn test_clear(#[case] adapter: &str) {
     let namespace = generate_unique_namespace();
 
     let batch = vec![
-        InflightActivationBuilder::new()
+        ActivationBuilder::new()
             .id("id_0")
             .taskname("taskname")
             .namespace(&namespace)
@@ -1794,7 +1785,7 @@ async fn test_vacuum_db_incremental() {
     };
     let store = SqliteActivationStore::new(
         &generate_temp_filename(),
-        InflightActivationStoreConfig::from_config(&config),
+        ActivationStoreConfig::from_config(&config),
     )
     .await
     .expect("could not create store");
@@ -1837,7 +1828,7 @@ async fn test_pending_activation_max_lag_no_pending(#[case] adapter: &str) {
     assert_eq!(0.0, store.pending_activation_max_lag(&now).await);
 
     let mut processing = make_activations(1);
-    processing[0].status = InflightActivationStatus::Processing;
+    processing[0].status = ActivationStatus::Processing;
     assert!(store.store(processing).await.is_ok());
 
     // No pending activations, max lag is 0
@@ -1922,7 +1913,7 @@ async fn test_db_status_calls_ok() {
     // Initialize a store to create the database and run migrations
     SqliteActivationStore::new(
         &url,
-        InflightActivationStoreConfig {
+        ActivationStoreConfig {
             max_processing_attempts: 3,
             processing_deadline_grace_sec: 0,
             claim_lease_ms: 5000,

--- a/src/store/traits.rs
+++ b/src/store/traits.rs
@@ -4,14 +4,14 @@ use chrono::{DateTime, Utc};
 use tokio::join;
 use tracing::warn;
 
-use crate::store::activation::{InflightActivation, InflightActivationStatus};
+use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::types::{BucketRange, DepthCounts, FailedTasksForwarder};
 
 #[async_trait]
-pub trait InflightActivationStore: Send + Sync {
+pub trait ActivationStore: Send + Sync {
     /// CONSUMER OPERATIONS
     /// Store a batch of activations
-    async fn store(&self, batch: Vec<InflightActivation>) -> Result<u64, Error>;
+    async fn store(&self, batch: Vec<Activation>) -> Result<u64, Error>;
 
     fn assign_partitions(&self, partitions: Vec<i32>) -> Result<(), Error>;
 
@@ -25,14 +25,14 @@ pub trait InflightActivationStore: Send + Sync {
         limit: Option<i32>,
         bucket: Option<BucketRange>,
         mark_processing: bool,
-    ) -> Result<Vec<InflightActivation>, Error>;
+    ) -> Result<Vec<Activation>, Error>;
 
     /// Claims `limit` activations within the `bucket` range. Push mode uses status `Claimed` until `mark_activation_processing` moves to `Processing`.
     async fn claim_activations_for_push(
         &self,
         limit: Option<i32>,
         bucket: Option<BucketRange>,
-    ) -> Result<Vec<InflightActivation>, Error> {
+    ) -> Result<Vec<Activation>, Error> {
         self.claim_activations(None, None, limit, bucket, false)
             .await
     }
@@ -42,7 +42,7 @@ pub trait InflightActivationStore: Send + Sync {
         &self,
         application: Option<&str>,
         namespace: Option<&str>,
-    ) -> Result<Option<InflightActivation>, Error> {
+    ) -> Result<Option<Activation>, Error> {
         // Convert single namespace to vector for internal use
         let namespaces = namespace.map(|ns| vec![ns.to_string()]);
 
@@ -76,16 +76,16 @@ pub trait InflightActivationStore: Send + Sync {
     async fn set_status(
         &self,
         id: &str,
-        status: InflightActivationStatus,
+        status: ActivationStatus,
         max_attempts: Option<u32>,
         delay_on_retry: Option<u64>,
-    ) -> Result<Option<InflightActivation>, Error>;
+    ) -> Result<Option<Activation>, Error>;
 
     /// Update the status of multiple activations in one batch.
     async fn set_status_batch(
         &self,
         ids: &[String],
-        status: InflightActivationStatus,
+        status: ActivationStatus,
     ) -> Result<u64, Error>;
 
     /// COUNT OPERATIONS
@@ -94,28 +94,27 @@ pub trait InflightActivationStore: Send + Sync {
 
     /// Count activations with Pending status
     async fn count_pending_activations(&self) -> Result<usize, Error> {
-        self.count_by_status(InflightActivationStatus::Pending)
-            .await
+        self.count_by_status(ActivationStatus::Pending).await
     }
 
     /// Count activations by status
-    async fn count_by_status(&self, status: InflightActivationStatus) -> Result<usize, Error>;
+    async fn count_by_status(&self, status: ActivationStatus) -> Result<usize, Error>;
 
     /// Count all activations
     async fn count(&self) -> Result<usize, Error>;
 
     /// ACTIVATION OPERATIONS
     /// Get an activation by id
-    async fn get_by_id(&self, id: &str) -> Result<Option<InflightActivation>, Error>;
+    async fn get_by_id(&self, id: &str) -> Result<Option<Activation>, Error>;
 
     /// Queue depths for pending, delay, and processing (writer backpressure and upkeep gauges).
     /// Default implementation uses separate calls, but stores may override with a single query.
     async fn count_depths(&self) -> Result<DepthCounts, Error> {
         let (pending, delay, claimed, processing) = join!(
-            self.count_by_status(InflightActivationStatus::Pending),
-            self.count_by_status(InflightActivationStatus::Delay),
-            self.count_by_status(InflightActivationStatus::Claimed),
-            self.count_by_status(InflightActivationStatus::Processing),
+            self.count_by_status(ActivationStatus::Pending),
+            self.count_by_status(ActivationStatus::Delay),
+            self.count_by_status(ActivationStatus::Claimed),
+            self.count_by_status(ActivationStatus::Processing),
         );
 
         Ok(DepthCounts {
@@ -148,7 +147,7 @@ pub trait InflightActivationStore: Send + Sync {
 
     /// UPKEEP OPERATIONS
     /// Get all activations with status Retry
-    async fn get_retry_activations(&self) -> Result<Vec<InflightActivation>, Error>;
+    async fn get_retry_activations(&self) -> Result<Vec<Activation>, Error>;
 
     /// Revert expired push claims back to pending status.
     async fn handle_claim_expiration(&self) -> Result<u64, Error>;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -16,12 +16,10 @@ use sentry_protos::taskbroker::v1::{self, OnAttemptsExceeded, RetryState, TaskAc
 use uuid::Uuid;
 
 use crate::config::Config;
-use crate::store::activation::{
-    InflightActivation, InflightActivationBuilder, InflightActivationStatus,
-};
+use crate::store::activation::{Activation, ActivationBuilder, ActivationStatus};
 use crate::store::adapters::postgres::{PostgresActivationStore, PostgresActivationStoreConfig};
-use crate::store::adapters::sqlite::{InflightActivationStoreConfig, SqliteActivationStore};
-use crate::store::traits::InflightActivationStore;
+use crate::store::adapters::sqlite::{ActivationStoreConfig, SqliteActivationStore};
+use crate::store::traits::ActivationStore;
 
 /// Builder for `TaskActivation`. We cannot generate a builder automatically because `TaskActivation` is defined in `sentry-protos`.
 pub struct TaskActivationBuilder {
@@ -143,12 +141,12 @@ impl Default for TaskActivationBuilder {
     }
 }
 
-impl InflightActivationBuilder {
+impl ActivationBuilder {
     pub fn new() -> Self {
         Self::default()
     }
 
-    pub fn build(mut self, builder: TaskActivationBuilder) -> InflightActivation {
+    pub fn build(mut self, builder: TaskActivationBuilder) -> Activation {
         // Grab required fields
         let id = self.id.as_ref().expect("field 'id' is required");
 
@@ -197,7 +195,7 @@ impl InflightActivationBuilder {
 
         match self._build() {
             Ok(activation) => activation,
-            Err(e) => panic!("Failed to build InflightActivation - {}", e),
+            Err(e) => panic!("Failed to build Activation - {}", e),
         }
     }
 }
@@ -239,13 +237,13 @@ pub fn generate_unique_namespace() -> String {
 }
 
 /// Create a collection of `count` pending unsaved activations in a particular `namespace`. If you do not want to provide a namespace, use `make_activations`.
-pub fn make_activations_with_namespace(namespace: String, count: u32) -> Vec<InflightActivation> {
-    let mut records: Vec<InflightActivation> = vec![];
+pub fn make_activations_with_namespace(namespace: String, count: u32) -> Vec<Activation> {
+    let mut records: Vec<Activation> = vec![];
 
     for i in 0..count {
         let now = Utc::now();
 
-        let item = InflightActivationBuilder::new()
+        let item = ActivationBuilder::new()
             .id(format!("id_{i}"))
             .taskname("taskname")
             .namespace(&namespace)
@@ -261,7 +259,7 @@ pub fn make_activations_with_namespace(namespace: String, count: u32) -> Vec<Inf
 }
 
 /// Create a collection of `count` pending unsaved activations in a unique namespace. If you want to provide the namespace, use `make_activations_with_namespace`.
-pub fn make_activations(count: u32) -> Vec<InflightActivation> {
+pub fn make_activations(count: u32) -> Vec<Activation> {
     let namespace = generate_unique_namespace();
     make_activations_with_namespace(namespace, count)
 }
@@ -271,17 +269,17 @@ pub fn create_config() -> Arc<Config> {
     Arc::new(Config::default())
 }
 
-/// Create an InflightActivationStore instance
-pub async fn create_test_store(adapter: &str) -> Arc<dyn InflightActivationStore> {
+/// Create an ActivationStore instance
+pub async fn create_test_store(adapter: &str) -> Arc<dyn ActivationStore> {
     match adapter {
         "sqlite" => Arc::new(
             SqliteActivationStore::new(
                 &generate_temp_filename(),
-                InflightActivationStoreConfig::from_config(&create_integration_config()),
+                ActivationStoreConfig::from_config(&create_integration_config()),
             )
             .await
             .unwrap(),
-        ) as Arc<dyn InflightActivationStore>,
+        ) as Arc<dyn ActivationStore>,
         "postgres" => {
             let store = Arc::new(
                 PostgresActivationStore::new(PostgresActivationStoreConfig::from_config(
@@ -289,7 +287,7 @@ pub async fn create_test_store(adapter: &str) -> Arc<dyn InflightActivationStore
                 ))
                 .await
                 .unwrap(),
-            ) as Arc<dyn InflightActivationStore>;
+            ) as Arc<dyn ActivationStore>;
             store.assign_partitions(vec![0]).unwrap();
             store
         }
@@ -433,7 +431,7 @@ pub async fn consume_topic(
     results
 }
 
-pub fn replace_retry_state(inflight: &mut InflightActivation, retry: Option<RetryState>) {
+pub fn replace_retry_state(inflight: &mut Activation, retry: Option<RetryState>) {
     let mut activation = TaskActivation::decode(&inflight.activation as &[u8]).unwrap();
     activation.retry_state = retry;
     inflight.activation = activation.encode_to_vec();
@@ -445,7 +443,7 @@ pub fn replace_retry_state(inflight: &mut InflightActivation, retry: Option<Retr
     }
 }
 
-/// Helper struct for asserting counts on the InflightActivationStore.
+/// Helper struct for asserting counts on the ActivationStore.
 #[derive(Default)]
 pub struct StatusCount {
     pub pending: usize,
@@ -457,12 +455,12 @@ pub struct StatusCount {
     pub failure: usize,
 }
 
-/// Assert the state of all counts in the inflight activation store.
-pub async fn assert_counts(expected: StatusCount, store: &dyn InflightActivationStore) {
+/// Assert the state of all counts in the activation store.
+pub async fn assert_counts(expected: StatusCount, store: &dyn ActivationStore) {
     assert_eq!(
         expected.pending,
         store
-            .count_by_status(InflightActivationStatus::Pending)
+            .count_by_status(ActivationStatus::Pending)
             .await
             .unwrap(),
         "difference in pending count",
@@ -470,7 +468,7 @@ pub async fn assert_counts(expected: StatusCount, store: &dyn InflightActivation
     assert_eq!(
         expected.claimed,
         store
-            .count_by_status(InflightActivationStatus::Claimed)
+            .count_by_status(ActivationStatus::Claimed)
             .await
             .unwrap(),
         "difference in claimed count",
@@ -478,7 +476,7 @@ pub async fn assert_counts(expected: StatusCount, store: &dyn InflightActivation
     assert_eq!(
         expected.processing,
         store
-            .count_by_status(InflightActivationStatus::Processing)
+            .count_by_status(ActivationStatus::Processing)
             .await
             .unwrap(),
         "difference in processing count",
@@ -486,7 +484,7 @@ pub async fn assert_counts(expected: StatusCount, store: &dyn InflightActivation
     assert_eq!(
         expected.retry,
         store
-            .count_by_status(InflightActivationStatus::Retry)
+            .count_by_status(ActivationStatus::Retry)
             .await
             .unwrap(),
         "difference in retry count",
@@ -494,7 +492,7 @@ pub async fn assert_counts(expected: StatusCount, store: &dyn InflightActivation
     assert_eq!(
         expected.delayed,
         store
-            .count_by_status(InflightActivationStatus::Delay)
+            .count_by_status(ActivationStatus::Delay)
             .await
             .unwrap(),
         "difference in delay count",
@@ -502,7 +500,7 @@ pub async fn assert_counts(expected: StatusCount, store: &dyn InflightActivation
     assert_eq!(
         expected.complete,
         store
-            .count_by_status(InflightActivationStatus::Complete)
+            .count_by_status(ActivationStatus::Complete)
             .await
             .unwrap(),
         "difference in complete count",
@@ -510,7 +508,7 @@ pub async fn assert_counts(expected: StatusCount, store: &dyn InflightActivation
     assert_eq!(
         expected.failure,
         store
-            .count_by_status(InflightActivationStatus::Failure)
+            .count_by_status(ActivationStatus::Failure)
             .await
             .unwrap(),
         "difference in failure count",

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -17,8 +17,8 @@ use uuid::Uuid;
 
 use crate::config::Config;
 use crate::store::activation::{Activation, ActivationBuilder, ActivationStatus};
-use crate::store::adapters::postgres::{PostgresActivationStore, PostgresActivationStoreConfig};
-use crate::store::adapters::sqlite::{ActivationStoreConfig, SqliteActivationStore};
+use crate::store::adapters::postgres::{PostgresStore, PostgresStoreConfig};
+use crate::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig};
 use crate::store::traits::ActivationStore;
 
 /// Builder for `TaskActivation`. We cannot generate a builder automatically because `TaskActivation` is defined in `sentry-protos`.
@@ -273,16 +273,16 @@ pub fn create_config() -> Arc<Config> {
 pub async fn create_test_store(adapter: &str) -> Arc<dyn ActivationStore> {
     match adapter {
         "sqlite" => Arc::new(
-            SqliteActivationStore::new(
+            SqliteStore::new(
                 &generate_temp_filename(),
-                ActivationStoreConfig::from_config(&create_integration_config()),
+                SqliteStoreConfig::from_config(&create_integration_config()),
             )
             .await
             .unwrap(),
         ) as Arc<dyn ActivationStore>,
         "postgres" => {
             let store = Arc::new(
-                PostgresActivationStore::new(PostgresActivationStoreConfig::from_config(
+                PostgresStore::new(PostgresStoreConfig::from_config(
                     &create_integration_config(),
                 ))
                 .await

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -19,13 +19,13 @@ use uuid::Uuid;
 use crate::SERVICE_NAME;
 use crate::config::Config;
 use crate::runtime_config::RuntimeConfigManager;
-use crate::store::traits::InflightActivationStore;
+use crate::store::traits::ActivationStore;
 
 /// The upkeep task that periodically performs upkeep
-/// on the inflight store
+/// on the activation store
 pub async fn upkeep(
     config: Arc<Config>,
-    store: Arc<dyn InflightActivationStore>,
+    store: Arc<dyn ActivationStore>,
     startup_time: DateTime<Utc>,
     runtime_config_manager: Arc<RuntimeConfigManager>,
     health_reporter: HealthReporter,
@@ -121,7 +121,7 @@ impl UpkeepResults {
 )]
 pub async fn do_upkeep(
     config: Arc<Config>,
-    store: Arc<dyn InflightActivationStore>,
+    store: Arc<dyn ActivationStore>,
     producer: Arc<FutureProducer>,
     startup_time: DateTime<Utc>,
     runtime_config_manager: Arc<RuntimeConfigManager>,
@@ -464,7 +464,7 @@ pub async fn do_upkeep(
     // Forwarded tasks
     metrics::counter!("upkeep.forwarded_tasks").increment(result_context.forwarded);
 
-    // State of inflight tasks
+    // State of activations
     metrics::gauge!("upkeep.current_pending_tasks").set(result_context.pending);
     metrics::gauge!("upkeep.current_claimed_tasks").set(result_context.claimed);
     metrics::gauge!("upkeep.current_processing_tasks").set(result_context.processing);
@@ -481,7 +481,7 @@ pub async fn do_upkeep(
     result_context
 }
 
-/// Create a new activation that is a 'retry' of the passed inflight_activation
+/// Create a new activation that is a 'retry' of the passed activation
 /// The retry_state.attempts is advanced as part of the retry state machine.
 #[instrument(skip_all)]
 fn create_retry_activation(activation: &TaskActivation) -> TaskActivation {
@@ -555,7 +555,7 @@ mod tests {
 
     use crate::config::Config;
     use crate::runtime_config::RuntimeConfigManager;
-    use crate::store::activation::InflightActivationStatus;
+    use crate::store::activation::ActivationStatus;
     use crate::test_utils::{
         StatusCount, assert_counts, consume_topic, create_config,
         create_integration_config_with_topic, create_producer, create_test_store, make_activations,
@@ -687,7 +687,7 @@ mod tests {
             activation.parameters = r#"{"a":"b"}"#.into();
         }
         activation.delay = Some(30);
-        records[0].status = InflightActivationStatus::Retry;
+        records[0].status = ActivationStatus::Retry;
         records[0].delay_until = Some(Utc::now() + Duration::from_secs(30));
         records[0].activation = activation.encode_to_vec();
 
@@ -750,7 +750,7 @@ mod tests {
 
         let mut batch = make_activations(2);
         // Make a task with a future processing deadline
-        batch[1].status = InflightActivationStatus::Processing;
+        batch[1].status = ActivationStatus::Processing;
         batch[1].processing_deadline = Some(Utc::now() + TimeDelta::minutes(5));
         assert!(store.store(batch.clone()).await.is_ok());
 
@@ -767,7 +767,7 @@ mod tests {
         // Should retain the processing record
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Processing)
+                .count_by_status(ActivationStatus::Processing)
                 .await
                 .unwrap(),
             1
@@ -786,7 +786,7 @@ mod tests {
 
         let mut batch = make_activations(2);
         // Make a task past with a processing deadline in the past
-        batch[1].status = InflightActivationStatus::Processing;
+        batch[1].status = ActivationStatus::Processing;
         batch[1].processing_deadline =
             Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
         assert!(store.store(batch.clone()).await.is_ok());
@@ -794,7 +794,7 @@ mod tests {
         // Should start off with one in processing
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Processing)
+                .count_by_status(ActivationStatus::Processing)
                 .await
                 .unwrap(),
             1
@@ -842,7 +842,7 @@ mod tests {
 
         let mut batch = make_activations(2);
         // Make a task past with a processing deadline in the past
-        batch[1].status = InflightActivationStatus::Processing;
+        batch[1].status = ActivationStatus::Processing;
         batch[1].processing_deadline =
             Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
         batch[1].processing_attempts = 0;
@@ -851,14 +851,14 @@ mod tests {
         // Should start off with one in processing
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Processing)
+                .count_by_status(ActivationStatus::Processing)
                 .await
                 .unwrap(),
             1
         );
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Pending)
+                .count_by_status(ActivationStatus::Pending)
                 .await
                 .unwrap(),
             1
@@ -911,7 +911,7 @@ mod tests {
                 delay_on_retry: None,
             }),
         );
-        batch[1].status = InflightActivationStatus::Processing;
+        batch[1].status = ActivationStatus::Processing;
         batch[1].processing_deadline =
             Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
         batch[1].at_most_once = true;
@@ -956,7 +956,7 @@ mod tests {
         // Because 1 is complete and has a higher offset than 0, index 2 can be discarded
         batch[0].processing_attempts = config.max_processing_attempts as i32;
 
-        batch[1].status = InflightActivationStatus::Complete;
+        batch[1].status = ActivationStatus::Complete;
         batch[1].added_at += Duration::from_secs(1);
 
         batch[2].processing_attempts = config.max_processing_attempts as i32;
@@ -978,7 +978,7 @@ mod tests {
         assert_eq!(result_context.completed, 3); // all three are removed as completed
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Pending)
+                .count_by_status(ActivationStatus::Pending)
                 .await
                 .unwrap(),
             0,
@@ -986,7 +986,7 @@ mod tests {
         );
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Complete)
+                .count_by_status(ActivationStatus::Complete)
                 .await
                 .unwrap(),
             0,
@@ -1021,7 +1021,7 @@ mod tests {
                 delay_on_retry: None,
             }),
         );
-        records[0].status = InflightActivationStatus::Failure;
+        records[0].status = ActivationStatus::Failure;
         records[1].added_at += Duration::from_secs(1);
         assert!(store.store(records.clone()).await.is_ok());
 
@@ -1067,7 +1067,7 @@ mod tests {
         let mut last_vacuum = Instant::now();
 
         let mut batch = make_activations(2);
-        batch[0].status = InflightActivationStatus::Failure;
+        batch[0].status = ActivationStatus::Failure;
         batch[1].added_at += Duration::from_secs(1);
         assert!(store.store(batch).await.is_ok());
 
@@ -1090,7 +1090,7 @@ mod tests {
         );
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Pending)
+                .count_by_status(ActivationStatus::Pending)
                 .await
                 .unwrap(),
             1,
@@ -1113,7 +1113,7 @@ mod tests {
         let mut batch = make_activations(4);
 
         batch[0].expires_at = Some(Utc::now() - Duration::from_secs(100));
-        batch[1].status = InflightActivationStatus::Complete;
+        batch[1].status = ActivationStatus::Complete;
         batch[2].expires_at = Some(Utc::now() - Duration::from_secs(100));
 
         // Ensure the fourth task is in the future
@@ -1135,7 +1135,7 @@ mod tests {
         assert_eq!(result_context.completed, 1); // 1 complete
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Pending)
+                .count_by_status(ActivationStatus::Pending)
                 .await
                 .unwrap(),
             1,
@@ -1143,7 +1143,7 @@ mod tests {
         );
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Complete)
+                .count_by_status(ActivationStatus::Complete)
                 .await
                 .unwrap(),
             0,
@@ -1182,23 +1182,23 @@ mod tests {
 
         let mut batch = make_activations(2);
 
-        batch[0].status = InflightActivationStatus::Delay;
+        batch[0].status = ActivationStatus::Delay;
         batch[0].delay_until = Some(Utc::now() - Duration::from_secs(1));
 
-        batch[1].status = InflightActivationStatus::Delay;
+        batch[1].status = ActivationStatus::Delay;
         batch[1].delay_until = Some(Utc::now() + Duration::from_secs(1));
 
         assert!(store.store(batch.clone()).await.is_ok());
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Delay)
+                .count_by_status(ActivationStatus::Delay)
                 .await
                 .unwrap(),
             2
         );
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Pending)
+                .count_by_status(ActivationStatus::Pending)
                 .await
                 .unwrap(),
             0
@@ -1215,7 +1215,7 @@ mod tests {
         assert_eq!(result_context.delay_elapsed, 1);
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Pending)
+                .count_by_status(ActivationStatus::Pending)
                 .await
                 .unwrap(),
             1
@@ -1247,7 +1247,7 @@ mod tests {
         assert_eq!(result_context.delay_elapsed, 1);
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Pending)
+                .count_by_status(ActivationStatus::Pending)
                 .await
                 .unwrap(),
             1
@@ -1304,7 +1304,7 @@ demoted_namespaces:
         assert_eq!(result_context.forwarded, 2);
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Pending)
+                .count_by_status(ActivationStatus::Pending)
                 .await
                 .unwrap(),
             4,
@@ -1312,7 +1312,7 @@ demoted_namespaces:
         );
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Complete)
+                .count_by_status(ActivationStatus::Complete)
                 .await
                 .unwrap(),
             2,
@@ -1365,7 +1365,7 @@ demoted_namespaces:
         assert_eq!(result_context.killswitched, 3);
         assert_eq!(
             store
-                .count_by_status(InflightActivationStatus::Pending)
+                .count_by_status(ActivationStatus::Pending)
                 .await
                 .unwrap(),
             3


### PR DESCRIPTION
## Summary
- Rename Rust types `InflightActivation`, `InflightActivationStore` (trait), `InflightActivationStatus`, `InflightActivationBuilder`, `InflightActivationStoreConfig`, `InflightActivationBatcher`, `InflightActivationWriter` to their unprefixed equivalents.
- Rename `src/kafka/inflight_activation_{batcher,writer}.rs` to `activation_{batcher,writer}.rs`.
- Update doc comments, the AGENTS.md style example, and `bench_InflightActivationStore` → `bench_ActivationStore`.

The `Inflight` prefix wasn't actually disambiguating against anything — the only nearby type is the protobuf `TaskActivation`, and the `TaskActivation` vs `Activation` contrast reads more clearly without the extra modifier.

## Intentionally not changed
- The `inflight_taskactivations` SQL table and migration filenames (renaming would require a new migration and is out of scope).
- The Python `InflightTaskActivation` wrapper — `Inflight` had to stay because dropping just it would collide with the imported protobuf `TaskActivation`.
- Metric names (`consumer.inflight_activation_writer.*`) — kept the old names to avoid breaking dashboards/alerts.
- Local variable names like `inflight`, `inflight_opt`, `inflight_msgs`, and the `taskbroker-inflight.sqlite` default path.
- Persisted DB status strings (unchanged because `Display`/`FromStr` for `ActivationStatus` use the variant names, which weren't renamed).

## Test plan
- [x] `cargo check --all-targets`
- [x] `cargo build --release`
- [x] `cargo test --lib` (246 passed, 0 failed)
- [x] `make format`
- [x] `make lint`
- [x] Integration tests in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)