### PR TITLE
fix(client): log push-mode request deserializer failures

### DIFF
--- a/clients/python/src/taskbroker_client/worker/client.py
+++ b/clients/python/src/taskbroker_client/worker/client.py
@@ -225,7 +225,18 @@ class RequestSignatureServerInterceptor(ServerInterceptor):
                 _RPC_SIGNATURE_AUTH_TLS.failed = True
                 return inner_deserializer(b"")
 
-            return inner_deserializer(serialized_request)
+            try:
+                return inner_deserializer(serialized_request)
+            except Exception:
+                # gRPC swallows deserializer exceptions in `grpc._common._transform`
+                # (it logs to the `grpc._common` logger and returns None), and the server
+                # then aborts the call with an opaque INTERNAL "Exception deserializing
+                # request!". Log here so the failure is visible on our own logger.
+                logger.exception(
+                    "taskworker.grpc_server.request_deserialization_failed",
+                    extra={"method": method},
+                )
+                raise
 
         def unary_unary(request: Any, context: grpc.ServicerContext) -> Any:
             if getattr(_RPC_SIGNATURE_AUTH_TLS, "failed", False):

--- a/clients/python/tests/worker/test_client.py
+++ b/clients/python/tests/worker/test_client.py
@@ -5,7 +5,9 @@ import random
 import string
 import time
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
@@ -13,6 +15,7 @@ from unittest.mock import Mock, patch
 import grpc
 import pytest
 from google.protobuf.message import Message
+from sentry_protos.taskbroker.v1 import taskbroker_pb2_grpc
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     TASK_ACTIVATION_STATUS_COMPLETE,
     TASK_ACTIVATION_STATUS_RETRY,
@@ -20,6 +23,7 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     GetTaskRequest,
     GetTaskResponse,
     PushTaskRequest,
+    PushTaskResponse,
     SetTaskStatusRequest,
     SetTaskStatusResponse,
     TaskActivation,
@@ -392,6 +396,70 @@ def test_request_signature_server_interceptor_skips_grpc_health_check() -> None:
     interceptor = RequestSignatureServerInterceptor(["secret"])
 
     assert interceptor.intercept_service(lambda _: handler, handler_call_details) is handler
+
+
+class _RecordingWorkerServicer(taskbroker_pb2_grpc.WorkerServiceServicer):
+    """Records the requests it receives, like the real WorkerServicer would process them"""
+
+    def __init__(self) -> None:
+        self.requests: list[PushTaskRequest] = []
+
+    def PushTask(self, request: PushTaskRequest, context: grpc.ServicerContext) -> PushTaskResponse:
+        self.requests.append(request)
+        return PushTaskResponse()
+
+
+@contextmanager
+def _running_worker_server(
+    secrets: list[str],
+) -> Generator[tuple[_RecordingWorkerServicer, grpc.Channel], None, None]:
+    """Run a real gRPC server with the signature interceptor, as PushTaskWorker does.
+
+    The signature is verified inside a deserializer wrapper that gRPC runs on a
+    different thread than the servicer, so this behaviour can only be exercised
+    against a real server, not a mocked channel.
+    """
+    servicer = _RecordingWorkerServicer()
+    server = grpc.server(
+        ThreadPoolExecutor(max_workers=2),
+        interceptors=[RequestSignatureServerInterceptor(secrets)],
+    )
+    taskbroker_pb2_grpc.add_WorkerServiceServicer_to_server(servicer, server)
+    port = server.add_insecure_port("[::]:0")
+    server.start()
+    channel = grpc.insecure_channel(f"localhost:{port}")
+    try:
+        yield servicer, channel
+    finally:
+        channel.close()
+        server.stop(grace=None)
+
+
+def test_request_signature_server_interceptor_logs_deserialization_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # gRPC swallows deserializer exceptions in `grpc._common._transform` and the
+    # server aborts the call with an opaque INTERNAL status, so the interceptor must
+    # log the exception itself to leave a trace on our own logger.
+    body = b"\xff\xff\xff\xff not a protobuf"
+    signature = _push_task_hmac(b"secret", body)
+
+    with _running_worker_server(["secret"]) as (servicer, channel):
+        multicallable = channel.unary_unary(
+            _PUSH_TASK_METHOD,
+            request_serializer=None,
+            response_deserializer=PushTaskResponse.FromString,
+        )
+        with caplog.at_level("ERROR", logger="taskbroker_client.worker.client"):
+            with pytest.raises(grpc.RpcError) as excinfo:
+                multicallable(body, timeout=5, metadata=(("sentry-signature", signature),))
+
+    assert excinfo.value.code() == grpc.StatusCode.INTERNAL
+    assert servicer.requests == []
+    assert any(
+        record.message == "taskworker.grpc_server.request_deserialization_failed"
+        for record in caplog.records
+    )
 
 
 def test_get_task_with_namespace() -> None:


