### PR TITLE
feat(taskbroker): Add kafka_consume_retry_topic config flag

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,12 @@ pub struct Config {
     /// Required for raw_mode where the main topic has other consumers.
     pub kafka_retry_topic: Option<String>,
 
+    /// Whether to consume from the retry topic.
+    /// When false (default), this taskbroker only produces to the retry topic
+    /// but does not consume from it, allowing the retry topic to be shared
+    /// across multiple taskbroker instances.
+    pub kafka_consume_retry_topic: bool,
+
     /// The default number of partitions for a topic
     pub default_topic_partitions: i32,
 
@@ -377,6 +383,7 @@ impl Default for Config {
             kafka_deadletter_ssl_certificate_location: None,
             kafka_deadletter_ssl_key_location: None,
             kafka_retry_topic: None,
+            kafka_consume_retry_topic: false,
             default_topic_partitions: 1,
             kafka_session_timeout_ms: 6000,
             kafka_auto_commit_interval_ms: 5000,

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,8 +171,10 @@ async fn main() -> Result<(), Error> {
 
         // Build list of topics to consume from
         let mut topics_to_consume = vec![consumer_config.kafka_topic.clone()];
-        if let Some(ref retry_topic) = consumer_config.kafka_retry_topic {
-            topics_to_consume.push(retry_topic.clone());
+        if consumer_config.kafka_consume_retry_topic {
+            if let Some(ref retry_topic) = consumer_config.kafka_retry_topic {
+                topics_to_consume.push(retry_topic.clone());
+            }
         }
 
         async move {

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,10 +171,10 @@ async fn main() -> Result<(), Error> {
 
         // Build list of topics to consume from
         let mut topics_to_consume = vec![consumer_config.kafka_topic.clone()];
-        if consumer_config.kafka_consume_retry_topic {
-            if let Some(ref retry_topic) = consumer_config.kafka_retry_topic {
-                topics_to_consume.push(retry_topic.clone());
-            }
+        if consumer_config.kafka_consume_retry_topic
+            && let Some(ref retry_topic) = consumer_config.kafka_retry_topic
+        {
+            topics_to_consume.push(retry_topic.clone());
         }
 
         async move {


### PR DESCRIPTION
## Summary
- Add `kafka_consume_retry_topic` config flag (default: false)
- Allows sharing the retry topic across multiple taskbroker instances for s4s2

ref STREAM-1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)