### PR TITLE
Change 'No pending activations' log from warn to debug level

### DIFF
--- a/src/grpc/server.rs
+++ b/src/grpc/server.rs
@@ -189,7 +189,7 @@ impl ConsumerService for TaskbrokerServer {
             }
 
             Ok(None) => {
-                warn!("No pending activations");
+                debug!("No pending activations");
 
                 // If we return an error, the worker will place the result back in its internal queue and send the update again in the future, which is not desired
                 Ok(Response::new(SetTaskStatusResponse { task: None }))


### PR DESCRIPTION
## Linear
Refs [STREAM-1120](https://linear.app/getsentry/issue/STREAM-1120/stop-logging-no-pending-activations-so-much)

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Reduces the log level of "No pending activations" from `warn!` to `debug!` in the gRPC server's `set_task_status` method.

## Changes
- Changed log level in `src/grpc/server.rs` line 192 from `warn!` to `debug!`

## Rationale
Having no pending activations is a normal operational state that doesn't require warning-level logging. This change reduces log noise during normal operation while still keeping the message available at debug level for troubleshooting.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/D0B93FHP02E/p1780939560288229?thread_ts=1780939560.288229&cid=D0B93FHP02E)

<div><a href="https://cursor.com/agents/bc-527f4d26-7842-4173-8e24-41d754c6238a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-527f4d26-7842-4173-8e24-41d754c6238a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

