### PR TITLE
fix(config): legacy retry topic uses deadletter cluster

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -768,10 +768,18 @@ impl Config {
 
             // Add the retry topic if configured. Retry topics are produce-only;
             // this taskbroker writes retries to them but does not consume from
-            // them. Aliasing the main topic is allowed (retries are re-enqueued
-            // there), but aliasing the deadletter topic is not: the names would
-            // collide and the retry would silently inherit the deadletter
-            // cluster/role.
+            // them. Retries are published by the upkeep producer, which is the
+            // same producer used for the deadletter topic and therefore connects
+            // to the deadletter cluster (see kafka_producer_cluster). A distinct
+            // legacy retry topic must therefore be registered on the deadletter
+            // cluster, not the main consumer cluster -- otherwise the
+            // same-cluster validation below compares the retry topic against the
+            // wrong cluster and rejects configs where the main consumer cluster
+            // differs from the deadletter cluster. Aliasing the main topic is
+            // allowed (retries are re-enqueued there, which requires the main and
+            // deadletter clusters to coincide), but aliasing the deadletter topic
+            // is not: the names would collide and the retry would silently
+            // inherit the deadletter role.
             if let Some(ref retry_topic) = self.kafka_retry_topic {
                 if retry_topic == &self.kafka_deadletter_topic {
                     return Err(Box::new(figment::Error::from(format!(
@@ -782,7 +790,7 @@ impl Config {
                 self.kafka_topics
                     .entry(retry_topic.clone())
                     .or_insert_with(|| TopicConfig {
-                        cluster: DEFAULT_CLUSTER.to_owned(),
+                        cluster: DEADLETTER_CLUSTER.to_owned(),
                         consumer_group,
                         produce_only: true,
                         raw: None,
@@ -2015,6 +2023,42 @@ kafka_clusters:
                 "unexpected error: {}",
                 err
             );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_legacy_retry_topic_uses_deadletter_cluster() {
+        // Reproduces the `ingest-profiles-raw` pool: the main consumer topic
+        // lives on a different cluster than the retry+DLQ topics. The retry
+        // producer is the upkeep/deadletter producer, so a distinct legacy
+        // retry topic must be registered on the deadletter cluster, not the
+        // main consumer cluster. Otherwise the same-cluster validation compares
+        // the retry topic against the wrong cluster and rejects this config.
+        Jail::expect_with(|jail| {
+            jail.set_env("TASKBROKER_KAFKA_CLUSTER", "kafka-profiles:9092");
+            jail.set_env("TASKBROKER_KAFKA_TOPIC", "profiles");
+            jail.set_env("TASKBROKER_KAFKA_RETRY_TOPIC", "taskworker-ingest");
+            jail.set_env("TASKBROKER_KAFKA_DEADLETTER_TOPIC", "taskworker-ingest-dlq");
+            jail.set_env("TASKBROKER_KAFKA_DEADLETTER_CLUSTER", "kafka-small:9092");
+
+            let args = Args { config: None };
+            let config = Config::from_args(&args).expect("legacy retry config should validate");
+
+            // The retry topic resolves to the deadletter cluster (where the
+            // upkeep producer actually publishes), not the main consumer cluster.
+            let retry_topic = config
+                .kafka_topics
+                .get("taskworker-ingest")
+                .expect("retry topic registered");
+            assert!(retry_topic.produce_only);
+            assert_eq!(
+                config.cluster(&retry_topic.cluster).unwrap().address,
+                "kafka-small:9092"
+            );
+            // And it matches the producer's cluster.
+            assert_eq!(config.kafka_producer_cluster().address, "kafka-small:9092");
 
             Ok(())
         });

--- a/src/config.rs
+++ b/src/config.rs
@@ -766,20 +766,10 @@ impl Config {
                 ))));
             }
 
-            // Add the retry topic if configured. Retry topics are produce-only;
-            // this taskbroker writes retries to them but does not consume from
-            // them. Retries are published by the upkeep producer, which is the
-            // same producer used for the deadletter topic and therefore connects
-            // to the deadletter cluster (see kafka_producer_cluster). A distinct
-            // legacy retry topic must therefore be registered on the deadletter
-            // cluster, not the main consumer cluster -- otherwise the
-            // same-cluster validation below compares the retry topic against the
-            // wrong cluster and rejects configs where the main consumer cluster
-            // differs from the deadletter cluster. Aliasing the main topic is
-            // allowed (retries are re-enqueued there, which requires the main and
-            // deadletter clusters to coincide), but aliasing the deadletter topic
-            // is not: the names would collide and the retry would silently
-            // inherit the deadletter role.
+            // Register the retry topic on the deadletter cluster: retries are
+            // published by the upkeep producer, which is the same producer used
+            // for the deadletter topic (see kafka_producer_cluster). Aliasing
+            // the deadletter topic is rejected to avoid a name collision.
             if let Some(ref retry_topic) = self.kafka_retry_topic {
                 if retry_topic == &self.kafka_deadletter_topic {
                     return Err(Box::new(figment::Error::from(format!(


### PR DESCRIPTION
ref STREAM-1042

Follow-up to #663, which added the `normalize_and_validate` check that the retry target and deadletter topic must resolve to the same cluster (they share the upkeep producer). This fixes a false positive in that check for legacy configs.

In legacy normalization a distinct `kafka_retry_topic` was registered on `DEFAULT_CLUSTER` (the main consumer cluster). But retries are produced by the upkeep producer, which is the same producer used for the DLQ and connects to the deadletter topic's cluster (`kafka_producer_config` → `kafka_producer_cluster`). The same-cluster check then compared the retry topic's mis-assigned cluster against the deadletter cluster and rejected configs where the main consumer cluster differs from the deadletter cluster — even though retries would have gone to the deadletter cluster at runtime as intended.

Fix: register the legacy retry topic on `DEADLETTER_CLUSTER` so the config model matches the cluster the producer actually uses. This only diverges when `kafka_deadletter_cluster` is explicitly set; when unset it falls back to the main address, so the change is a no-op for those pools.

See `test_legacy_retry_topic_uses_deadletter_cluster` for the repro — it fails with the verbatim production error without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
