### PR TITLE
fix(producer): DummyProducer typing

### DIFF
--- a/clients/python/tests/worker/test_producer.py
+++ b/clients/python/tests/worker/test_producer.py
@@ -26,7 +26,7 @@ class DummyProducer:
         self.use_simple_futures = use_simple_futures
 
     def produce(
-        self, topic: Topic, payload: KafkaPayload
+        self, destination: Topic | Partition, payload: KafkaPayload
     ) -> ProducerFuture[BrokerValue[KafkaPayload]]:
         future: ProducerFuture[BrokerValue[KafkaPayload]]
         if self.use_simple_futures:


### PR DESCRIPTION
This was causing mypy lint errors in main CI that weren't being caught earlier for some reason.