### PR TITLE
ref(workerchild): add metric tracking pending futures

### DIFF
--- a/clients/python/src/taskbroker_client/worker/workerchild.py
+++ b/clients/python/src/taskbroker_client/worker/workerchild.py
@@ -284,17 +284,16 @@ def child_process(
             )
 
         def check_task_future_completion() -> None:
+            # Records how many activations with pending producer futures
+            # the worker child has.
+            metrics.gauge(
+                "taskworker.worker.activations_with_pending_futures",
+                len(pending_task_futures),
+                tags={
+                    "processing_pool": processing_pool_name,
+                },
+            )
             if len(pending_task_futures) > 0:
-                # Records a distribution of how many activations with pending producer futures
-                # a processing pool has across all worker child processes.
-                # Only reports if the worker actually has pending futures.
-                metrics.distribution(
-                    "taskworker.worker.activations_with_pending_futures",
-                    len(pending_task_futures),
-                    tags={
-                        "processing_pool": processing_pool_name,
-                    },
-                )
                 for task in pending_task_futures.copy():
                     if all([f.done() for f in task.pending_futures]):
                         await_task_futures(task)

--- a/clients/python/src/taskbroker_client/worker/workerchild.py
+++ b/clients/python/src/taskbroker_client/worker/workerchild.py
@@ -285,6 +285,16 @@ def child_process(
 
         def check_task_future_completion() -> None:
             if len(pending_task_futures) > 0:
+                # Records a distribution of how many activations with pending producer futures
+                # a processing pool has across all worker child processes.
+                # Only reports if the worker actually has pending futures.
+                metrics.distribution(
+                    "taskworker.worker.activations_with_pending_futures",
+                    len(pending_task_futures),
+                    tags={
+                        "processing_pool": processing_pool_name,
+                    },
+                )
                 for task in pending_task_futures.copy():
                     if all([f.done() for f in task.pending_futures]):
                         await_task_futures(task)


### PR DESCRIPTION
Adds a metric to get a picture of how many activations with pending futures a processing pool has.