### PR TITLE
fix(push): Include error details in activation push failure message

### DIFF
--- a/src/push/thread.rs
+++ b/src/push/thread.rs
@@ -80,7 +80,7 @@ impl PushThread {
             error!(
                 task_id = %id,
                 error = ?e,
-                "Failed to send activation to worker"
+                "Failed to send activation to worker: {e}"
             );
 
             return;


### PR DESCRIPTION
## Summary
- Include the error string directly in the log message for "Failed to send activation to worker" errors, making it easier to spot the cause in logs without needing to parse structured fields

ref INC-2209

## Test plan
- [x] Code compiles
- [x] Clippy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)