### PR TITLE
ref(producer): minor metrics improvements

### DIFF
--- a/clients/python/src/taskbroker_client/worker/workerchild.py
+++ b/clients/python/src/taskbroker_client/worker/workerchild.py
@@ -284,16 +284,16 @@ def child_process(
             )
 
         def check_task_future_completion() -> None:
-            # Records how many activations with pending producer futures
-            # the worker child has.
-            metrics.gauge(
-                "taskworker.worker.activations_with_pending_futures",
-                len(pending_task_futures),
-                tags={
-                    "processing_pool": processing_pool_name,
-                },
-            )
             if len(pending_task_futures) > 0:
+                # Records how many activations with pending producer futures
+                # the worker child has. Only records when there are pending activations.
+                metrics.gauge(
+                    "taskworker.worker.activations_with_pending_futures",
+                    len(pending_task_futures),
+                    tags={
+                        "processing_pool": processing_pool_name,
+                    },
+                )
                 for task in pending_task_futures.copy():
                     if all([f.done() for f in task.pending_futures]):
                         await_task_futures(task)
@@ -310,13 +310,13 @@ def child_process(
                 break
 
             try:
+                check_task_future_completion()
                 inflight = child_tasks.get(timeout=1.0)
             except queue.Empty:
                 metrics.incr(
                     "taskworker.worker.child_task_queue_empty",
                     tags={"processing_pool": processing_pool_name},
                 )
-                check_task_future_completion()
                 continue
 
             task_func = _get_known_task(inflight.activation)
@@ -473,8 +473,6 @@ def child_process(
                     task_func=task_func,
                 )
                 pending_task_futures.append(pending_task)
-
-            check_task_future_completion()
 
         # Once we get the shutdown signal, drain any pending futures
         for task in pending_task_futures.copy():


### PR DESCRIPTION
Currently, taskproducer metrics look strange:
- latency max spikes up to 1s: https://app.datadoghq.com/s/FH6-Y3/ij5-abd-evg
  - I think the latency issue is because when the worker tries to fetch from an empty queue, it has a 1s timeout before it runs `check_task_future_completion()`
  - This PR tries to fix this issue by having the worker run `check_task_future_completion()` before it tries to fetch a new task
  - This also simplifies the logic by only calling `check_task_future_completion()` from a single place
- very few activations with pending futures are reported: https://app.datadoghq.com/s/FH6-Y3/cpk-wy4-7mv
  - I think this is because the majority of tasks don't produce anything, so any gauge samples that show a value are getting drowned out by samples reporting `0`
  - This PR tries to fix this by only having the gauge report when there are pending activations in the queue