### PR TITLE
ref(config): (3) Move `RawModeConfig` to `config::raw` Module

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,6 +18,12 @@ pub mod store;
 
 use store::DatabaseAdapter;
 
+pub mod raw;
+pub mod store;
+
+use raw::RawModeConfig;
+use store::DatabaseAdapter;
+
 /// Configuration for a single Kafka topic in multi-topic mode.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct TopicConfig {
@@ -44,23 +50,6 @@ pub struct TopicConfig {
     /// Falls back to the global `kafka_auto_offset_reset` when unset.
     #[serde(default)]
     pub auto_offset_reset: Option<String>,
-}
-
-/// Raw mode settings for a topic.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct RawModeConfig {
-    /// The namespace to assign to raw mode activations.
-    pub namespace: Option<String>,
-    /// The application to assign to raw mode activations.
-    pub application: Option<String>,
-    /// The taskname to assign to raw mode activations.
-    pub taskname: Option<String>,
-    /// Processing deadline duration in seconds for raw mode activations.
-    pub processing_deadline_duration: Option<u16>,
-    /// zstd compression level for raw-mode payloads. Defaults to 3 (matching the
-    /// producer's zstandard default). Set to -1 to disable compression.
-    #[serde(default)]
-    pub compression_level: Option<i32>,
 }
 
 /// Configuration for a Kafka cluster.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,10 +14,6 @@ use crate::Args;
 use crate::fetch::MAX_FETCH_THREADS;
 use crate::logging::LogFormat;
 
-pub mod store;
-
-use store::DatabaseAdapter;
-
 pub mod raw;
 pub mod store;
 

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+/// Raw mode settings for a topic.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct RawModeConfig {
+    /// The namespace to assign to raw mode activations.
+    pub namespace: Option<String>,
+    /// The application to assign to raw mode activations.
+    pub application: Option<String>,
+    /// The taskname to assign to raw mode activations.
+    pub taskname: Option<String>,
+    /// Processing deadline duration in seconds for raw mode activations.
+    pub processing_deadline_duration: Option<u16>,
+    /// zstd compression level for raw-mode payloads. Defaults to 3 (matching the
+    /// producer's zstandard default). Set to -1 to disable compression.
+    #[serde(default)]
+    pub compression_level: Option<i32>,
+}

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -9,7 +9,8 @@ use rdkafka::message::OwnedMessage;
 use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivation};
 use uuid::Uuid;
 
-use crate::config::{Config, RawModeConfig};
+use crate::config::Config;
+use crate::config::raw::RawModeConfig;
 use crate::store::activation::{Activation, ActivationStatus};
 
 use super::deserialize_activation::bucket_from_id;


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 3** of my configuration improvement effort. Let's create a new `config::raw` module to keep all configuration related to raw mode, which is primarily `RawModeConfig`.