### PR TITLE
feat(taskbroker): Better Claim Lease Computation

### DIFF
--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -36,8 +36,8 @@ const QUERY_MS: u64 = 1000;
 pub fn compute_claim_lease_ms(config: &Config) -> u64 {
     // Imagine we are computing the lease for some task in a batch of N tasks
     let fetch_batch_size = config.fetch_batch_size.max(1) as u64;
-    let push_threads = config.push_threads as u64;
-    let push_queue_size = config.push_queue_size as u64;
+    let push_threads = config.push_threads.max(1) as u64;
+    let push_queue_size = config.push_queue_size.max(1) as u64;
 
     // In the worst case, this task is the last in a batch where every queue push times out
     let queue_ms = fetch_batch_size * config.push_queue_timeout_ms;

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -15,6 +15,48 @@ use crate::worker::WorkerMap;
 
 mod thread;
 
+/// Approximately the longest time it should take to perform a task update query (used by `compute_claim_lease_ms`).
+/// Setting this too low will not impact correctness, but in the worst case, it may cause tasks to excute more than once.
+const QUERY_MS: u64 = 1000;
+
+/// Computes how long a claim should remain active before upkeep reverts back to pending.
+///
+/// A claimed activation is not yet processing. It still has to be submitted by
+/// the fetch loop to the bounded push queue, wait behind any already queued
+/// activations, be pushed to the worker, and then be marked as processing in the
+/// store. The lease therefore covers...
+///
+/// - The longest possible time to submit one claimed fetch batch into a full queue
+/// - The longest possible time for the push queue to drain
+/// - The (roughly) longest possible time to update every task to "processing" (or "pending")
+///
+/// This computation could definitely use some refinement, but it's more accurate than
+/// what we had before, and it's located in one place rather than being copied between
+/// the SQLite and Postgres adapters.
+pub fn compute_claim_lease_ms(config: &Config) -> u64 {
+    // Imagine we are computing the lease for some task in a batch of N tasks
+    let fetch_batch_size = config.fetch_batch_size.max(1) as u64;
+    let push_threads = config.push_threads as u64;
+    let push_queue_size = config.push_queue_size as u64;
+
+    // In the worst case, this task is the last in a batch where every queue push times out
+    let queue_ms = fetch_batch_size * config.push_queue_timeout_ms;
+
+    // The push queue drains in "rounds" since there are multiple push threads
+    // If there are 5 push threads and the queue has 10 slots, it will only take ⌈10 / 5⌉ = 2 rounds to drain it
+    // We add 1 to account for the task we are pushing right now
+    let rounds = push_queue_size.div_ceil(push_threads) + 1;
+
+    // In the worst case, every task in the push queue will time out when pushing
+    let drain_ms = rounds * config.push_timeout_ms;
+
+    // In the worst case, every task in the push queue will take `QUERY_MS` time to update from claimed to processing
+    // Since query timeouts aren't actually enforced right now, this is merely an approximation
+    let update_ms = rounds * QUERY_MS;
+
+    queue_ms + drain_ms + update_ms
+}
+
 /// Error returned when enqueueing an activation for the push workers fails.
 #[derive(Debug)]
 pub enum QueueError {

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -17,6 +17,7 @@ use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivation};
 use tracing::{instrument, warn};
 
 use crate::config::Config;
+use crate::push::compute_claim_lease_ms;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::retry::{RetryConfig, retry_query};
 use crate::store::traits::ActivationStore;
@@ -138,7 +139,6 @@ pub struct PostgresStoreConfig {
     pub run_migrations: bool,
     pub max_processing_attempts: usize,
     pub processing_deadline_grace_sec: u64,
-    /// Milliseconds added to `claim_expires_at` before grace: `fetch_batch_size * push_queue_timeout_ms`.
     pub claim_lease_ms: u64,
     pub vacuum_page_count: Option<usize>,
     pub enable_sqlite_status_metrics: bool,
@@ -166,7 +166,7 @@ impl PostgresStoreConfig {
             max_processing_attempts: config.max_processing_attempts,
             vacuum_page_count: config.vacuum_page_count,
             processing_deadline_grace_sec: config.processing_deadline_grace_sec,
-            claim_lease_ms: config.fetch_batch_size.max(1) as u64 * config.push_queue_timeout_ms,
+            claim_lease_ms: compute_claim_lease_ms(config),
             enable_sqlite_status_metrics: config.enable_sqlite_status_metrics,
             retry_config: RetryConfig::from_config(config),
         }
@@ -509,7 +509,7 @@ impl ActivationStore for PostgresStore {
             } else {
                 query_builder.push(format!(
                     "UPDATE inflight_taskactivations
-                     SET claim_expires_at = now() + ({claim_lease_ms} * interval '1 millisecond') + (interval '{grace_period} seconds'),
+                     SET claim_expires_at = now() + ({claim_lease_ms} * interval '1 millisecond'),
                          processing_deadline = NULL,
                          status = "
                 ));

--- a/src/store/adapters/sqlite.rs
+++ b/src/store/adapters/sqlite.rs
@@ -25,6 +25,7 @@ use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivation};
 use tracing::{instrument, warn};
 
 use crate::config::Config;
+use crate::push::compute_claim_lease_ms;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::traits::ActivationStore;
 use crate::store::types::{BucketRange, FailedTasksForwarder};
@@ -140,7 +141,6 @@ pub async fn create_sqlite_pool(url: &str) -> Result<(Pool<Sqlite>, Pool<Sqlite>
 pub struct SqliteStoreConfig {
     pub max_processing_attempts: usize,
     pub processing_deadline_grace_sec: u64,
-    /// Milliseconds added to `claim_expires_at` before grace: `fetch_batch_size * push_queue_timeout_ms`.
     pub claim_lease_ms: u64,
     pub vacuum_page_count: Option<usize>,
     pub enable_sqlite_status_metrics: bool,
@@ -152,7 +152,7 @@ impl SqliteStoreConfig {
             max_processing_attempts: config.max_processing_attempts,
             vacuum_page_count: config.vacuum_page_count,
             processing_deadline_grace_sec: config.processing_deadline_grace_sec,
-            claim_lease_ms: config.fetch_batch_size.max(1) as u64 * config.push_queue_timeout_ms,
+            claim_lease_ms: compute_claim_lease_ms(config),
             enable_sqlite_status_metrics: config.enable_sqlite_status_metrics,
         }
     }
@@ -560,7 +560,7 @@ impl ActivationStore for SqliteStore {
             query_builder.push_bind(ActivationStatus::Processing);
         } else {
             query_builder.push(format!(
-                "claim_expires_at = unixepoch('now', '+' || {:.3} || ' seconds', '+' || {grace_period} || ' seconds'), processing_deadline = NULL, status = ",
+                "claim_expires_at = unixepoch('now', '+' || {:.3} || ' seconds'), processing_deadline = NULL, status = ",
                 self.config.claim_lease_ms as f64 / 1000.0,
             ));
 


### PR DESCRIPTION
Right now, the claim lease (how long an activation should stay "claimed" before being reverted back to "pending" by upkeep) is calculated incorrectly. It's too short, so in the worst case scenario (fully saturated system), activations may be reverted back to pending before they're even sent.

An activation should remain "claimed" for _at least_ as long as it takes in the worst case for an activation to be sent, which we can calculate with some basic arithmetic.

_But won't activations remain claimed for too long?_ **No,** since we now revert claimed tasks back to pending immediately whenever a send fails for whatever reason, whether it's a worker error or a timeout. This only affects how long activations remain claimed when a broker goes down without sending the claimed activations it's currently holding, which will not happen often (only crashes or deployments).

This isn't a perfect computation, and we can explore better solutions, but this is already safer than the computation we currently have.