### PR TITLE
feat: Add default metrics tags to Sentry errors

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use sentry::integrations::tracing::EventFilter;
@@ -37,6 +38,9 @@ pub struct LoggingConfig {
 
     /// The log format to use
     pub log_format: LogFormat,
+
+    /// Default tags to add to all Sentry events.
+    pub default_tags: BTreeMap<String, String>,
 }
 
 impl LoggingConfig {
@@ -47,6 +51,7 @@ impl LoggingConfig {
             traces_sample_rate: config.traces_sample_rate.unwrap_or(0.0),
             log_filter: config.log_filter.clone(),
             log_format: config.log_format,
+            default_tags: config.default_metrics_tags.clone(),
         }
     }
 }
@@ -62,6 +67,12 @@ pub fn init(log_config: LoggingConfig) {
             traces_sample_rate: log_config.traces_sample_rate,
             enable_logs: true,
             ..Default::default()
+        });
+
+        sentry::configure_scope(|scope| {
+            for (key, value) in &log_config.default_tags {
+                scope.set_tag(key, value);
+            }
         });
 
         // We manually deinitialize sentry later

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ async fn main() -> Result<(), Error> {
         .await;
 
     // Upkeep loop
-    let upkeep_task = tokio::spawn({
+    let upkeep_task = taskbroker::tokio::spawn({
         let upkeep_store = store.clone();
         let upkeep_config = config.clone();
         let runtime_config_manager = runtime_config_manager.clone();
@@ -130,7 +130,7 @@ async fn main() -> Result<(), Error> {
     });
 
     // Maintenance task loop
-    let maintenance_task = tokio::spawn({
+    let maintenance_task = taskbroker::tokio::spawn({
         let guard = elegant_departure::get_shutdown_guard().shutdown_on_drop();
         let maintenance_store = store.clone();
         let mut timer = time::interval(Duration::from_millis(config.maintenance_task_interval_ms));
@@ -155,7 +155,7 @@ async fn main() -> Result<(), Error> {
     });
 
     // Consumer from kafka
-    let consumer_task = tokio::spawn({
+    let consumer_task = taskbroker::tokio::spawn({
         let consumer_store = store.clone();
         let consumer_config = config.clone();
         let runtime_config_manager = runtime_config_manager.clone();
@@ -209,7 +209,7 @@ async fn main() -> Result<(), Error> {
         let flusher_store = store.clone();
         let flusher_config = config.clone();
 
-        let handle = tokio::spawn(async move {
+        let handle = taskbroker::tokio::spawn(async move {
             flusher::run_flusher(
                 rx,
                 flusher_config.status_update_batch_size,
@@ -226,7 +226,7 @@ async fn main() -> Result<(), Error> {
 
     // GRPC server - only start if port is configured (port 0 disables it)
     let grpc_server_task = if config.grpc_port > 0 {
-        Some(tokio::spawn({
+        Some(taskbroker::tokio::spawn({
             let grpc_store = store.clone();
             let grpc_config = config.clone();
             let grpc_status_tx = status_update_tx.clone();
@@ -315,14 +315,18 @@ async fn main() -> Result<(), Error> {
             workers.push(map);
         }
 
-        Some(tokio::spawn(async move { push_pool.start(workers).await }))
+        Some(taskbroker::tokio::spawn(async move {
+            push_pool.start(workers).await
+        }))
     } else {
         None
     };
 
     // Initialize fetch threads
     let fetch_task = if config.delivery_mode == DeliveryMode::Push {
-        Some(tokio::spawn(async move { fetch_pool.start().await }))
+        Some(taskbroker::tokio::spawn(
+            async move { fetch_pool.start().await },
+        ))
     } else {
         None
     };

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,5 +1,20 @@
 use std::future::Future;
-use tokio::task::JoinSet;
+
+use sentry::{Hub, SentryFutureExt};
+use tokio::task::{JoinHandle, JoinSet};
+
+/// Spawns a task with the main Sentry hub propagated.
+///
+/// This ensures that global Sentry tags configured via `configure_scope` on
+/// the main thread are available in spawned tasks. Without this, tokio worker
+/// threads would have their own hub without those tags.
+pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    tokio::spawn(future.bind_hub(Hub::new_from_top(Hub::main())))
+}
 
 /// Spawns `max(n, 1)` tasks, each running the future produced by `f` with the task's index.
 /// Returns a [`JoinSet`] containing all spawned tasks.
@@ -13,7 +28,7 @@ where
 
     let count = n.max(1);
     for i in 0..count {
-        join_set.spawn(f(i));
+        join_set.spawn(f(i).bind_hub(Hub::new_from_top(Hub::main())));
     }
 
     join_set


### PR DESCRIPTION
## Summary
- Reuse the default metrics tags (e.g. pool name, latency_tier) as Sentry tags so errors can be filtered/correlated with specific taskbroker instances
- Add a `taskbroker::tokio::spawn` helper that propagates the main Sentry hub to spawned tasks, ensuring tags are available across all threads

## Test plan
- [ ] Deploy and verify tags appear on Sentry errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)