### PR TITLE
fix(devenv): sync python client packages

### DIFF
--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -27,7 +27,14 @@ def main(context: dict[str, str]) -> int:
 
     print("syncing .venv ...")
     proc.run(
-        (f"{reporoot}/.devenv/bin/uv", "sync", "--frozen", "--quiet", "--active"),
+        (
+            f"{reporoot}/.devenv/bin/uv",
+            "sync",
+            "--frozen",
+            "--quiet",
+            "--active",
+            "--all-packages",
+        ),
     )
 
     print("installing pre-commit hooks ...")


### PR DESCRIPTION
`devenv sync` was only syncing the top-level taskbroker `pyproject.toml` and not the its workspace packages, `--all-packages` fixes that.