### PR TITLE
feat(taskbroker): Refactor Worker Abstraction

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -326,12 +326,6 @@ pub struct Config {
     /// Maximum milliseconds to wait before flushing a batch of status updates.
     pub status_update_interval_ms: u64,
 
-    /// The hostname used to construct `callback_url` for task push requests.
-    pub callback_addr: String,
-
-    /// The port used to construct `callback_url` for task push requests.
-    pub callback_port: u32,
-
     /// Maps every application to its worker endpoint, both represented as strings.
     pub worker_map: BTreeMap<String, String>,
 
@@ -443,8 +437,6 @@ impl Default for Config {
             batch_status_updates: false,
             status_update_batch_size: 1,
             status_update_interval_ms: 100,
-            callback_addr: "0.0.0.0".into(),
-            callback_port: 50051,
             worker_map: [("sentry".into(), "http://127.0.0.1:50052".into())].into(),
             raw_mode: false,
             raw_namespace: None,
@@ -935,50 +927,6 @@ mod tests {
             };
             let config = Config::from_args(&args).unwrap();
             assert_eq!(config.delivery_mode, DeliveryMode::Push);
-
-            Ok(())
-        });
-    }
-
-    #[test]
-    fn test_default_push_callback_fields() {
-        let config = Config::default();
-        assert_eq!(config.callback_addr, "0.0.0.0");
-        assert_eq!(config.callback_port, 50051);
-    }
-
-    #[test]
-    fn test_from_args_push_callback_fields_from_env() {
-        Jail::expect_with(|jail| {
-            jail.set_env("TASKBROKER_CALLBACK_ADDR", "127.0.0.1");
-            jail.set_env("TASKBROKER_CALLBACK_PORT", "51000");
-
-            let args = Args { config: None };
-            let config = Config::from_args(&args).unwrap();
-            assert_eq!(config.callback_addr, "127.0.0.1");
-            assert_eq!(config.callback_port, 51000);
-
-            Ok(())
-        });
-    }
-
-    #[test]
-    fn test_from_args_push_callback_fields_from_config_file() {
-        Jail::expect_with(|jail| {
-            jail.create_file(
-                "config.yaml",
-                r#"
-                callback_addr: 10.0.0.1
-                callback_port: 52000
-            "#,
-            )?;
-
-            let args = Args {
-                config: Some("config.yaml".to_owned()),
-            };
-            let config = Config::from_args(&args).unwrap();
-            assert_eq!(config.callback_addr, "10.0.0.1");
-            assert_eq!(config.callback_port, 52000);
 
             Ok(())
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod store;
 pub mod test_utils;
 pub mod tokio;
 pub mod upkeep;
+pub mod worker;
 
 /// Name of the grpc service.
 /// Using the service type to get a name wasn't working across modules.

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,7 +290,7 @@ async fn main() -> Result<(), Error> {
         let mut workers: Vec<WorkerMap> = vec![];
 
         // For every push thread, create a map from applications to worker connections
-        for _ in 0..config.push_threads {
+        for _ in 0..config.push_threads.max(1) {
             let mut map = HashMap::new();
 
             for (application, endpoint) in config.worker_map.clone() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -5,6 +6,7 @@ use anyhow::{Error, anyhow};
 use chrono::Utc;
 use clap::Parser;
 use sentry_protos::taskbroker::v1::consumer_service_server::ConsumerServiceServer;
+use taskbroker::worker::{Worker, WorkerClient, WorkerMap};
 use tokio::signal::unix::SignalKind;
 use tokio::task::JoinHandle;
 use tokio::{select, time};
@@ -285,7 +287,32 @@ async fn main() -> Result<(), Error> {
 
     // Initialize push threads
     let push_task = if config.delivery_mode == DeliveryMode::Push {
-        Some(tokio::spawn(async move { push_pool.start().await }))
+        let mut workers: Vec<WorkerMap> = vec![];
+
+        // For every push thread, create a map from applications to worker connections
+        for _ in 0..config.push_threads {
+            let mut map = HashMap::new();
+
+            for (application, endpoint) in config.worker_map.clone() {
+                let worker = match Worker::connect(config.clone(), endpoint).await {
+                    Ok(w) => {
+                        debug!("Connected to worker!");
+                        Box::new(w) as Box<dyn WorkerClient>
+                    }
+
+                    Err(e) => {
+                        error!(error = ?e, "Failed to connect to worker");
+                        return Err(e);
+                    }
+                };
+
+                map.insert(application, worker);
+            }
+
+            workers.push(map);
+        }
+
+        Some(tokio::spawn(async move { push_pool.start(workers).await }))
     } else {
         None
     };

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -166,9 +166,13 @@ async fn push_task(
         return;
     };
 
-    match worker.push_task(activation.clone()).await {
+    let start = Instant::now();
+    let result = worker.push_task(activation.clone()).await;
+    metrics::histogram!("worker.push_task.duration").record(start.elapsed());
+
+    match result {
         Ok(_) => {
-            metrics::counter!("push.push_task", "result" => "ok").increment(1);
+            metrics::counter!("worker.push_task", "result" => "ok").increment(1);
             debug!(task_id = %id, "Activation sent to worker");
 
             if activation.processing_attempts < 1 {
@@ -202,7 +206,7 @@ async fn push_task(
 
         // Once claim expires, status will be set back to pending
         Err(e) => {
-            metrics::counter!("push.push_task", "result" => "error").increment(1);
+            metrics::counter!("worker.push_task", "result" => "error").increment(1);
 
             error!(
                 task_id = %id,

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -1,50 +1,19 @@
 use chrono::Utc;
 use std::cmp::max;
-use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use async_backtrace::framed;
 use elegant_departure::get_shutdown_guard;
 use flume::{Receiver, SendError, Sender};
-use hmac::{Hmac, Mac};
-use prost::Message;
-use sentry_protos::taskbroker::v1::worker_service_client::WorkerServiceClient;
-use sentry_protos::taskbroker::v1::{PushTaskRequest, TaskActivation};
-use sha2::Sha256;
 use tokio::task::JoinSet;
-use tonic::async_trait;
-use tonic::metadata::MetadataValue;
-use tonic::transport::Channel;
 use tracing::{debug, error, info};
 
 use crate::config::Config;
 use crate::store::activation::Activation;
 use crate::store::traits::ActivationStore;
-
-type HmacSha256 = Hmac<Sha256>;
-
-type WorkerFactory = Arc<
-    dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<Box<dyn WorkerClient + Send>>> + Send>>
-        + Send
-        + Sync,
->;
-
-/// gRPC path for `WorkerService::PushTask` — keep in sync with `sentry_protos` generated client.
-const WORKER_PUSH_TASK_PATH: &str = "/sentry_protos.taskbroker.v1.WorkerService/PushTask";
-
-/// HMAC-SHA256(secret, grpc_path + ":" + message), hex-encoded. Matches Python `RequestSignatureInterceptor` and broker [`crate::grpc::auth_middleware`].
-fn sentry_signature_hex(secret: &str, grpc_path: &str, message: &[u8]) -> String {
-    let mut mac =
-        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts keys of any length");
-    mac.update(grpc_path.as_bytes());
-    mac.update(b":");
-    mac.update(message);
-    hex::encode(mac.finalize().into_bytes())
-}
+use crate::worker::WorkerMap;
 
 /// Error returned when enqueueing an activation for the push workers fails.
 #[derive(Debug)]
@@ -55,41 +24,6 @@ pub enum PushError {
 
     /// Channel disconnected (no receivers) or another failure.
     Channel(SendError<(Activation, Instant)>),
-}
-
-/// Thin interface for the worker client. It mostly serves to enable proper unit testing, but it also decouples the actual client implementation from our pushing logic.
-#[async_trait]
-trait WorkerClient {
-    /// Send a single `PushTaskRequest` to the worker service.
-    /// When `grpc_shared_secret` is not empty, it signs the request with `grpc_shared_secret[0]` and sets `sentry-signature` metadata (same scheme as Python pull client and broker `AuthLayer`).
-    async fn send(&mut self, request: PushTaskRequest, grpc_shared_secret: &[String])
-    -> Result<()>;
-}
-
-#[async_trait]
-impl WorkerClient for WorkerServiceClient<Channel> {
-    #[framed]
-    async fn send(
-        &mut self,
-        request: PushTaskRequest,
-        grpc_shared_secret: &[String],
-    ) -> Result<()> {
-        let mut req = tonic::Request::new(request);
-
-        if let Some(secret) = grpc_shared_secret.first() {
-            let body = req.get_ref().encode_to_vec();
-            let signature = sentry_signature_hex(secret, WORKER_PUSH_TASK_PATH, &body);
-            let value = MetadataValue::try_from(signature.as_str())
-                .context("sentry-signature metadata value must be valid ASCII")?;
-            req.metadata_mut().insert("sentry-signature", value);
-        }
-
-        self.push_task(req)
-            .await
-            .map_err(|status| anyhow::anyhow!(status))?;
-
-        Ok(())
-    }
 }
 
 /// Wrapper around `config.push_threads` asynchronous tasks, each of which receives an activation from the channel, sends it to the worker service, and repeats.
@@ -105,84 +39,37 @@ pub struct PushPool {
 
     /// Activation store, which we need for marking tasks as sent.
     store: Arc<dyn ActivationStore>,
-
-    worker_factory: WorkerFactory,
 }
 
 impl PushPool {
     /// Initialize a new push pool.
     pub fn new(config: Arc<Config>, store: Arc<dyn ActivationStore>) -> Self {
-        let worker_factory: WorkerFactory = Arc::new(|endpoint: String| {
-            Box::pin(async move {
-                let client = WorkerServiceClient::connect(endpoint).await?;
-                Ok(Box::new(client) as Box<dyn WorkerClient + Send>)
-            })
-        });
-        Self::new_with_factory(config, store, worker_factory)
-    }
-
-    fn new_with_factory(
-        config: Arc<Config>,
-        store: Arc<dyn ActivationStore>,
-        worker_factory: WorkerFactory,
-    ) -> Self {
         let (sender, receiver) = flume::bounded(config.push_queue_size);
+
         Self {
             sender,
             receiver,
             config,
             store,
-            worker_factory,
         }
     }
 
     /// Spawn `config.push_threads` asynchronous tasks, each of which repeatedly moves pending activations from the channel to the worker service until the shutdown signal is received.
     #[framed]
-    pub async fn start(&self) -> Result<()> {
-        let store = self.store.clone();
-        let worker_factory = self.worker_factory.clone();
-        let mut push_pool: JoinSet<Result<()>> = crate::tokio::spawn_pool(
-            self.config.push_threads,
-            |_| {
-                let worker_map = self.config.worker_map.clone();
+    pub async fn start(&self, workers: Vec<WorkerMap>) -> Result<()> {
+        let mut workers = workers.into_iter();
+
+        let mut push_pool: JoinSet<Result<()>> =
+            crate::tokio::spawn_pool(self.config.push_threads, |_| {
                 let receiver = self.receiver.clone();
-                let store = store.clone();
-                let worker_factory = worker_factory.clone();
+                let store = self.store.clone();
+
+                let mut workers = workers.next().unwrap();
 
                 let guard = get_shutdown_guard().shutdown_on_drop();
 
-                let callback_url = format!(
-                    "{}:{}",
-                    self.config.callback_addr, self.config.callback_port
-                );
-
-                let timeout = Duration::from_millis(self.config.push_timeout_ms);
-                let grpc_shared_secret = self.config.grpc_shared_secret.clone();
-
                 async_backtrace::frame!(async move {
                     metrics::counter!("push.worker.connect.attempt").increment(1);
-
-                    let mut workers: HashMap<String, Box<dyn WorkerClient + Send>> = HashMap::new();
-
-                    for (application, endpoint) in worker_map.clone() {
-                        let worker = match worker_factory(endpoint).await {
-                            Ok(w) => {
-                                metrics::counter!("push.worker.connect", "result" => "ok", "application" => application.clone())
-                                    .increment(1);
-                                w
-                            }
-
-                            Err(e) => {
-                                metrics::counter!("push.worker.connect", "result" => "error", "application" => application.clone())
-                                    .increment(1);
-                                error!(error = ?e, "Failed to connect to worker");
-
-                                return Err(e);
-                            }
-                        };
-
-                        workers.insert(application, worker);
-                    }
 
                     loop {
                         tokio::select! {
@@ -202,141 +89,19 @@ impl PushPool {
 
                                 metrics::histogram!("push.queue.latency").record(time.elapsed());
 
-                                let id = activation.id.clone();
-                                let callback_url = callback_url.clone();
-
-                                let Some(worker) = workers.get_mut(&activation.application) else {
-                                    metrics::counter!("push.missing_worker_mapping", "application" => activation.application.clone()).increment(1);
-
-                                    error!(
-                                        task_id = %id,
-                                        application = activation.application,
-                                        "Task application has no worker pool mapping"
-                                    );
-
-                                    continue;
-                                };
-
-                                match push_task(
-                                    worker.as_mut(),
-                                    activation.clone(),
-                                    callback_url,
-                                    timeout,
-                                    grpc_shared_secret.as_slice(),
-                                )
-                                .await
-                                {
-                                    Ok(_) => {
-                                        metrics::counter!("push.push_task", "result" => "ok").increment(1);
-                                        debug!(task_id = %id, "Activation sent to worker");
-
-                                        if activation.processing_attempts < 1 {
-                                            let latency = max(0, activation.received_latency(Utc::now()));
-
-                                            metrics::histogram!(
-                                                "push.received_to_push.latency",
-                                                "namespace" => activation.namespace,
-                                                "taskname" => activation.taskname,
-                                            )
-                                            .record(latency as f64);
-                                        } else {
-                                            debug!(task_id = %id, namespace = activation.namespace, taskname = activation.taskname, "Activation already processed, skipping received → push latency recording");
-                                        }
-
-                                        let start = Instant::now();
-                                        let result = store.mark_activation_processing(&id).await;
-                                        metrics::histogram!("push.mark_activation_processing.duration").record(start.elapsed());
-
-                                        if let Err(e) = result {
-                                            metrics::counter!("push.mark_activation_processing", "result" => "error").increment(1);
-
-                                            error!(
-                                                task_id = %id,
-                                                error = ?e,
-                                                "Failed to mark activation as sent after push"
-                                            );
-                                        }
-                                    }
-
-                                    // Once claim expires, status will be set back to pending
-                                    Err(e) => {
-                                        metrics::counter!("push.push_task", "result" => "error").increment(1);
-
-                                        error!(
-                                            task_id = %id,
-                                            error = ?e,
-                                            "Failed to send activation to worker"
-                                        )
-                                    }
-                                };
+                                push_task(store.clone(), &mut workers, activation).await;
                             }
                         }
                     }
 
                     // Drain channel before exiting without recording duration metrics since they don't matter at this time
                     for (activation, _) in receiver.drain() {
-                        let id = activation.id.clone();
-                        let callback_url = callback_url.clone();
-
-                        let Some(worker) = workers.get_mut(&activation.application) else {
-                            metrics::counter!("push.missing_worker_mapping", "application" => activation.application.clone()).increment(1);
-
-                            error!(
-                                task_id = %id,
-                                application = activation.application,
-                                "Task application has no worker pool mapping"
-                            );
-
-                            continue;
-                        };
-
-                        match push_task(
-                            worker.as_mut(),
-                            activation,
-                            callback_url,
-                            timeout,
-                            grpc_shared_secret.as_slice(),
-                        )
-                        .await
-                        {
-                            Ok(_) => {
-                                metrics::counter!("push.push_task", "result" => "ok").increment(1);
-                                debug!(task_id = %id, "Activation sent to worker");
-
-                                let start = Instant::now();
-                                let result = store.mark_activation_processing(&id).await;
-                                metrics::histogram!("push.mark_activation_processing.duration")
-                                    .record(start.elapsed());
-
-                                if let Err(e) = result {
-                                    metrics::counter!("push.mark_activation_processing", "result" => "error").increment(1);
-
-                                    error!(
-                                        task_id = %id,
-                                        error = ?e,
-                                        "Failed to mark activation as processing after push"
-                                    );
-                                }
-                            }
-
-                            // Once processing deadline expires, status will be set back to pending
-                            Err(e) => {
-                                metrics::counter!("push.push_task", "result" => "error")
-                                    .increment(1);
-
-                                error!(
-                                    task_id = %id,
-                                    error = ?e,
-                                    "Failed to send activation to worker"
-                                )
-                            }
-                        };
+                        push_task(store.clone(), &mut workers, activation).await;
                     }
 
                     Ok(())
                 })
-            },
-        );
+            });
 
         while let Some(result) = push_pool.join_next().await {
             match result {
@@ -385,37 +150,69 @@ impl PushPool {
 /// Decode task activation and push it to a worker.
 #[framed]
 async fn push_task(
-    worker: &mut (dyn WorkerClient + Send),
+    store: Arc<dyn ActivationStore>,
+    workers: &mut WorkerMap,
     activation: Activation,
-    callback_url: String,
-    timeout: Duration,
-    grpc_shared_secret: &[String],
-) -> Result<()> {
-    let start = Instant::now();
-    metrics::counter!("push.push_task.attempts").increment(1);
+) {
+    let id = activation.id.clone();
 
-    // Try to decode activation (if it fails, we will see the error where `push_task` is called)
-    let task = match TaskActivation::decode(&activation.activation as &[u8]) {
-        Ok(task) => task,
-        Err(err) => {
-            metrics::histogram!("push.push_task.duration").record(start.elapsed());
-            return Err(err.into());
+    let Some(worker) = workers.get_mut(&activation.application) else {
+        metrics::counter!("push.missing_worker_mapping", "application" => activation.application.clone()).increment(1);
+
+        error!(
+            task_id = %id,
+            application = activation.application,
+            "Task application has no worker pool mapping"
+        );
+
+        return;
+    };
+
+    match worker.push_task(activation.clone()).await {
+        Ok(_) => {
+            metrics::counter!("push.push_task", "result" => "ok").increment(1);
+            debug!(task_id = %id, "Activation sent to worker");
+
+            if activation.processing_attempts < 1 {
+                let latency = max(0, activation.received_latency(Utc::now()));
+
+                metrics::histogram!(
+                    "push.received_to_push.latency",
+                    "namespace" => activation.namespace,
+                    "taskname" => activation.taskname,
+                )
+                .record(latency as f64);
+            } else {
+                debug!(task_id = %id, namespace = activation.namespace, taskname = activation.taskname, "Activation already processed, skipping received → push latency recording");
+            }
+
+            let start = Instant::now();
+            let result = store.mark_activation_processing(&id).await;
+            metrics::histogram!("push.mark_activation_processing.duration").record(start.elapsed());
+
+            if let Err(e) = result {
+                metrics::counter!("push.mark_activation_processing", "result" => "error")
+                    .increment(1);
+
+                error!(
+                    task_id = %id,
+                    error = ?e,
+                    "Failed to mark activation as sent after push"
+                );
+            }
         }
-    };
 
-    let request = PushTaskRequest {
-        task: Some(task),
-        callback_url,
-    };
+        // Once claim expires, status will be set back to pending
+        Err(e) => {
+            metrics::counter!("push.push_task", "result" => "error").increment(1);
 
-    let result = match tokio::time::timeout(timeout, worker.send(request, grpc_shared_secret)).await
-    {
-        Ok(r) => r,
-        Err(e) => Err(e.into()),
-    };
-
-    metrics::histogram!("push.push_task.duration").record(start.elapsed());
-    result
+            error!(
+                task_id = %id,
+                error = ?e,
+                "Failed to send activation to worker"
+            )
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -69,8 +69,6 @@ impl PushPool {
                 let guard = get_shutdown_guard().shutdown_on_drop();
 
                 async_backtrace::frame!(async move {
-                    metrics::counter!("push.worker.connect.attempt").increment(1);
-
                     loop {
                         tokio::select! {
                             _ = guard.wait() => {

--- a/src/push/tests.rs
+++ b/src/push/tests.rs
@@ -1,9 +1,8 @@
 use std::sync::{Arc, Mutex};
 
-use anyhow::anyhow;
+use anyhow::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use sentry_protos::taskbroker::v1::PushTaskRequest;
 use tokio::sync::Notify;
 use tokio::time::{Duration, timeout};
 
@@ -12,55 +11,9 @@ use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::traits::ActivationStore;
 use crate::store::types::FailedTasksForwarder;
 use crate::test_utils::{create_test_store, make_activations};
+use crate::worker::test_worker_map;
 
 use super::*;
-
-/// Fake worker client that records requests and optionally fails.
-struct MockWorkerClient {
-    captured_requests: Vec<PushTaskRequest>,
-    should_fail: bool,
-}
-
-impl MockWorkerClient {
-    fn new(should_fail: bool) -> Self {
-        Self {
-            captured_requests: vec![],
-            should_fail,
-        }
-    }
-}
-
-#[async_trait]
-impl WorkerClient for MockWorkerClient {
-    async fn send(
-        &mut self,
-        request: PushTaskRequest,
-        _grpc_shared_secret: &[String],
-    ) -> Result<()> {
-        self.captured_requests.push(request);
-        if self.should_fail {
-            return Err(anyhow!("mock send failure"));
-        }
-        Ok(())
-    }
-}
-
-/// Fake worker client that fires a Notify when send() is called.
-struct NotifyingWorkerClient {
-    should_fail: bool,
-    notify: Arc<Notify>,
-}
-
-#[async_trait]
-impl WorkerClient for NotifyingWorkerClient {
-    async fn send(&mut self, _request: PushTaskRequest, _: &[String]) -> Result<()> {
-        self.notify.notify_one();
-        if self.should_fail {
-            return Err(anyhow!("mock send failure"));
-        }
-        Ok(())
-    }
-}
 
 /// Minimal fake store that records which activation IDs have been marked as processing.
 #[derive(Default, Clone)]
@@ -76,12 +29,14 @@ impl MockStore {
 
 #[async_trait]
 impl ActivationStore for MockStore {
-    async fn store(&self, _batch: Vec<Activation>) -> anyhow::Result<u64> {
+    async fn store(&self, _batch: Vec<Activation>) -> Result<u64> {
         Ok(0)
     }
-    fn assign_partitions(&self, _partitions: Vec<i32>) -> anyhow::Result<()> {
+
+    fn assign_partitions(&self, _partitions: Vec<i32>) -> Result<()> {
         Ok(())
     }
+
     async fn claim_activations(
         &self,
         _application: Option<&str>,
@@ -89,178 +44,115 @@ impl ActivationStore for MockStore {
         _limit: Option<i32>,
         _bucket: Option<crate::store::types::BucketRange>,
         _mark_processing: bool,
-    ) -> anyhow::Result<Vec<Activation>> {
+    ) -> Result<Vec<Activation>> {
         Ok(vec![])
     }
-    async fn mark_activation_processing(&self, id: &str) -> anyhow::Result<()> {
+
+    async fn mark_activation_processing(&self, id: &str) -> Result<()> {
         self.marked_processing.lock().unwrap().push(id.to_string());
         Ok(())
     }
+
     async fn set_status(
         &self,
         _id: &str,
         _status: ActivationStatus,
         _max_attempts: Option<u32>,
         _delay_on_retry: Option<u64>,
-    ) -> anyhow::Result<Option<Activation>> {
+    ) -> Result<Option<Activation>> {
         Ok(None)
     }
-    async fn set_status_batch(
-        &self,
-        _ids: &[String],
-        _status: ActivationStatus,
-    ) -> anyhow::Result<u64> {
+
+    async fn set_status_batch(&self, _ids: &[String], _status: ActivationStatus) -> Result<u64> {
         Ok(0)
     }
+
     async fn pending_activation_max_lag(&self, _now: &DateTime<Utc>) -> f64 {
         0.0
     }
-    async fn count_by_status(&self, _status: ActivationStatus) -> anyhow::Result<usize> {
+
+    async fn count_by_status(&self, _status: ActivationStatus) -> Result<usize> {
         Ok(0)
     }
-    async fn count(&self) -> anyhow::Result<usize> {
+
+    async fn count(&self) -> Result<usize> {
         Ok(0)
     }
-    async fn get_by_id(&self, _id: &str) -> anyhow::Result<Option<Activation>> {
+
+    async fn get_by_id(&self, _id: &str) -> Result<Option<Activation>> {
         Ok(None)
     }
+
     async fn set_processing_deadline(
         &self,
         _id: &str,
         _deadline: Option<DateTime<Utc>>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<()> {
         Ok(())
     }
-    async fn delete_activation(&self, _id: &str) -> anyhow::Result<()> {
+
+    async fn delete_activation(&self, _id: &str) -> Result<()> {
         Ok(())
     }
-    async fn vacuum_db(&self) -> anyhow::Result<()> {
+
+    async fn vacuum_db(&self) -> Result<()> {
         Ok(())
     }
-    async fn full_vacuum_db(&self) -> anyhow::Result<()> {
+
+    async fn full_vacuum_db(&self) -> Result<()> {
         Ok(())
     }
-    async fn db_size(&self) -> anyhow::Result<u64> {
+
+    async fn db_size(&self) -> Result<u64> {
         Ok(0)
     }
-    async fn get_retry_activations(&self) -> anyhow::Result<Vec<Activation>> {
+
+    async fn get_retry_activations(&self) -> Result<Vec<Activation>> {
         Ok(vec![])
     }
-    async fn handle_claim_expiration(&self) -> anyhow::Result<u64> {
+
+    async fn handle_claim_expiration(&self) -> Result<u64> {
         Ok(0)
     }
-    async fn handle_processing_deadline(&self) -> anyhow::Result<u64> {
+
+    async fn handle_processing_deadline(&self) -> Result<u64> {
         Ok(0)
     }
-    async fn handle_processing_attempts(&self) -> anyhow::Result<u64> {
+
+    async fn handle_processing_attempts(&self) -> Result<u64> {
         Ok(0)
     }
-    async fn handle_expires_at(&self) -> anyhow::Result<u64> {
+
+    async fn handle_expires_at(&self) -> Result<u64> {
         Ok(0)
     }
-    async fn handle_delay_until(&self) -> anyhow::Result<u64> {
+
+    async fn handle_delay_until(&self) -> Result<u64> {
         Ok(0)
     }
-    async fn handle_failed_tasks(&self) -> anyhow::Result<FailedTasksForwarder> {
+
+    async fn handle_failed_tasks(&self) -> Result<FailedTasksForwarder> {
         Ok(FailedTasksForwarder {
             to_discard: vec![],
             to_deadletter: vec![],
         })
     }
-    async fn mark_completed(&self, _ids: Vec<String>) -> anyhow::Result<u64> {
+
+    async fn mark_completed(&self, _ids: Vec<String>) -> Result<u64> {
         Ok(0)
     }
-    async fn remove_completed(&self) -> anyhow::Result<u64> {
+
+    async fn remove_completed(&self) -> Result<u64> {
         Ok(0)
     }
-    async fn remove_killswitched(&self, _killswitched_tasks: Vec<String>) -> anyhow::Result<u64> {
+
+    async fn remove_killswitched(&self, _killswitched_tasks: Vec<String>) -> Result<u64> {
         Ok(0)
     }
-    async fn clear(&self) -> anyhow::Result<()> {
+
+    async fn clear(&self) -> Result<()> {
         Ok(())
     }
-}
-
-/// Factory that fires `notify` when send() is called, then succeeds or fails per `should_fail`.
-fn notifying_factory(should_fail: bool, notify: Arc<Notify>) -> WorkerFactory {
-    Arc::new(move |_: String| {
-        let notify = notify.clone();
-        Box::pin(async move {
-            Ok(Box::new(NotifyingWorkerClient {
-                should_fail,
-                notify,
-            }) as Box<dyn WorkerClient + Send>)
-        })
-    })
-}
-
-/// Factory that always fails to connect (simulates a broken endpoint).
-fn failing_connect_factory() -> WorkerFactory {
-    Arc::new(|_: String| Box::pin(async { Err(anyhow::anyhow!("simulated connect failure")) }))
-}
-
-#[tokio::test]
-async fn push_task_returns_ok_on_client_success() {
-    let activation = make_activations(1).remove(0);
-    let mut worker = MockWorkerClient::new(false);
-    let callback_url = "taskbroker:50051".to_string();
-
-    let result = push_task(
-        &mut worker,
-        activation.clone(),
-        callback_url.clone(),
-        Duration::from_secs(5),
-        &[],
-    )
-    .await;
-    assert!(result.is_ok(), "push_task should succeed");
-    assert_eq!(worker.captured_requests.len(), 1);
-
-    let request = &worker.captured_requests[0];
-    assert_eq!(request.callback_url, callback_url);
-    assert_eq!(
-        request.task.as_ref().map(|task| task.id.as_str()),
-        Some(activation.id.as_str())
-    );
-}
-
-#[tokio::test]
-async fn push_task_returns_err_on_invalid_payload() {
-    let mut activation = make_activations(1).remove(0);
-    activation.activation = vec![1, 2, 3, 4];
-
-    let mut worker = MockWorkerClient::new(false);
-    let result = push_task(
-        &mut worker,
-        activation,
-        "taskbroker:50051".to_string(),
-        Duration::from_secs(5),
-        &[],
-    )
-    .await;
-
-    assert!(result.is_err(), "invalid payload should fail decoding");
-    assert!(
-        worker.captured_requests.is_empty(),
-        "worker should not be called if decode fails"
-    );
-}
-
-#[tokio::test]
-async fn push_task_propagates_client_error() {
-    let activation = make_activations(1).remove(0);
-    let mut worker = MockWorkerClient::new(true);
-
-    let result = push_task(
-        &mut worker,
-        activation,
-        "taskbroker:50051".to_string(),
-        Duration::from_secs(5),
-        &[],
-    )
-    .await;
-    assert!(result.is_err(), "worker send errors should propagate");
-    assert_eq!(worker.captured_requests.len(), 1);
 }
 
 #[tokio::test]
@@ -304,34 +196,6 @@ async fn push_pool_submit_backpressures_when_queue_full() {
     );
 }
 
-#[test]
-fn sentry_signature_hex_matches_hmac_contract() {
-    let digest = sentry_signature_hex("super secret", "/test/path", b"hello");
-    assert_eq!(
-        digest,
-        "6408482d9e6d4975ada4c0302fda813c5718e571e6f9a2d6e2803cb48528044e"
-    );
-}
-
-/// When the worker factory fails to connect, start() returns an error immediately.
-#[tokio::test]
-async fn push_pool_start_worker_connect_failure_returns_error() {
-    let config = Arc::new(Config {
-        worker_map: [("sentry".into(), "unused".into())].into(),
-        push_threads: 1,
-        push_queue_size: 10,
-        ..Config::default()
-    });
-    let store = Arc::new(MockStore::default());
-    let pool = PushPool::new_with_factory(config, store, failing_connect_factory());
-
-    let result = pool.start().await;
-    assert!(
-        result.is_err(),
-        "start() should return Err when the worker factory fails to connect"
-    );
-}
-
 /// After a successful push for a first-attempt activation (processing_attempts == 0),
 /// mark_activation_processing must be called on the store.
 #[tokio::test]
@@ -344,14 +208,15 @@ async fn push_pool_start_marks_activation_processing_on_first_attempt() {
         ..Config::default()
     });
     let store = Arc::new(MockStore::default());
-    let pool = Arc::new(PushPool::new_with_factory(
-        config,
-        store.clone(),
-        notifying_factory(false, notify.clone()),
-    ));
+    let pool = Arc::new(PushPool::new(config, store.clone()));
 
     let pool_start = pool.clone();
-    tokio::spawn(async move { pool_start.start().await });
+    let worker_notify = notify.clone();
+    tokio::spawn(async move {
+        pool_start
+            .start(vec![test_worker_map(false, worker_notify)])
+            .await
+    });
 
     let activation = make_activations(1).remove(0);
     assert_eq!(activation.processing_attempts, 0);
@@ -363,7 +228,7 @@ async fn push_pool_start_marks_activation_processing_on_first_attempt() {
         .await
         .expect("submit should succeed");
 
-    // Wait for the worker to call send(), then give it time to call mark_activation_processing
+    // Wait for the worker to call push_task(), then give it time to call mark_activation_processing.
     timeout(Duration::from_secs(2), notify.notified())
         .await
         .expect("timed out waiting for push to be delivered");
@@ -388,14 +253,15 @@ async fn push_pool_start_marks_activation_processing_on_retry() {
         ..Config::default()
     });
     let store = Arc::new(MockStore::default());
-    let pool = Arc::new(PushPool::new_with_factory(
-        config,
-        store.clone(),
-        notifying_factory(false, notify.clone()),
-    ));
+    let pool = Arc::new(PushPool::new(config, store.clone()));
 
     let pool_start = pool.clone();
-    tokio::spawn(async move { pool_start.start().await });
+    let worker_notify = notify.clone();
+    tokio::spawn(async move {
+        pool_start
+            .start(vec![test_worker_map(false, worker_notify)])
+            .await
+    });
 
     let mut activation = make_activations(1).remove(0);
     activation.processing_attempts = 1;
@@ -430,14 +296,15 @@ async fn push_pool_start_does_not_mark_activation_processing_on_push_failure() {
         ..Config::default()
     });
     let store = Arc::new(MockStore::default());
-    let pool = Arc::new(PushPool::new_with_factory(
-        config,
-        store.clone(),
-        notifying_factory(true, notify.clone()),
-    ));
+    let pool = Arc::new(PushPool::new(config, store.clone()));
 
     let pool_start = pool.clone();
-    tokio::spawn(async move { pool_start.start().await });
+    let worker_notify = notify.clone();
+    tokio::spawn(async move {
+        pool_start
+            .start(vec![test_worker_map(true, worker_notify)])
+            .await
+    });
 
     let activation = make_activations(1).remove(0);
     let time = Instant::now();

--- a/src/push/tests.rs
+++ b/src/push/tests.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, Mutex};
 
-use anyhow::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use tokio::sync::Notify;
@@ -29,14 +28,12 @@ impl MockStore {
 
 #[async_trait]
 impl ActivationStore for MockStore {
-    async fn store(&self, _batch: Vec<Activation>) -> Result<u64> {
+    async fn store(&self, _batch: Vec<Activation>) -> anyhow::Result<u64> {
         Ok(0)
     }
-
-    fn assign_partitions(&self, _partitions: Vec<i32>) -> Result<()> {
+    fn assign_partitions(&self, _partitions: Vec<i32>) -> anyhow::Result<()> {
         Ok(())
     }
-
     async fn claim_activations(
         &self,
         _application: Option<&str>,
@@ -44,113 +41,94 @@ impl ActivationStore for MockStore {
         _limit: Option<i32>,
         _bucket: Option<crate::store::types::BucketRange>,
         _mark_processing: bool,
-    ) -> Result<Vec<Activation>> {
+    ) -> anyhow::Result<Vec<Activation>> {
         Ok(vec![])
     }
-
-    async fn mark_activation_processing(&self, id: &str) -> Result<()> {
+    async fn mark_activation_processing(&self, id: &str) -> anyhow::Result<()> {
         self.marked_processing.lock().unwrap().push(id.to_string());
         Ok(())
     }
-
     async fn set_status(
         &self,
         _id: &str,
         _status: ActivationStatus,
         _max_attempts: Option<u32>,
         _delay_on_retry: Option<u64>,
-    ) -> Result<Option<Activation>> {
+    ) -> anyhow::Result<Option<Activation>> {
         Ok(None)
     }
-
-    async fn set_status_batch(&self, _ids: &[String], _status: ActivationStatus) -> Result<u64> {
+    async fn set_status_batch(
+        &self,
+        _ids: &[String],
+        _status: ActivationStatus,
+    ) -> anyhow::Result<u64> {
         Ok(0)
     }
-
     async fn pending_activation_max_lag(&self, _now: &DateTime<Utc>) -> f64 {
         0.0
     }
-
-    async fn count_by_status(&self, _status: ActivationStatus) -> Result<usize> {
+    async fn count_by_status(&self, _status: ActivationStatus) -> anyhow::Result<usize> {
         Ok(0)
     }
-
-    async fn count(&self) -> Result<usize> {
+    async fn count(&self) -> anyhow::Result<usize> {
         Ok(0)
     }
-
-    async fn get_by_id(&self, _id: &str) -> Result<Option<Activation>> {
+    async fn get_by_id(&self, _id: &str) -> anyhow::Result<Option<Activation>> {
         Ok(None)
     }
-
     async fn set_processing_deadline(
         &self,
         _id: &str,
         _deadline: Option<DateTime<Utc>>,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         Ok(())
     }
-
-    async fn delete_activation(&self, _id: &str) -> Result<()> {
+    async fn delete_activation(&self, _id: &str) -> anyhow::Result<()> {
         Ok(())
     }
-
-    async fn vacuum_db(&self) -> Result<()> {
+    async fn vacuum_db(&self) -> anyhow::Result<()> {
         Ok(())
     }
-
-    async fn full_vacuum_db(&self) -> Result<()> {
+    async fn full_vacuum_db(&self) -> anyhow::Result<()> {
         Ok(())
     }
-
-    async fn db_size(&self) -> Result<u64> {
+    async fn db_size(&self) -> anyhow::Result<u64> {
         Ok(0)
     }
-
-    async fn get_retry_activations(&self) -> Result<Vec<Activation>> {
+    async fn get_retry_activations(&self) -> anyhow::Result<Vec<Activation>> {
         Ok(vec![])
     }
-
-    async fn handle_claim_expiration(&self) -> Result<u64> {
+    async fn handle_claim_expiration(&self) -> anyhow::Result<u64> {
         Ok(0)
     }
-
-    async fn handle_processing_deadline(&self) -> Result<u64> {
+    async fn handle_processing_deadline(&self) -> anyhow::Result<u64> {
         Ok(0)
     }
-
-    async fn handle_processing_attempts(&self) -> Result<u64> {
+    async fn handle_processing_attempts(&self) -> anyhow::Result<u64> {
         Ok(0)
     }
-
-    async fn handle_expires_at(&self) -> Result<u64> {
+    async fn handle_expires_at(&self) -> anyhow::Result<u64> {
         Ok(0)
     }
-
-    async fn handle_delay_until(&self) -> Result<u64> {
+    async fn handle_delay_until(&self) -> anyhow::Result<u64> {
         Ok(0)
     }
-
-    async fn handle_failed_tasks(&self) -> Result<FailedTasksForwarder> {
+    async fn handle_failed_tasks(&self) -> anyhow::Result<FailedTasksForwarder> {
         Ok(FailedTasksForwarder {
             to_discard: vec![],
             to_deadletter: vec![],
         })
     }
-
-    async fn mark_completed(&self, _ids: Vec<String>) -> Result<u64> {
+    async fn mark_completed(&self, _ids: Vec<String>) -> anyhow::Result<u64> {
         Ok(0)
     }
-
-    async fn remove_completed(&self) -> Result<u64> {
+    async fn remove_completed(&self) -> anyhow::Result<u64> {
         Ok(0)
     }
-
-    async fn remove_killswitched(&self, _killswitched_tasks: Vec<String>) -> Result<u64> {
+    async fn remove_killswitched(&self, _killswitched_tasks: Vec<String>) -> anyhow::Result<u64> {
         Ok(0)
     }
-
-    async fn clear(&self) -> Result<()> {
+    async fn clear(&self) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -3,9 +3,9 @@ use tokio::task::JoinSet;
 
 /// Spawns `max(n, 1)` tasks, each running the future produced by `f` with the task's index.
 /// Returns a [`JoinSet`] containing all spawned tasks.
-pub fn spawn_pool<F, Fut>(n: usize, f: F) -> JoinSet<Fut::Output>
+pub fn spawn_pool<F, Fut>(n: usize, mut f: F) -> JoinSet<Fut::Output>
 where
-    F: Fn(usize) -> Fut,
+    F: FnMut(usize) -> Fut,
     Fut: Future + Send + 'static,
     Fut::Output: Send,
 {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -74,14 +74,15 @@ impl Worker {
 impl WorkerClient for Worker {
     #[framed]
     async fn push_task(&mut self, activation: Activation) -> Result<()> {
+        metrics::counter!("worker.push_task.attempts").increment(1);
+
         // Try to decode activation
         let task =
             TaskActivation::decode(&activation.activation as &[u8]).map_err(|e| anyhow!(e))?;
 
-        // The callback URL isn't used by push taskworkers anymore, so we can use an empty string until it's removed from the schema
         let request = PushTaskRequest {
             task: Some(task),
-            callback_url: "".into(),
+            callback_url: "".into(), // Workers don't use this anymore, so use an empty string until field is removed from schema
         };
 
         // Wrap inside a Tonic request
@@ -177,14 +178,12 @@ pub fn test_worker_map(fail: bool, notify: Arc<Notify>) -> WorkerMap {
 
 #[cfg(test)]
 mod tests {
-    use hmac::{Hmac, Mac};
-    use sha2::Sha256;
-
     use crate::test_utils::make_activations;
 
     use super::MockWorkerClient;
     use super::WORKER_PUSH_TASK_PATH;
     use super::WorkerClient;
+    use super::sentry_signature_hex;
 
     #[tokio::test]
     async fn worker_push_task_returns_ok_on_client_success() {
@@ -223,12 +222,7 @@ mod tests {
 
     #[test]
     fn worker_sentry_signature_hex_matches_hmac_contract() {
-        let mut mac = Hmac::<Sha256>::new_from_slice(b"super secret")
-            .expect("HMAC accepts keys of any length");
-        mac.update(WORKER_PUSH_TASK_PATH.as_bytes());
-        mac.update(b":");
-        mac.update(b"hello");
-        let digest = hex::encode(mac.finalize().into_bytes());
+        let digest = sentry_signature_hex("super secret", WORKER_PUSH_TASK_PATH, b"hello");
 
         assert_eq!(
             digest,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,0 +1,238 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use async_backtrace::framed;
+use hmac::{Hmac, Mac};
+use prost::Message;
+use sentry_protos::taskbroker::v1::worker_service_client::WorkerServiceClient;
+use sentry_protos::taskbroker::v1::{PushTaskRequest, TaskActivation};
+use sha2::Sha256;
+use tonic::metadata::MetadataValue;
+use tonic::transport::Channel;
+use tonic::{Request, async_trait};
+
+use crate::config::Config;
+use crate::store::activation::Activation;
+
+#[cfg(test)]
+use tokio::sync::Notify;
+
+// Alias for ergonomics.
+pub type WorkerMap = HashMap<String, Box<dyn WorkerClient>>;
+
+/// gRPC path for `WorkerService::PushTask` that should be kept in sync with `sentry_protos` generated client.
+pub const WORKER_PUSH_TASK_PATH: &str = "/sentry_protos.taskbroker.v1.WorkerService/PushTask";
+
+/// Helper to compute HMAC-SHA256(secret, grpc_path + ":" + message) in hexadecimal. Matches Python `RequestSignatureInterceptor`.
+fn sentry_signature_hex(secret: &str, grpc_path: &str, message: &[u8]) -> String {
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("HMAC accepts keys of any length");
+    mac.update(grpc_path.as_bytes());
+    mac.update(b":");
+    mac.update(message);
+    hex::encode(mac.finalize().into_bytes())
+}
+
+/// Thin interface for the worker client. It mostly serves to enable proper unit testing,
+/// but it also decouples the actual client implementation from our pushing logic.
+#[async_trait]
+pub trait WorkerClient: Send + Sync {
+    /// Send a single activation to the worker service.
+    async fn push_task(&mut self, activation: Activation) -> Result<()>;
+}
+
+/// Wrapper around worker connection that provides authentication and timeouts.
+pub struct Worker {
+    /// Connection to the worker service.
+    client: WorkerServiceClient<Channel>,
+
+    /// List of secrets shared with the worker.
+    secrets: Vec<String>,
+
+    /// Wait this much time before giving up on a push.
+    timeout: Duration,
+}
+
+impl Worker {
+    pub async fn connect(config: Arc<Config>, endpoint: String) -> Result<Self> {
+        let client = WorkerServiceClient::connect(endpoint).await?;
+
+        let secrets = config.grpc_shared_secret.clone();
+        let timeout = Duration::from_millis(config.push_timeout_ms);
+
+        Ok(Self {
+            client,
+            secrets,
+            timeout,
+        })
+    }
+}
+
+#[async_trait]
+impl WorkerClient for Worker {
+    #[framed]
+    async fn push_task(&mut self, activation: Activation) -> Result<()> {
+        // Try to decode activation
+        let task =
+            TaskActivation::decode(&activation.activation as &[u8]).map_err(|e| anyhow!(e))?;
+
+        // The callback URL isn't used by push taskworkers anymore, so we can use an empty string until it's removed from the schema
+        let request = PushTaskRequest {
+            task: Some(task),
+            callback_url: "".into(),
+        };
+
+        // Wrap inside a Tonic request
+        let mut request = Request::new(request);
+
+        // Sign if secrets are present
+        if let Some(secret) = self.secrets.first() {
+            let body = request.get_ref().encode_to_vec();
+            let signature = sentry_signature_hex(secret, WORKER_PUSH_TASK_PATH, &body);
+            let value = MetadataValue::try_from(signature.as_str())
+                .context("sentry-signature metadata value must be valid ASCII")?;
+
+            request.metadata_mut().insert("sentry-signature", value);
+        }
+
+        // Push with timeout
+        let future = self.client.push_task(request);
+        tokio::time::timeout(self.timeout, future).await??;
+
+        Ok(())
+    }
+}
+
+/// Fake worker client that records pushed activation IDs and optionally fails.
+#[cfg(test)]
+struct MockWorkerClient {
+    /// Pushed activation IDs.
+    pushed: Vec<String>,
+
+    /// Should `push_task` fail?
+    fail: bool,
+}
+
+#[cfg(test)]
+impl MockWorkerClient {
+    fn new(fail: bool) -> Self {
+        Self {
+            pushed: vec![],
+            fail,
+        }
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl WorkerClient for MockWorkerClient {
+    async fn push_task(&mut self, activation: Activation) -> Result<()> {
+        TaskActivation::decode(&activation.activation as &[u8]).map_err(|e| anyhow!(e))?;
+        self.pushed.push(activation.id);
+
+        if self.fail {
+            return Err(anyhow!("mock send failure"));
+        }
+
+        Ok(())
+    }
+}
+
+/// Fake worker client that fires a `Notify` when `push_task` is called.
+#[cfg(test)]
+struct NotifyingWorkerClient {
+    /// Fire off notification when `push_task` is called
+    notify: Arc<Notify>,
+
+    /// Should `push_task` fail?
+    fail: bool,
+}
+
+#[cfg(test)]
+#[async_trait]
+impl WorkerClient for NotifyingWorkerClient {
+    async fn push_task(&mut self, _activation: Activation) -> Result<()> {
+        self.notify.notify_one();
+
+        if self.fail {
+            return Err(anyhow!("mock send failure"));
+        }
+
+        Ok(())
+    }
+}
+
+/// Create a map of notifying worker clients for tests.
+#[cfg(test)]
+pub fn test_worker_map(fail: bool, notify: Arc<Notify>) -> WorkerMap {
+    let mut workers = HashMap::new();
+
+    let client = NotifyingWorkerClient { fail, notify };
+
+    workers.insert("sentry".into(), Box::new(client) as Box<dyn WorkerClient>);
+    workers
+}
+
+#[cfg(test)]
+mod tests {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    use crate::test_utils::make_activations;
+
+    use super::MockWorkerClient;
+    use super::WORKER_PUSH_TASK_PATH;
+    use super::WorkerClient;
+
+    #[tokio::test]
+    async fn worker_push_task_returns_ok_on_client_success() {
+        let activation = make_activations(1).remove(0);
+        let mut worker = MockWorkerClient::new(false);
+
+        let result = worker.push_task(activation.clone()).await;
+        assert!(result.is_ok(), "push_task should succeed");
+        assert_eq!(worker.pushed, vec![activation.id]);
+    }
+
+    #[tokio::test]
+    async fn worker_push_task_returns_err_on_invalid_payload() {
+        let mut activation = make_activations(1).remove(0);
+        activation.activation = vec![1, 2, 3, 4];
+
+        let mut worker = MockWorkerClient::new(false);
+        let result = worker.push_task(activation).await;
+
+        assert!(result.is_err(), "invalid payload should fail decoding");
+        assert!(
+            worker.pushed.is_empty(),
+            "worker should not record a push if decode fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn worker_push_task_propagates_client_error() {
+        let activation = make_activations(1).remove(0);
+        let mut worker = MockWorkerClient::new(true);
+
+        let result = worker.push_task(activation.clone()).await;
+        assert!(result.is_err(), "worker push errors should propagate");
+        assert_eq!(worker.pushed, vec![activation.id]);
+    }
+
+    #[test]
+    fn worker_sentry_signature_hex_matches_hmac_contract() {
+        let mut mac = Hmac::<Sha256>::new_from_slice(b"super secret")
+            .expect("HMAC accepts keys of any length");
+        mac.update(WORKER_PUSH_TASK_PATH.as_bytes());
+        mac.update(b":");
+        mac.update(b"hello");
+        let digest = hex::encode(mac.finalize().into_bytes());
+
+        assert_eq!(
+            digest,
+            "cfdf2c4d2efd3a2d28bd10de6471ef352d03f49d2d3bd880ee7051ea39fbe239"
+        );
+    }
+}


### PR DESCRIPTION
## Linear
Completes [STREAM-1051](https://linear.app/getsentry/issue/STREAM-1051/refactor-worker-abstraction)

## Description
The current worker abstraction isn't doing enough. It should hide the details of authentication, timeouts, and message encoding / decoding from the push pool, which should only be responsible for pushing tasks to the worker via a simple `push_task` method and not much else.

Here's an overview of my changes.

* Avoid using `WorkerFactory` by establishing worker connections in main and passing them down into the push pool
* Move duplicated logic for handling push results from the push pool to a separate function
* Move timeout, authentication, and message decoding logic into the worker client `push_task` method
* Move worker-related abstractions into `worker.rs`
* Update tests to reflect new API

This is mostly just shuffling code around, so there shouldn't be any impact on behavior.