### PR DESCRIPTION
## Summary

In **push mode** the Python worker runs a gRPC server (`PushTaskWorker` → `WorkerServicer`). When a `PushTask` request body fails to deserialize — proto schema mismatch between broker and worker, or a corrupted payload — the underlying exception is **silently swallowed** and the broker only sees an opaque `INTERNAL` status. Nothing lands on our own logger and no metric is emitted, so the failure is effectively invisible in worker logs.

This PR logs the exception on the `taskbroker_client.worker.client` logger before re-raising.

## Where the exception is swallowed

The request deserializer (our `RequestSignatureServerInterceptor` wraps it) is invoked by gRPC, and gRPC catches *any* exception it raises. Links below are pinned to the `grpcio==1.75.1` tag (the version this repo locks).

1. **The swallow** — [`grpc/_common.py` `_transform()`, lines 88–92](https://github.com/grpc/grpc/blob/v1.75.1/src/python/grpcio/grpc/_common.py#L88-L92):
   ```python
   try:
       return transformer(message)        # <- our deserializer
   except Exception:                      # pylint: disable=broad-except
       _LOGGER.exception(exception_message)   # logged on the `grpc._common` logger only
       return None                            # exception turned into None
   ```
   [`deserialize()`](https://github.com/grpc/grpc/blob/v1.75.1/src/python/grpcio/grpc/_common.py#L99-L104) calls this with `exception_message="Exception deserializing message!"`.

2. **The opaque status** — [`grpc/_server.py` `_receive_message()`, lines 333–343](https://github.com/grpc/grpc/blob/v1.75.1/src/python/grpcio/grpc/_server.py#L333-L343):
   ```python
   request = _common.deserialize(serialized_request, request_deserializer)
   ...
   if request is None:
       _abort(state, call, cygrpc.StatusCode.internal,
              b"Exception deserializing request!")
   ```

So the real traceback exists only on the `grpc._common` logger at `ERROR`. Unless the worker explicitly routes gRPC's internal loggers to a handler, it is lost — and the broker just gets `INTERNAL "Exception deserializing request!"` with no detail about *why*.

## Fix

Wrap the deserializer body in the interceptor and log on our own logger before re-raising (gRPC still produces the `INTERNAL` status for the caller, but now there's a visible, attributable record on the worker side):

```python
try:
    return inner_deserializer(serialized_request)
except Exception:
    logger.exception(
        "taskworker.grpc_server.request_deserialization_failed",
        extra={"method": method},
    )
    raise
```

## Test

`test_request_signature_server_interceptor_logs_deserialization_errors` stands up a real `grpc.server` with the interceptor, sends a correctly-signed but unparseable body, and asserts:
- the caller receives `StatusCode.INTERNAL`
- the servicer never runs
- a `taskworker.grpc_server.request_deserialization_failed` record is emitted on our logger

Verified the test **fails without the fix** (no such log record) and **passes with it**. A real server is required because the deserializer runs on gRPC's event-polling thread, not the servicer thread — a mocked channel cannot exercise this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)