### PR TITLE
Try Fixing `k8s-spawn-job` Invocation Again

### DIFF
--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -9,4 +9,5 @@ k8s-spawn-job \
   "taskbroker-migrations" \
   "us-central1-docker.pkg.dev/sentryio/taskbroker/image:${GO_REVISION_TASKBROKER_REPO}" \
   /opt/taskbroker \
+  -- \
   --run migrations


### PR DESCRIPTION
## Linear
Refs [STREAM-1088](https://linear.app/getsentry/issue/STREAM-1088/migration-step-in-push-taskbroker-deployment)

## Description
Pipeline fails with this error (different from the one in #675). Hopefully this fixes the problem.

```
usage: k8s-spawn-job [-h] --container-name CONTAINER_NAME
                     --label-selector LABEL_SELECTOR [-e ENVVARS]
                     [--context CONTEXT] [--namespace NAMESPACE]
                     [--use-local-config] [--try-deployments-and-statefulsets]
                     [--max-job-duration MAX_JOB_DURATION]
                     [--min-memory MIN_MEMORY]
                     job_name image command [args ...]
k8s-spawn-job: error: unrecognized arguments: --run
[script-executor] Script completed with exit code: 2.
```