### PR TITLE
feat(taskbroker): Undo Claim on Send Failure

### DIFF
--- a/src/push/thread.rs
+++ b/src/push/thread.rs
@@ -94,8 +94,10 @@ impl PushThread {
                 error!(
                     task_id = %id,
                     error = ?e,
-                    "Failed to undo claim on failed send"
+                    "Failed to undo claim on send failure"
                 );
+
+                return;
             }
 
             metrics::counter!("push.undo_claim", "result" => "ok").increment(1);

--- a/src/push/thread.rs
+++ b/src/push/thread.rs
@@ -8,7 +8,7 @@ use elegant_departure::get_shutdown_guard;
 use flume::Receiver;
 use tracing::{debug, error};
 
-use crate::store::activation::Activation;
+use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::traits::ActivationStore;
 use crate::timed;
 use crate::worker::WorkerMap;
@@ -82,6 +82,23 @@ impl PushThread {
                 error = ?e,
                 "Failed to send activation to worker: {e}"
             );
+
+            // Revert claimed task back to pending
+            if let Err(e) = self
+                .store
+                .set_status(&id, ActivationStatus::Pending, None, None)
+                .await
+            {
+                metrics::counter!("push.undo_claim", "result" => "error").increment(1);
+
+                error!(
+                    task_id = %id,
+                    error = ?e,
+                    "Failed to undo claim on failed send"
+                );
+            }
+
+            metrics::counter!("push.undo_claim", "result" => "ok").increment(1);
 
             return;
         }


### PR DESCRIPTION
## Linear
Completes [STREAM-1066](https://linear.app/getsentry/issue/STREAM-1066/revert-claimed-tasks-to-pending-on-send-failure)

## Description
Right now, when a push fails for whatever reason (for example, it times out because workers are busy) we simply leave it as "claimed" until upkeep reverts it back to "pending" later. This means when workers go down (for example, during a deployment) there is a large number of tasks that are claimed but not sent, contributing to the processing limit and causing a sharp decline in throughput until they are set back to pending.

This PR aims to fix that problem by reverting claimed tasks back to pending immediately on send failure. We'll know if it works if the dips during worker deployments / recycles become more subtle.