### PR TITLE
feat(query retries): Enable query retry with default of 3 retries

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -519,7 +519,7 @@ impl Default for Config {
             pg_default_database_name: "postgres".to_owned(),
             pg_extra_query_params: None,
             db_write_failure_backoff_ms: 4000,
-            db_query_max_retries: None,
+            db_query_max_retries: Some(3),
             db_query_retry_delay_ms: 100,
             db_insert_batch_max_len: 256,
             db_insert_batch_max_size: 16_000_000,

--- a/src/store/retry.rs
+++ b/src/store/retry.rs
@@ -220,8 +220,11 @@ mod tests {
     }
 
     #[test]
-    fn test_config_defaults_to_zero_retries() {
-        let config = RetryConfig::from_config(&Arc::new(Config::default()));
+    fn test_config_none_means_zero_retries() {
+        let config = RetryConfig::from_config(&Arc::new(Config {
+            db_query_max_retries: None,
+            ..Config::default()
+        }));
         assert_eq!(config.max_retries, 0);
     }
 


### PR DESCRIPTION
## Summary
- Sets `db_query_max_retries` default from `None` to `Some(3)`
- Enables automatic retry of transient database errors (`Io`, `PoolTimedOut`) with 100ms delay between attempts
- Applies to all wrapped Postgres query sites added in #XXX

## Context
Follow-up to the query retry infrastructure PR. That PR added the retry mechanism but defaulted to off (`None`) for safe rollout. This PR turns it on.

## Test plan
- [ ] Monitor `store.retry.attempt`, `store.retry.succeeded`, `store.retry.exhausted` metrics after deploy
- [ ] Verify no increase in error rates or latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)