### PR TITLE
ref(config): (2) Move `DatabaseAdapter` to `config::store` Module

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,10 @@ use crate::fetch::MAX_FETCH_THREADS;
 use crate::logging::LogFormat;
 use crate::store::adapters::postgres;
 
+pub mod store;
+
+use store::DatabaseAdapter;
+
 /// Configuration for a single Kafka topic in multi-topic mode.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct TopicConfig {
@@ -123,16 +127,6 @@ impl ClusterConfig {
             config.set("ssl.key.location", ssl_private_key_location);
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum DatabaseAdapter {
-    /// SQLite database adapter
-    Sqlite,
-
-    /// PostgreSQL database adapter
-    Postgres,
 }
 
 impl DatabaseAdapter {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,7 +13,6 @@ use validator::{Validate, ValidationError};
 use crate::Args;
 use crate::fetch::MAX_FETCH_THREADS;
 use crate::logging::LogFormat;
-use crate::store::adapters::postgres;
 
 pub mod store;
 
@@ -125,18 +124,6 @@ impl ClusterConfig {
         }
         if let Some(ref ssl_private_key_location) = self.ssl_key_location {
             config.set("ssl.key.location", ssl_private_key_location);
-        }
-    }
-}
-
-impl DatabaseAdapter {
-    pub async fn migrate(&self, config: &Config) -> Result<()> {
-        match self {
-            Self::Postgres => postgres::migrate(config).await,
-            Self::Sqlite => {
-                warn!("Standalone migration not supported for SQLite");
-                Ok(())
-            }
         }
     }
 }

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-use crate::{config::Config, store::adapters::postgres};
+use crate::config::Config;
+use crate::store::adapters::postgres;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DatabaseAdapter {
+    /// SQLite database adapter
+    Sqlite,
+
+    /// PostgreSQL database adapter
+    Postgres,
+}

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -1,4 +1,8 @@
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::{config::Config, store::adapters::postgres};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -8,4 +12,16 @@ pub enum DatabaseAdapter {
 
     /// PostgreSQL database adapter
     Postgres,
+}
+
+impl DatabaseAdapter {
+    pub async fn migrate(&self, config: &Config) -> Result<()> {
+        match self {
+            Self::Postgres => postgres::migrate(config).await,
+            Self::Sqlite => {
+                warn!("Standalone migration not supported for SQLite");
+                Ok(())
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,8 @@ use tonic::transport::Server;
 use tonic_health::ServingStatus;
 use tracing::{debug, error, info, warn};
 
-use taskbroker::config::{Config, DatabaseAdapter, DeliveryMode};
+use taskbroker::config::store::DatabaseAdapter;
+use taskbroker::config::{Config, DeliveryMode};
 use taskbroker::fetch::FetchPool;
 use taskbroker::grpc::auth_middleware::AuthLayer;
 use taskbroker::grpc::metrics_middleware::MetricsLayer;


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 2** of my configuration improvement effort. Let's create a new `config::store` module to keep all store-related configuration, such as the `DatabaseAdapter` enum. More will come later.