### PR TITLE
feat(config): Add Validation to Several Config Fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,6 +2057,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,6 +3193,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "validator",
 ]
 
 [[package]]
@@ -3700,6 +3723,36 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validator"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+dependencies = [
+ "darling",
+ "once_cell",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ libsqlite3-sys = "0.30.1"
 metrics = "0.24.0"
 metrics-exporter-statsd = "0.9.0"
 prost = "0.14"
+validator = { version = "0.20.0", features = ["derive"] }
 prost-types = "0.14"
 rand = "0.8.5"
 rdkafka = { version = "0.37.0", features = ["cmake-build", "ssl"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,12 +2,15 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 
+use anyhow::Result;
 use figment::providers::{Env, Format, Yaml};
 use figment::{Figment, Metadata, Profile, Provider};
 use rdkafka::ClientConfig;
 use serde::{Deserialize, Serialize};
+use validator::{Validate, ValidationError};
 
 use crate::Args;
+use crate::fetch::MAX_FETCH_THREADS;
 use crate::logging::LogFormat;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
@@ -31,7 +34,7 @@ pub enum DeliveryMode {
     Push,
 }
 
-#[derive(PartialEq, Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
 pub struct Config {
     /// The sentry DSN to use for error reporting.
     pub sentry_dsn: Option<String>,
@@ -300,34 +303,41 @@ pub struct Config {
     pub delivery_mode: DeliveryMode,
 
     /// The number of concurrent fetch loops in push mode, which should be ≤ `MAX_FETCH_THREADS` and a power of two.
-    /// If it's not a power of two or it's too large, it will be rounded to a valid nearby value.
+    #[validate(range(min = 1, max = MAX_FETCH_THREADS), custom(function = "validate_power_of_two"))]
     pub fetch_threads: usize,
 
     /// Time in milliseconds to wait between fetch attempts when no pending activation is found.
     pub fetch_wait_ms: u64,
 
     /// The number of activations to claim with a single fetch query.
+    #[validate(range(min = 1))]
     pub fetch_batch_size: i32,
 
-    /// The number of concurrent pushers each dispatcher should run.
+    /// The number of concurrent push threads to run.
+    #[validate(range(min = 1))]
     pub push_threads: usize,
 
     /// The size of the push queue.
+    #[validate(range(min = 1))]
     pub push_queue_size: usize,
 
     /// Maximum time in milliseconds to wait when submitting an activation to the push pool.
+    #[validate(range(min = 1))]
     pub push_queue_timeout_ms: u64,
 
     /// Maximum time in milliseconds for a single push RPC to the worker service. This should be greater than the worker's internal timeout.
+    #[validate(range(min = 1))]
     pub push_timeout_ms: u64,
 
     /// Update statuses from the gRPC server in batches?
     pub batch_status_updates: bool,
 
     /// The size of a batch of status updates.
+    #[validate(range(min = 1))]
     pub status_update_batch_size: usize,
 
     /// Maximum milliseconds to wait before flushing a batch of status updates.
+    #[validate(range(min = 1))]
     pub status_update_interval_ms: u64,
 
     /// Maps every application to its worker endpoint, both represented as strings.
@@ -454,13 +464,18 @@ impl Default for Config {
 
 impl Config {
     /// Build a config instance from defaults, env vars, file + CLI options
-    pub fn from_args(args: &Args) -> Result<Self, Box<figment::Error>> {
+    pub fn from_args(args: &Args) -> Result<Self> {
         let mut builder = Figment::from(Config::default());
+
         if let Some(path) = &args.config {
             builder = builder.merge(Yaml::file(path));
         }
+
         builder = builder.merge(Env::prefixed("TASKBROKER_"));
-        let config = builder.extract()?;
+
+        let config: Config = builder.extract()?;
+        config.validate()?;
+
         Ok(config)
     }
 
@@ -558,12 +573,29 @@ impl Provider for Config {
     }
 }
 
+/// Ensures that `n` is a power of two, used to validate `fetch_threads`.
+fn validate_power_of_two(n: usize) -> Result<(), ValidationError> {
+    let mut m = n;
+
+    while m > 1 {
+        if m % 2 == 1 {
+            // Not divisible by two
+            return Err(ValidationError::new("not_power_of_two"));
+        }
+
+        m /= 2;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
     use std::collections::BTreeMap;
 
     use figment::Jail;
+    use validator::Validate;
 
     use crate::Args;
     use crate::logging::LogFormat;
@@ -589,6 +621,81 @@ mod tests {
             config.worker_map.get("sentry").map(String::as_str),
             Some("http://127.0.0.1:50052")
         );
+    }
+
+    #[test]
+    fn test_validate_rejects_invalid_fields() {
+        let mut config = Config::default();
+
+        // Fetch threads cannot be zero
+        config.fetch_threads = 0;
+        assert!(config.validate().is_err());
+
+        config.fetch_threads = 1;
+        assert!(config.validate().is_ok());
+
+        // Fetch threads must be a power of two
+        config.fetch_threads = 3;
+        assert!(config.validate().is_err());
+
+        config.fetch_threads = 4;
+        assert!(config.validate().is_ok());
+
+        // Fetch threads must be ≤ 256
+        config.fetch_threads = 512;
+        assert!(config.validate().is_err());
+
+        config.fetch_threads = 1;
+        assert!(config.validate().is_ok());
+
+        // Fetch batch size cannot be zero
+        config.fetch_batch_size = 0;
+        assert!(config.validate().is_err());
+
+        config.fetch_batch_size = 1;
+        assert!(config.validate().is_ok());
+
+        // Push threads cannot be zero
+        config.push_threads = 0;
+        assert!(config.validate().is_err());
+
+        config.push_threads = 1;
+        assert!(config.validate().is_ok());
+
+        // Push queue size cannot be zero
+        config.push_queue_size = 0;
+        assert!(config.validate().is_err());
+
+        config.push_queue_size = 1;
+        assert!(config.validate().is_ok());
+
+        // Push queue timeout cannot be zero
+        config.push_queue_timeout_ms = 0;
+        assert!(config.validate().is_err());
+
+        config.push_queue_timeout_ms = 1;
+        assert!(config.validate().is_ok());
+
+        // Push timeout cannot be zero
+        config.push_timeout_ms = 0;
+        assert!(config.validate().is_err());
+
+        config.push_timeout_ms = 1;
+        assert!(config.validate().is_ok());
+
+        // Status update batch size cannot be zero
+        config.status_update_batch_size = 0;
+        assert!(config.validate().is_err());
+
+        config.status_update_batch_size = 1;
+        assert!(config.validate().is_ok());
+
+        // Status update interval cannot be zero
+        config.status_update_interval_ms = 0;
+        assert!(config.validate().is_err());
+
+        config.status_update_interval_ms = 1;
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1027,18 +1027,11 @@ impl Provider for Config {
 
 /// Ensures that `n` is a power of two, used to validate `fetch_threads`.
 fn validate_power_of_two(n: usize) -> Result<(), ValidationError> {
-    let mut m = n;
-
-    while m > 1 {
-        if m % 2 == 1 {
-            // Not divisible by two
-            return Err(ValidationError::new("not_power_of_two"));
-        }
-
-        m /= 2;
+    if n.is_power_of_two() {
+        Ok(())
+    } else {
+        Err(ValidationError::new("not_power_of_two"))
     }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -1082,10 +1075,12 @@ mod tests {
 
     #[test]
     fn test_validate_rejects_invalid_fields() {
-        let mut config = Config::default();
+        let mut config = Config {
+            fetch_threads: 0,
+            ..Config::default()
+        };
 
         // Fetch threads cannot be zero
-        config.fetch_threads = 0;
         assert!(config.validate().is_err());
 
         config.fetch_threads = 1;

--- a/src/config.rs
+++ b/src/config.rs
@@ -589,9 +589,13 @@ impl Config {
 
         // Use "__" for nested configurations via environment variables, like `TASKBROKER_KAFKA_TOPICS__PROFILES__CLUSTER`
         builder = builder.merge(Env::prefixed("TASKBROKER_").split("__"));
-
         let mut config: Config = builder.extract()?;
+
+        // Normalize and validate Kafka values
         config.normalize_and_validate()?;
+
+        // Validate all other values
+        config.validate()?;
 
         Ok(config)
     }
@@ -857,9 +861,6 @@ impl Config {
                 deadletter_address
             ));
         }
-
-        // Validate all other values
-        self.validate()?;
 
         Ok(())
     }

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -19,28 +19,12 @@ use crate::timed;
 
 /// This value should be a power of two. If it decreases, some ranges will no longer be queried.
 /// That means the pending activation query will skip tasks within these ranges.
-pub const MAX_FETCH_THREADS: i16 = 256;
-
-/// Returns the largest positive divisor of [`MAX_FETCH_THREADS`] that is also a power of two.
-pub fn normalize_fetch_threads(n: usize) -> usize {
-    let n = n.max(1);
-    let mut v = MAX_FETCH_THREADS;
-
-    while v > 1 {
-        if (v as usize) <= n {
-            return v as usize;
-        }
-
-        v /= 2;
-    }
-
-    1
-}
+pub const MAX_FETCH_THREADS: usize = 256;
 
 /// Inclusive bucket range for fetch thread `thread_index` when using `fetch_threads` concurrent fetch loops.
 /// Requires `fetch_threads` to divide [`MAX_FETCH_THREADS`] (enforced via [`normalize_fetch_threads`]).
 pub fn bucket_range_for_fetch_thread(thread_index: usize, fetch_threads: usize) -> BucketRange {
-    let maximum = MAX_FETCH_THREADS as usize;
+    let maximum = MAX_FETCH_THREADS;
     let buckets_per_range = maximum / fetch_threads;
 
     let low = (thread_index * buckets_per_range) as i16;
@@ -79,14 +63,14 @@ impl FetchPool {
     #[framed]
     pub async fn start(&self) -> Result<()> {
         let fetch_wait_ms = self.config.fetch_wait_ms;
-        let fetch_threads = normalize_fetch_threads(self.config.fetch_threads);
+        let fetch_threads = self.config.fetch_threads;
 
         let mut fetch_pool = crate::tokio::spawn_pool(fetch_threads, |thread_index| {
             let store = self.store.clone();
             let sender = self.sender.clone();
             let config = self.config.clone();
 
-            let limit = Some(config.fetch_batch_size.max(1));
+            let limit = Some(config.fetch_batch_size);
             let bucket = Some(bucket_range_for_fetch_thread(thread_index, fetch_threads));
 
             let guard = get_shutdown_guard().shutdown_on_drop();

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ async fn main() -> Result<(), Error> {
 
     // Status update flush task
     let (status_update_tx, status_update_task) = if config.batch_status_updates {
-        let (tx, rx) = tokio::sync::mpsc::channel(config.status_update_batch_size.max(1));
+        let (tx, rx) = tokio::sync::mpsc::channel(config.status_update_batch_size);
 
         let flusher_store = store.clone();
         let flusher_config = config.clone();
@@ -293,7 +293,7 @@ async fn main() -> Result<(), Error> {
         let mut workers: Vec<WorkerMap> = vec![];
 
         // For every push thread, create a map from applications to worker connections
-        for _ in 0..config.push_threads.max(1) {
+        for _ in 0..config.push_threads {
             let mut map = HashMap::new();
 
             for (application, endpoint) in config.worker_map.clone() {


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
Some configuration options have specific requirements, like they must be greater than zero or a power of two. Until now, we've relied on ad hoc assertions and calls to functions like `max(1)` to enforce these constraints. I think it would be better to guarantee these constraints immediately on startup because ad hoc checks can easily be forgotten.