### PR TITLE
ref(taskbroker): (6) Add `StoreConfig` for Store Configuration

### DIFF
--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -1,5 +1,41 @@
 use serde::{Deserialize, Serialize};
 
+use crate::config::store::DatabaseAdapter;
+
+macro_rules! map {
+    () => {};
+
+    ($deprecated:expr => some($current:expr), $($rest:tt)*) => {
+        if let Some(v) = $deprecated.take() {
+            $current = Some(v);
+        }
+
+        $crate::config::deprecated::map!($($rest)*);
+    };
+
+    ($deprecated:expr => $current:expr, $($rest:tt)*) => {
+        if let Some(v) = $deprecated.take() {
+            $current = v;
+        }
+
+        $crate::config::deprecated::map!($($rest)*);
+    };
+
+    ($deprecated:expr => some($current:expr)) => {
+        if let Some(v) = $deprecated.take() {
+            $current = Some(v);
+        }
+    };
+
+    ($deprecated:expr => $current:expr) => {
+        if let Some(v) = $deprecated.take() {
+            $current = v;
+        }
+    };
+}
+
+pub(crate) use map;
+
 #[derive(PartialEq, Debug, Deserialize, Serialize, Default)]
 pub struct DeprecatedConfig {
     /// The topic to fetch task messages from.
@@ -82,4 +118,99 @@ pub struct DeprecatedConfig {
     /// Enable raw mode for consuming unstructured Kafka messages.
     /// In raw mode, Kafka message bytes are wrapped into TaskActivation.
     pub raw_mode: Option<bool>,
+
+    /// The database adapter to use for the activation store.
+    pub database_adapter: Option<DatabaseAdapter>,
+
+    /// Whether to run the migrations on the database.
+    /// This is only used by the postgres database adapter, since
+    /// in production the migrations shouldn't be run by the taskbroker.
+    pub run_migrations: Option<bool>,
+
+    /// The host of the postgres database to use for the activation store.
+    pub pg_host: Option<String>,
+
+    /// The port of the postgres database to use for the activation store.
+    pub pg_port: Option<u16>,
+
+    // User permitted to run DDL operations.
+    pub pg_ddl_username: Option<String>,
+
+    /// The username of the postgres database to use for the activation store.
+    pub pg_username: Option<String>,
+
+    /// The password of the postgres database to use for the activation store.
+    pub pg_password: Option<String>,
+
+    /// Password for the user permitted to run DDL operations.
+    pub pg_ddl_password: Option<String>,
+
+    /// The name of the postgres database to use for the activation store.
+    pub pg_database_name: Option<String>,
+
+    /// The default postgres database to use for migrations..
+    pub pg_default_database_name: Option<String>,
+
+    /// Extra query parameters that can be added to the postgres connection string. Should be in the format of "key=value&key2=value2".
+    /// For example, "sslmode=require&sslrootcert=/path/to/root.crt".
+    pub pg_extra_query_params: Option<String>,
+
+    /// The path to the sqlite database
+    pub db_path: Option<String>,
+
+    /// The amount of time to wait before retrying writes to db when write fails.
+    pub db_write_failure_backoff_ms: Option<u64>,
+
+    /// The maximum number of times to retry a transient database query error
+    /// before surfacing the error. When None, queries are not retried.
+    pub db_query_max_retries: Option<u32>,
+
+    /// The delay in milliseconds between query retry attempts.
+    pub db_query_retry_delay_ms: Option<u64>,
+
+    /// The maximum number of tasks that are buffered
+    /// before being written to ActivationStore (sqlite).
+    pub db_insert_batch_max_len: Option<usize>,
+
+    /// The maximum number of bytes that are buffered
+    /// before being written to ActivationStore (sqlite).
+    pub db_insert_batch_max_size: Option<usize>,
+
+    /// The time in milliseconds to buffer tasks
+    /// before being written to ActivationStore (sqlite).
+    pub db_insert_batch_max_time_ms: Option<u64>,
+
+    /// The maximum size of the sqlite database in bytes.
+    /// If the database reaches or exceeds this size, ingestion will
+    /// pause until the database size is reduced.
+    pub db_max_size: Option<u64>,
+
+    /// The maximum number of pending records that can be
+    /// in the ActivationStore (sqlite)
+    pub max_pending_count: Option<usize>,
+
+    /// The maximum number of delay records that can be
+    /// in the ActivationStore (sqlite)
+    pub max_delay_count: Option<usize>,
+
+    /// The maximum number of processing records that can be
+    /// in the ActivationStore (sqlite)
+    pub max_processing_count: Option<usize>,
+
+    /// The maximum number of times a task can be reset from
+    /// processing back to pending. When this limit is reached,
+    /// the activation will be discarded/deadlettered.
+    pub max_processing_attempts: Option<usize>,
+
+    /// The number of additional seconds that processing deadlines
+    /// are extended by. This helps reduce broker deadline resets when
+    /// brokers are under load, or there are small networking delays.
+    pub processing_deadline_grace_sec: Option<u64>,
+
+    /// The number of pages to vacuum from sqlite when vacuum is run.
+    /// If None, all pages will be vacuumed.
+    pub vacuum_page_count: Option<usize>,
+
+    /// Enable additional metrics for the sqlite.
+    pub enable_sqlite_status_metrics: Option<bool>,
 }

--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -5,12 +5,14 @@ use crate::config::store::DatabaseAdapter;
 macro_rules! map {
     () => {};
 
+    // An optional deprecated value ALWAYS wins
     ($deprecated:expr => some($current:expr), $($rest:tt)*) => {
         $current = $deprecated.take();
 
         $crate::config::deprecated::map!($($rest)*);
     };
 
+    // A plain deprecated value ONLY wins when it's provided
     ($deprecated:expr => $current:expr, $($rest:tt)*) => {
         if let Some(v) = $deprecated.take() {
             $current = v;
@@ -19,10 +21,12 @@ macro_rules! map {
         $crate::config::deprecated::map!($($rest)*);
     };
 
+    // An optional deprecated value ALWAYS wins
     ($deprecated:expr => some($current:expr)) => {
         $current = $deprecated.take();
     };
 
+    // A plain deprecated value ONLY wins when it's provided
     ($deprecated:expr => $current:expr) => {
         if let Some(v) = $deprecated.take() {
             $current = v;

--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -5,28 +5,12 @@ use crate::config::store::DatabaseAdapter;
 macro_rules! map {
     () => {};
 
-    // An optional deprecated value ALWAYS wins
-    ($deprecated:expr => some($current:expr), $($rest:tt)*) => {
-        $current = $deprecated.take();
-
-        $crate::config::deprecated::map!($($rest)*);
-    };
-
-    // A plain deprecated value ONLY wins when it's provided
-    ($deprecated:expr => $current:expr, $($rest:tt)*) => {
-        if let Some(v) = $deprecated.take() {
-            $current = v;
-        }
-
-        $crate::config::deprecated::map!($($rest)*);
-    };
-
-    // An optional deprecated value ALWAYS wins
+    // An optional deprecated value always wins
     ($deprecated:expr => some($current:expr)) => {
         $current = $deprecated.take();
     };
 
-    // A plain deprecated value ONLY wins when it's provided
+    // A plain deprecated value only wins when it's provided
     ($deprecated:expr => $current:expr) => {
         if let Some(v) = $deprecated.take() {
             $current = v;

--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -6,9 +6,7 @@ macro_rules! map {
     () => {};
 
     ($deprecated:expr => some($current:expr), $($rest:tt)*) => {
-        if let Some(v) = $deprecated.take() {
-            $current = Some(v);
-        }
+        $current = $deprecated.take();
 
         $crate::config::deprecated::map!($($rest)*);
     };
@@ -22,9 +20,7 @@ macro_rules! map {
     };
 
     ($deprecated:expr => some($current:expr)) => {
-        if let Some(v) = $deprecated.take() {
-            $current = Some(v);
-        }
+        $current = $deprecated.take();
     };
 
     ($deprecated:expr => $current:expr) => {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -325,6 +325,9 @@ impl Config {
         builder = builder.merge(Env::prefixed("TASKBROKER_").split("__"));
         let mut config: Config = builder.extract()?;
 
+        // Map deprecated fields to current fields
+        config.map_deprecated_options();
+
         // Normalize and validate Kafka values
         config.normalize_and_validate()?;
 
@@ -332,6 +335,38 @@ impl Config {
         config.validate()?;
 
         Ok(config)
+    }
+
+    fn map_deprecated_options(&mut self) {
+        // Map store configuration options
+        deprecated::map! {
+            self.deprecated.database_adapter               => self.store.database_adapter,
+            self.deprecated.run_migrations                 => self.store.run_migrations,
+            self.deprecated.pg_host                        => self.store.pg_host,
+            self.deprecated.pg_port                        => self.store.pg_port,
+            self.deprecated.pg_ddl_username                => self.store.pg_ddl_username,
+            self.deprecated.pg_username                    => self.store.pg_username,
+            self.deprecated.pg_password                    => self.store.pg_password,
+            self.deprecated.pg_ddl_password                => self.store.pg_ddl_password,
+            self.deprecated.pg_database_name               => self.store.pg_database_name,
+            self.deprecated.pg_default_database_name       => self.store.pg_default_database_name,
+            self.deprecated.pg_extra_query_params          => some(self.store.pg_extra_query_params),
+            self.deprecated.db_path                        => self.store.db_path,
+            self.deprecated.db_write_failure_backoff_ms    => self.store.db_write_failure_backoff_ms,
+            self.deprecated.db_query_max_retries           => some(self.store.db_query_max_retries),
+            self.deprecated.db_query_retry_delay_ms        => self.store.db_query_retry_delay_ms,
+            self.deprecated.db_insert_batch_max_len        => self.store.db_insert_batch_max_len,
+            self.deprecated.db_insert_batch_max_size       => self.store.db_insert_batch_max_size,
+            self.deprecated.db_insert_batch_max_time_ms    => self.store.db_insert_batch_max_time_ms,
+            self.deprecated.db_max_size                    => some(self.store.db_max_size),
+            self.deprecated.max_pending_count              => self.store.max_pending_count,
+            self.deprecated.max_delay_count                => self.store.max_delay_count,
+            self.deprecated.max_processing_count           => self.store.max_processing_count,
+            self.deprecated.max_processing_attempts        => self.store.max_processing_attempts,
+            self.deprecated.processing_deadline_grace_sec  => self.store.processing_deadline_grace_sec,
+            self.deprecated.vacuum_page_count              => some(self.store.vacuum_page_count),
+            self.deprecated.enable_sqlite_status_metrics   => self.store.enable_sqlite_status_metrics,
+        };
     }
 
     /// Normalize the legacy single-topic config into the new multi-topic

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,6 +11,7 @@ use tracing::warn;
 use validator::{Validate, ValidationError};
 
 use crate::Args;
+use crate::config::store::StoreConfig;
 use crate::fetch::MAX_FETCH_THREADS;
 use crate::logging::LogFormat;
 
@@ -110,96 +111,11 @@ pub struct Config {
     /// The number of ms for timeouts when publishing messages to kafka.
     pub kafka_send_timeout_ms: u64,
 
-    /// The database adapter to use for the activation store.
-    pub database_adapter: DatabaseAdapter,
-
-    /// Whether to run the migrations on the database.
-    /// This is only used by the postgres database adapter, since
-    /// in production the migrations shouldn't be run by the taskbroker.
-    pub run_migrations: bool,
-
-    /// The host of the postgres database to use for the activation store.
-    pub pg_host: String,
-
-    /// The port of the postgres database to use for the activation store.
-    pub pg_port: u16,
-
-    // User permitted to run DDL operations.
-    pub pg_ddl_username: String,
-
-    /// The username of the postgres database to use for the activation store.
-    pub pg_username: String,
-
-    /// The password of the postgres database to use for the activation store.
-    pub pg_password: String,
-
-    /// Password for the user permitted to run DDL operations.
-    pub pg_ddl_password: String,
-
-    /// The name of the postgres database to use for the activation store.
-    pub pg_database_name: String,
-
-    /// The default postgres database to use for migrations..
-    pub pg_default_database_name: String,
-
-    /// Extra query parameters that can be added to the postgres connection string. Should be in the format of "key=value&key2=value2".
-    /// For example, "sslmode=require&sslrootcert=/path/to/root.crt".
-    pub pg_extra_query_params: Option<String>,
-
-    /// The path to the sqlite database
-    pub db_path: String,
-
-    /// The amount of time to wait before retrying writes to db when write fails.
-    pub db_write_failure_backoff_ms: u64,
-
-    /// The maximum number of times to retry a transient database query error
-    /// before surfacing the error. When None, queries are not retried.
-    pub db_query_max_retries: Option<u32>,
-
-    /// The delay in milliseconds between query retry attempts.
-    pub db_query_retry_delay_ms: u64,
-
-    /// The maximum number of tasks that are buffered
-    /// before being written to ActivationStore (sqlite).
-    pub db_insert_batch_max_len: usize,
-
-    /// The maximum number of bytes that are buffered
-    /// before being written to ActivationStore (sqlite).
-    pub db_insert_batch_max_size: usize,
-
-    /// The time in milliseconds to buffer tasks
-    /// before being written to ActivationStore (sqlite).
-    pub db_insert_batch_max_time_ms: u64,
-
-    /// The maximum size of the sqlite database in bytes.
-    /// If the database reaches or exceeds this size, ingestion will
-    /// pause until the database size is reduced.
-    pub db_max_size: Option<u64>,
+    /// The activation store configuration.
+    pub store: StoreConfig,
 
     /// The path to the runtime config file
     pub runtime_config_path: Option<String>,
-
-    /// The maximum number of pending records that can be
-    /// in the ActivationStore (sqlite)
-    pub max_pending_count: usize,
-
-    /// The maximum number of delay records that can be
-    /// in the ActivationStore (sqlite)
-    pub max_delay_count: usize,
-
-    /// The maximum number of processing records that can be
-    /// in the ActivationStore (sqlite)
-    pub max_processing_count: usize,
-
-    /// The maximum number of times a task can be reset from
-    /// processing back to pending. When this limit is reached,
-    /// the activation will be discarded/deadlettered.
-    pub max_processing_attempts: usize,
-
-    /// The number of additional seconds that processing deadlines
-    /// are extended by. This helps reduce broker deadline resets when
-    /// brokers are under load, or there are small networking delays.
-    pub processing_deadline_grace_sec: u64,
 
     /// The frequency at which upkeep tasks
     /// (discarding, retrying activations, etc.) are executed.
@@ -233,10 +149,6 @@ pub struct Config {
     /// Should be at least as large as max_message_size.
     pub grpc_max_message_size: usize,
 
-    /// The number of pages to vacuum from sqlite when vacuum is run.
-    /// If None, all pages will be vacuumed.
-    pub vacuum_page_count: Option<usize>,
-
     /// Enable to have the application perform `VACUUM` on the database
     /// when it starts up, but before the GRPC server, consumer and upkeep begin.
     pub full_vacuum_on_start: bool,
@@ -247,9 +159,6 @@ pub struct Config {
 
     /// The interval in milliseconds between full `VACUUM`s on the database by the upkeep thread.
     pub vacuum_interval_ms: u64,
-
-    /// Enable additional metrics for the sqlite.
-    pub enable_sqlite_status_metrics: bool,
 
     /// When true, the upkeep loop emits the current `async_backtrace::taskdump_tree`
     /// snapshot at `debug!` every 30 seconds. Useful for diagnosing hangs in the
@@ -364,31 +273,8 @@ impl Default for Config {
             kafka_auto_commit_interval_ms: 5000,
             kafka_auto_offset_reset: "latest".to_owned(),
             kafka_send_timeout_ms: 500,
-            db_path: "./taskbroker-inflight.sqlite".to_owned(),
-            database_adapter: DatabaseAdapter::Sqlite,
-            run_migrations: false,
-            pg_host: "sentry-postgres-1".to_owned(),
-            pg_port: 5432,
-            pg_ddl_username: "postgres".to_owned(),
-            pg_ddl_password: "password".to_owned(),
-            pg_username: "postgres".to_owned(),
-            pg_password: "password".to_owned(),
-            pg_database_name: "default".to_owned(),
-            pg_default_database_name: "postgres".to_owned(),
-            pg_extra_query_params: None,
-            db_write_failure_backoff_ms: 4000,
-            db_query_max_retries: Some(3),
-            db_query_retry_delay_ms: 100,
-            db_insert_batch_max_len: 256,
-            db_insert_batch_max_size: 16_000_000,
-            db_insert_batch_max_time_ms: 1000,
-            db_max_size: Some(3000000000),
+            store: StoreConfig::default(),
             runtime_config_path: None,
-            max_pending_count: 2048,
-            max_delay_count: 8192,
-            max_processing_count: 2048,
-            max_processing_attempts: 5,
-            processing_deadline_grace_sec: 3,
             upkeep_task_interval_ms: 1000,
             upkeep_unhealthy_interval_ms: 5000,
             health_check_killswitched: false,
@@ -397,11 +283,9 @@ impl Default for Config {
             max_delayed_task_allowed_sec: 3600,
             max_message_size: 5000000,
             grpc_max_message_size: 52 * 1024 * 1024, // 52MB
-            vacuum_page_count: None,
             full_vacuum_on_start: true,
             full_vacuum_on_upkeep: true,
             vacuum_interval_ms: 30000,
-            enable_sqlite_status_metrics: true,
             log_async_backtrace: false,
             delivery_mode: DeliveryMode::Pull,
             fetch_threads: 1,
@@ -698,7 +582,7 @@ impl Config {
         // avoid that contention (e.g. filtering by (topic, partition) or another
         // mechanism entirely). Reject the combination here, before any consumer
         // spawns.
-        if consumable.len() > 1 && self.database_adapter == DatabaseAdapter::Postgres {
+        if consumable.len() > 1 && self.store.database_adapter == DatabaseAdapter::Postgres {
             return Err(anyhow!(
                 "multi-topic consumption ({} consumable topics) is not supported with the \
                  postgres database adapter; use the sqlite adapter or a single consumable topic",
@@ -987,10 +871,10 @@ mod tests {
         assert_eq!(config.log_filter, "info,librdkafka=warn,h2=off");
         assert_eq!(config.log_format, LogFormat::Text);
         assert_eq!(config.grpc_port, 50051);
-        assert_eq!(config.db_path, "./taskbroker-inflight.sqlite");
-        assert_eq!(config.max_pending_count, 2048);
-        assert_eq!(config.max_processing_count, 2048);
-        assert_eq!(config.vacuum_page_count, None);
+        assert_eq!(config.store.db_path, "./taskbroker-inflight.sqlite");
+        assert_eq!(config.store.max_pending_count, 2048);
+        assert_eq!(config.store.max_processing_count, 2048);
+        assert_eq!(config.store.vacuum_page_count, None);
         assert_eq!(
             config.worker_map.get("sentry").map(String::as_str),
             Some("http://127.0.0.1:50052")
@@ -1126,13 +1010,13 @@ mod tests {
             assert_eq!(config.kafka_auto_offset_reset, "earliest".to_owned());
             assert_eq!(config.kafka_session_timeout_ms, 6000.to_owned());
             assert_eq!(config.kafka_deadletter_topic, "error-tasks-dlq".to_owned());
-            assert_eq!(config.database_adapter, DatabaseAdapter::Postgres);
-            assert_eq!(config.db_path, "./taskbroker-error.sqlite".to_owned());
-            assert_eq!(config.max_pending_count, 512);
-            assert_eq!(config.max_processing_count, 512);
-            assert_eq!(config.max_processing_attempts, 5);
-            assert_eq!(config.vacuum_page_count, Some(1000));
-            assert_eq!(config.db_max_size, Some(3_000_000_000));
+            assert_eq!(config.store.database_adapter, DatabaseAdapter::Postgres);
+            assert_eq!(config.store.db_path, "./taskbroker-error.sqlite".to_owned());
+            assert_eq!(config.store.max_pending_count, 512);
+            assert_eq!(config.store.max_processing_count, 512);
+            assert_eq!(config.store.max_processing_attempts, 5);
+            assert_eq!(config.store.vacuum_page_count, Some(1000));
+            assert_eq!(config.store.db_max_size, Some(3_000_000_000));
             assert!(config.full_vacuum_on_start);
             assert_eq!(
                 config.worker_map,
@@ -1162,8 +1046,8 @@ mod tests {
             };
             let config = Config::from_args(&args).unwrap();
             assert_eq!(config.log_filter, "error");
-            assert_eq!(config.database_adapter, DatabaseAdapter::Postgres);
-            assert_eq!(config.max_processing_attempts, 5);
+            assert_eq!(config.store.database_adapter, DatabaseAdapter::Postgres);
+            assert_eq!(config.store.max_processing_attempts, 5);
 
             Ok(())
         });
@@ -1191,10 +1075,13 @@ mod tests {
                 "127.0.0.1:9092"
             );
             assert_eq!(config.kafka_deadletter_topic, "taskworker-dlq".to_owned());
-            assert_eq!(config.db_path, "./taskbroker-inflight.sqlite".to_owned());
-            assert_eq!(config.max_pending_count, 2048);
-            assert_eq!(config.max_processing_count, 2048);
-            assert_eq!(config.max_processing_attempts, 5);
+            assert_eq!(
+                config.store.db_path,
+                "./taskbroker-inflight.sqlite".to_owned()
+            );
+            assert_eq!(config.store.max_pending_count, 2048);
+            assert_eq!(config.store.max_processing_count, 2048);
+            assert_eq!(config.store.max_processing_attempts, 5);
             assert_eq!(
                 config.default_metrics_tags,
                 BTreeMap::from([("key".to_owned(), "value".to_owned())])

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,6 +25,9 @@ use kafka::{ClusterConfig, TopicConfig};
 use raw::RawModeConfig;
 use store::DatabaseAdapter;
 
+/// Used to identify whether a configuration option was provided by a user, or whether it is a default.
+const DEFAULT_CONFIG_PROVIDER: &str = "TaskbrokerConfig";
+
 /// How the taskbroker delivers tasks to workers.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -326,7 +329,7 @@ impl Config {
         let mut config: Config = builder.extract()?;
 
         // Map deprecated fields to current fields
-        config.map_deprecated_options();
+        config.map_deprecated_options(&mut builder);
 
         // Normalize and validate Kafka values
         config.normalize_and_validate()?;
@@ -337,42 +340,146 @@ impl Config {
         Ok(config)
     }
 
-    /// Map deprecated options to new options.
-    /// If the deprecated value is plain (like an integer or a string), it's ONLY used when it's actually provided.
-    /// If the deprecated value is optional, it's ALWAYS used no matter what. So...
-    /// - If `db_max_size` is not provided, then `store.db_max_size` is `None`
-    /// - If `db_max_size` is `null`, then `store.db_max_size` is `None`
-    /// - If `db_max_size` is 5, then `store.db_max_size` is `Some(5)`
-    fn map_deprecated_options(&mut self) {
-        // Map store configuration options
-        deprecated::map! {
-            self.deprecated.database_adapter               => self.store.database_adapter,
-            self.deprecated.run_migrations                 => self.store.run_migrations,
-            self.deprecated.pg_host                        => self.store.pg_host,
-            self.deprecated.pg_port                        => self.store.pg_port,
-            self.deprecated.pg_ddl_username                => self.store.pg_ddl_username,
-            self.deprecated.pg_username                    => self.store.pg_username,
-            self.deprecated.pg_password                    => self.store.pg_password,
-            self.deprecated.pg_ddl_password                => self.store.pg_ddl_password,
-            self.deprecated.pg_database_name               => self.store.pg_database_name,
-            self.deprecated.pg_default_database_name       => self.store.pg_default_database_name,
-            self.deprecated.pg_extra_query_params          => some(self.store.pg_extra_query_params),
-            self.deprecated.db_path                        => self.store.db_path,
-            self.deprecated.db_write_failure_backoff_ms    => self.store.db_write_failure_backoff_ms,
-            self.deprecated.db_query_max_retries           => some(self.store.db_query_max_retries),
-            self.deprecated.db_query_retry_delay_ms        => self.store.db_query_retry_delay_ms,
-            self.deprecated.db_insert_batch_max_len        => self.store.db_insert_batch_max_len,
-            self.deprecated.db_insert_batch_max_size       => self.store.db_insert_batch_max_size,
-            self.deprecated.db_insert_batch_max_time_ms    => self.store.db_insert_batch_max_time_ms,
-            self.deprecated.db_max_size                    => some(self.store.db_max_size),
-            self.deprecated.max_pending_count              => self.store.max_pending_count,
-            self.deprecated.max_delay_count                => self.store.max_delay_count,
-            self.deprecated.max_processing_count           => self.store.max_processing_count,
-            self.deprecated.max_processing_attempts        => self.store.max_processing_attempts,
-            self.deprecated.processing_deadline_grace_sec  => self.store.processing_deadline_grace_sec,
-            self.deprecated.vacuum_page_count              => some(self.store.vacuum_page_count),
-            self.deprecated.enable_sqlite_status_metrics   => self.store.enable_sqlite_status_metrics,
-        };
+    /// Map deprecated options to new options to maintain backwards compatability. Here is an example using `db_max_size`...
+    /// - If the user provides the new field `store.db_max_size`, it will be used
+    /// - If the user does not provide `store.db_max_size`, use the deprecated field `db_max_size` instead
+    fn map_deprecated_options(&mut self, builder: &mut Figment) {
+        // Nested function definition since it's not used anywhere else
+        fn user_provided(builder: &Figment, key: &str) -> bool {
+            builder
+                .find_metadata(key)
+                .is_some_and(|metadata| metadata.name != DEFAULT_CONFIG_PROVIDER)
+        }
+
+        if !user_provided(builder, "store.database_adapter") {
+            // User did not provide `store.database_adapter`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.database_adapter => self.store.database_adapter);
+        }
+
+        if !user_provided(builder, "store.run_migrations") {
+            // User did not provide `store.run_migrations`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.run_migrations => self.store.run_migrations);
+        }
+
+        if !user_provided(builder, "store.pg_host") {
+            // User did not provide `store.pg_host`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.pg_host => self.store.pg_host);
+        }
+
+        if !user_provided(builder, "store.pg_port") {
+            // User did not provide `store.pg_port`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.pg_port => self.store.pg_port);
+        }
+
+        if !user_provided(builder, "store.pg_ddl_username") {
+            // User did not provide `store.pg_ddl_username`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.pg_ddl_username => self.store.pg_ddl_username);
+        }
+
+        if !user_provided(builder, "store.pg_username") {
+            // User did not provide `store.pg_username`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.pg_username => self.store.pg_username);
+        }
+
+        if !user_provided(builder, "store.pg_password") {
+            // User did not provide `store.pg_password`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.pg_password => self.store.pg_password);
+        }
+
+        if !user_provided(builder, "store.pg_ddl_password") {
+            // User did not provide `store.pg_ddl_password`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.pg_ddl_password => self.store.pg_ddl_password);
+        }
+
+        if !user_provided(builder, "store.pg_database_name") {
+            // User did not provide `store.pg_database_name`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.pg_database_name => self.store.pg_database_name);
+        }
+
+        if !user_provided(builder, "store.pg_default_database_name") {
+            // User did not provide `store.pg_default_database_name`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.pg_default_database_name => self.store.pg_default_database_name);
+        }
+
+        if !user_provided(builder, "store.pg_extra_query_params") {
+            // User did not provide `store.pg_extra_query_params`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.pg_extra_query_params => some(self.store.pg_extra_query_params));
+        }
+
+        if !user_provided(builder, "store.db_path") {
+            // User did not provide `store.db_path`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.db_path => self.store.db_path);
+        }
+
+        if !user_provided(builder, "store.db_write_failure_backoff_ms") {
+            // User did not provide `store.db_write_failure_backoff_ms`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.db_write_failure_backoff_ms => self.store.db_write_failure_backoff_ms);
+        }
+
+        if !user_provided(builder, "store.db_query_max_retries") {
+            // User did not provide `store.db_query_max_retries`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.db_query_max_retries => some(self.store.db_query_max_retries));
+        }
+
+        if !user_provided(builder, "store.db_query_retry_delay_ms") {
+            // User did not provide `store.db_query_retry_delay_ms`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.db_query_retry_delay_ms => self.store.db_query_retry_delay_ms);
+        }
+
+        if !user_provided(builder, "store.db_insert_batch_max_len") {
+            // User did not provide `store.db_insert_batch_max_len`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.db_insert_batch_max_len => self.store.db_insert_batch_max_len);
+        }
+
+        if !user_provided(builder, "store.db_insert_batch_max_size") {
+            // User did not provide `store.db_insert_batch_max_size`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.db_insert_batch_max_size => self.store.db_insert_batch_max_size);
+        }
+
+        if !user_provided(builder, "store.db_insert_batch_max_time_ms") {
+            // User did not provide `store.db_insert_batch_max_time_ms`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.db_insert_batch_max_time_ms => self.store.db_insert_batch_max_time_ms);
+        }
+
+        if !user_provided(builder, "store.db_max_size") {
+            // User did not provide `store.db_max_size`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.db_max_size => some(self.store.db_max_size));
+        }
+
+        if !user_provided(builder, "store.max_pending_count") {
+            // User did not provide `store.max_pending_count`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.max_pending_count => self.store.max_pending_count);
+        }
+
+        if !user_provided(builder, "store.max_delay_count") {
+            // User did not provide `store.max_delay_count`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.max_delay_count => self.store.max_delay_count);
+        }
+
+        if !user_provided(builder, "store.max_processing_count") {
+            // User did not provide `store.max_processing_count`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.max_processing_count => self.store.max_processing_count);
+        }
+
+        if !user_provided(builder, "store.max_processing_attempts") {
+            // User did not provide `store.max_processing_attempts`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.max_processing_attempts => self.store.max_processing_attempts);
+        }
+
+        if !user_provided(builder, "store.processing_deadline_grace_sec") {
+            // User did not provide `store.processing_deadline_grace_sec`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.processing_deadline_grace_sec => self.store.processing_deadline_grace_sec);
+        }
+
+        if !user_provided(builder, "store.vacuum_page_count") {
+            // User did not provide `store.vacuum_page_count`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.vacuum_page_count => some(self.store.vacuum_page_count));
+        }
+
+        if !user_provided(builder, "store.enable_sqlite_status_metrics") {
+            // User did not provide `store.enable_sqlite_status_metrics`, fall back onto the deprecated version of that field
+            deprecated::map!(self.deprecated.enable_sqlite_status_metrics => self.store.enable_sqlite_status_metrics);
+        }
     }
 
     /// Normalize the legacy single-topic config into the new multi-topic
@@ -872,7 +979,7 @@ impl Config {
 
 impl Provider for Config {
     fn metadata(&self) -> Metadata {
-        Metadata::named("Taskbroker config")
+        Metadata::named(DEFAULT_CONFIG_PROVIDER)
     }
 
     fn data(&self) -> Result<figment::value::Map<Profile, figment::value::Dict>, figment::Error> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -340,7 +340,8 @@ impl Config {
         Ok(config)
     }
 
-    /// Map deprecated options to new options to maintain backwards compatability. Here is an example using `db_max_size`...
+    /// Map deprecated options to maintain backwards compatability.
+    /// Here is an example using `db_max_size`...
     /// - If the user provides the new field `store.db_max_size`, it will be used
     /// - If the user does not provide `store.db_max_size`, use the deprecated field `db_max_size` instead
     fn map_deprecated_options(&mut self, builder: &mut Figment) {
@@ -353,132 +354,184 @@ impl Config {
 
         if !user_provided(builder, "store.database_adapter") {
             // User did not provide `store.database_adapter`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.database_adapter => self.store.database_adapter);
+            deprecated::map! {
+                self.deprecated.database_adapter => self.store.database_adapter
+            };
         }
 
         if !user_provided(builder, "store.run_migrations") {
             // User did not provide `store.run_migrations`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.run_migrations => self.store.run_migrations);
+            deprecated::map! {
+                self.deprecated.run_migrations => self.store.run_migrations
+            };
         }
 
         if !user_provided(builder, "store.pg_host") {
             // User did not provide `store.pg_host`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.pg_host => self.store.pg_host);
+            deprecated::map! {
+                self.deprecated.pg_host => self.store.pg_host
+            };
         }
 
         if !user_provided(builder, "store.pg_port") {
             // User did not provide `store.pg_port`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.pg_port => self.store.pg_port);
+            deprecated::map! {
+                self.deprecated.pg_port => self.store.pg_port
+            };
         }
 
         if !user_provided(builder, "store.pg_ddl_username") {
             // User did not provide `store.pg_ddl_username`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.pg_ddl_username => self.store.pg_ddl_username);
+            deprecated::map! {
+                self.deprecated.pg_ddl_username => self.store.pg_ddl_username
+            };
         }
 
         if !user_provided(builder, "store.pg_username") {
             // User did not provide `store.pg_username`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.pg_username => self.store.pg_username);
+            deprecated::map! {
+                self.deprecated.pg_username => self.store.pg_username
+            };
         }
 
         if !user_provided(builder, "store.pg_password") {
             // User did not provide `store.pg_password`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.pg_password => self.store.pg_password);
+            deprecated::map! {
+                self.deprecated.pg_password => self.store.pg_password
+            };
         }
 
         if !user_provided(builder, "store.pg_ddl_password") {
             // User did not provide `store.pg_ddl_password`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.pg_ddl_password => self.store.pg_ddl_password);
+            deprecated::map! {
+                self.deprecated.pg_ddl_password => self.store.pg_ddl_password
+            };
         }
 
         if !user_provided(builder, "store.pg_database_name") {
             // User did not provide `store.pg_database_name`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.pg_database_name => self.store.pg_database_name);
+            deprecated::map! {
+                self.deprecated.pg_database_name => self.store.pg_database_name
+            };
         }
 
         if !user_provided(builder, "store.pg_default_database_name") {
             // User did not provide `store.pg_default_database_name`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.pg_default_database_name => self.store.pg_default_database_name);
+            deprecated::map! {
+                self.deprecated.pg_default_database_name => self.store.pg_default_database_name
+            };
         }
 
         if !user_provided(builder, "store.pg_extra_query_params") {
             // User did not provide `store.pg_extra_query_params`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.pg_extra_query_params => some(self.store.pg_extra_query_params));
+            deprecated::map! {
+                self.deprecated.pg_extra_query_params => some(self.store.pg_extra_query_params)
+            };
         }
 
         if !user_provided(builder, "store.db_path") {
             // User did not provide `store.db_path`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.db_path => self.store.db_path);
+            deprecated::map! {
+                self.deprecated.db_path => self.store.db_path
+            };
         }
 
         if !user_provided(builder, "store.db_write_failure_backoff_ms") {
             // User did not provide `store.db_write_failure_backoff_ms`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.db_write_failure_backoff_ms => self.store.db_write_failure_backoff_ms);
+            deprecated::map! {
+                self.deprecated.db_write_failure_backoff_ms => self.store.db_write_failure_backoff_ms
+            };
         }
 
         if !user_provided(builder, "store.db_query_max_retries") {
             // User did not provide `store.db_query_max_retries`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.db_query_max_retries => some(self.store.db_query_max_retries));
+            deprecated::map! {
+                self.deprecated.db_query_max_retries => some(self.store.db_query_max_retries)
+            };
         }
 
         if !user_provided(builder, "store.db_query_retry_delay_ms") {
             // User did not provide `store.db_query_retry_delay_ms`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.db_query_retry_delay_ms => self.store.db_query_retry_delay_ms);
+            deprecated::map! {
+                self.deprecated.db_query_retry_delay_ms => self.store.db_query_retry_delay_ms
+            };
         }
 
         if !user_provided(builder, "store.db_insert_batch_max_len") {
             // User did not provide `store.db_insert_batch_max_len`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.db_insert_batch_max_len => self.store.db_insert_batch_max_len);
+            deprecated::map! {
+                self.deprecated.db_insert_batch_max_len => self.store.db_insert_batch_max_len
+            };
         }
 
         if !user_provided(builder, "store.db_insert_batch_max_size") {
             // User did not provide `store.db_insert_batch_max_size`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.db_insert_batch_max_size => self.store.db_insert_batch_max_size);
+            deprecated::map! {
+                self.deprecated.db_insert_batch_max_size => self.store.db_insert_batch_max_size
+            };
         }
 
         if !user_provided(builder, "store.db_insert_batch_max_time_ms") {
             // User did not provide `store.db_insert_batch_max_time_ms`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.db_insert_batch_max_time_ms => self.store.db_insert_batch_max_time_ms);
+            deprecated::map! {
+                self.deprecated.db_insert_batch_max_time_ms => self.store.db_insert_batch_max_time_ms
+            };
         }
 
         if !user_provided(builder, "store.db_max_size") {
             // User did not provide `store.db_max_size`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.db_max_size => some(self.store.db_max_size));
+            deprecated::map! {
+                self.deprecated.db_max_size => some(self.store.db_max_size)
+            };
         }
 
         if !user_provided(builder, "store.max_pending_count") {
             // User did not provide `store.max_pending_count`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.max_pending_count => self.store.max_pending_count);
+            deprecated::map! {
+                self.deprecated.max_pending_count => self.store.max_pending_count
+            };
         }
 
         if !user_provided(builder, "store.max_delay_count") {
             // User did not provide `store.max_delay_count`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.max_delay_count => self.store.max_delay_count);
+            deprecated::map! {
+                self.deprecated.max_delay_count => self.store.max_delay_count
+            };
         }
 
         if !user_provided(builder, "store.max_processing_count") {
             // User did not provide `store.max_processing_count`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.max_processing_count => self.store.max_processing_count);
+            deprecated::map! {
+                self.deprecated.max_processing_count => self.store.max_processing_count
+            };
         }
 
         if !user_provided(builder, "store.max_processing_attempts") {
             // User did not provide `store.max_processing_attempts`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.max_processing_attempts => self.store.max_processing_attempts);
+            deprecated::map! {
+                self.deprecated.max_processing_attempts => self.store.max_processing_attempts
+            };
         }
 
         if !user_provided(builder, "store.processing_deadline_grace_sec") {
             // User did not provide `store.processing_deadline_grace_sec`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.processing_deadline_grace_sec => self.store.processing_deadline_grace_sec);
+            deprecated::map! {
+                self.deprecated.processing_deadline_grace_sec => self.store.processing_deadline_grace_sec
+            };
         }
 
         if !user_provided(builder, "store.vacuum_page_count") {
             // User did not provide `store.vacuum_page_count`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.vacuum_page_count => some(self.store.vacuum_page_count));
+            deprecated::map! {
+                self.deprecated.vacuum_page_count => some(self.store.vacuum_page_count)
+            };
         }
 
         if !user_provided(builder, "store.enable_sqlite_status_metrics") {
             // User did not provide `store.enable_sqlite_status_metrics`, fall back onto the deprecated version of that field
-            deprecated::map!(self.deprecated.enable_sqlite_status_metrics => self.store.enable_sqlite_status_metrics);
+            deprecated::map! {
+                self.deprecated.enable_sqlite_status_metrics => self.store.enable_sqlite_status_metrics
+            };
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -352,183 +352,158 @@ impl Config {
                 .is_some_and(|metadata| metadata.name != DEFAULT_CONFIG_PROVIDER)
         }
 
+        // This field was not provided, so use the deprecated version instead
         if !user_provided(builder, "store.database_adapter") {
-            // User did not provide `store.database_adapter`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.database_adapter => self.store.database_adapter
             };
         }
 
         if !user_provided(builder, "store.run_migrations") {
-            // User did not provide `store.run_migrations`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.run_migrations => self.store.run_migrations
             };
         }
 
         if !user_provided(builder, "store.pg_host") {
-            // User did not provide `store.pg_host`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.pg_host => self.store.pg_host
             };
         }
 
         if !user_provided(builder, "store.pg_port") {
-            // User did not provide `store.pg_port`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.pg_port => self.store.pg_port
             };
         }
 
         if !user_provided(builder, "store.pg_ddl_username") {
-            // User did not provide `store.pg_ddl_username`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.pg_ddl_username => self.store.pg_ddl_username
             };
         }
 
         if !user_provided(builder, "store.pg_username") {
-            // User did not provide `store.pg_username`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.pg_username => self.store.pg_username
             };
         }
 
         if !user_provided(builder, "store.pg_password") {
-            // User did not provide `store.pg_password`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.pg_password => self.store.pg_password
             };
         }
 
         if !user_provided(builder, "store.pg_ddl_password") {
-            // User did not provide `store.pg_ddl_password`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.pg_ddl_password => self.store.pg_ddl_password
             };
         }
 
         if !user_provided(builder, "store.pg_database_name") {
-            // User did not provide `store.pg_database_name`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.pg_database_name => self.store.pg_database_name
             };
         }
 
         if !user_provided(builder, "store.pg_default_database_name") {
-            // User did not provide `store.pg_default_database_name`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.pg_default_database_name => self.store.pg_default_database_name
             };
         }
 
         if !user_provided(builder, "store.pg_extra_query_params") {
-            // User did not provide `store.pg_extra_query_params`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.pg_extra_query_params => some(self.store.pg_extra_query_params)
             };
         }
 
         if !user_provided(builder, "store.db_path") {
-            // User did not provide `store.db_path`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.db_path => self.store.db_path
             };
         }
 
         if !user_provided(builder, "store.db_write_failure_backoff_ms") {
-            // User did not provide `store.db_write_failure_backoff_ms`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.db_write_failure_backoff_ms => self.store.db_write_failure_backoff_ms
             };
         }
 
         if !user_provided(builder, "store.db_query_max_retries") {
-            // User did not provide `store.db_query_max_retries`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.db_query_max_retries => some(self.store.db_query_max_retries)
             };
         }
 
         if !user_provided(builder, "store.db_query_retry_delay_ms") {
-            // User did not provide `store.db_query_retry_delay_ms`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.db_query_retry_delay_ms => self.store.db_query_retry_delay_ms
             };
         }
 
         if !user_provided(builder, "store.db_insert_batch_max_len") {
-            // User did not provide `store.db_insert_batch_max_len`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.db_insert_batch_max_len => self.store.db_insert_batch_max_len
             };
         }
 
         if !user_provided(builder, "store.db_insert_batch_max_size") {
-            // User did not provide `store.db_insert_batch_max_size`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.db_insert_batch_max_size => self.store.db_insert_batch_max_size
             };
         }
 
         if !user_provided(builder, "store.db_insert_batch_max_time_ms") {
-            // User did not provide `store.db_insert_batch_max_time_ms`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.db_insert_batch_max_time_ms => self.store.db_insert_batch_max_time_ms
             };
         }
 
         if !user_provided(builder, "store.db_max_size") {
-            // User did not provide `store.db_max_size`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.db_max_size => some(self.store.db_max_size)
             };
         }
 
         if !user_provided(builder, "store.max_pending_count") {
-            // User did not provide `store.max_pending_count`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.max_pending_count => self.store.max_pending_count
             };
         }
 
         if !user_provided(builder, "store.max_delay_count") {
-            // User did not provide `store.max_delay_count`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.max_delay_count => self.store.max_delay_count
             };
         }
 
         if !user_provided(builder, "store.max_processing_count") {
-            // User did not provide `store.max_processing_count`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.max_processing_count => self.store.max_processing_count
             };
         }
 
         if !user_provided(builder, "store.max_processing_attempts") {
-            // User did not provide `store.max_processing_attempts`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.max_processing_attempts => self.store.max_processing_attempts
             };
         }
 
         if !user_provided(builder, "store.processing_deadline_grace_sec") {
-            // User did not provide `store.processing_deadline_grace_sec`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.processing_deadline_grace_sec => self.store.processing_deadline_grace_sec
             };
         }
 
         if !user_provided(builder, "store.vacuum_page_count") {
-            // User did not provide `store.vacuum_page_count`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.vacuum_page_count => some(self.store.vacuum_page_count)
             };
         }
 
         if !user_provided(builder, "store.enable_sqlite_status_metrics") {
-            // User did not provide `store.enable_sqlite_status_metrics`, fall back onto the deprecated version of that field
             deprecated::map! {
                 self.deprecated.enable_sqlite_status_metrics => self.store.enable_sqlite_status_metrics
             };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -337,6 +337,12 @@ impl Config {
         Ok(config)
     }
 
+    /// Map deprecated options to new options.
+    /// If the deprecated value is plain (like an integer or a string), it's ONLY used when it's actually provided.
+    /// If the deprecated value is optional, it's ALWAYS used no matter what. So...
+    /// - If `db_max_size` is not provided, then `store.db_max_size` is `None`
+    /// - If `db_max_size` is `null`, then `store.db_max_size` is `None`
+    /// - If `db_max_size` is 5, then `store.db_max_size` is `Some(5)`
     fn map_deprecated_options(&mut self) {
         // Map store configuration options
         deprecated::map! {

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -26,3 +26,134 @@ impl DatabaseAdapter {
         }
     }
 }
+
+#[derive(PartialEq, Debug, Deserialize, Serialize)]
+pub struct StoreConfig {
+    /// The database adapter to use for the activation store.
+    pub database_adapter: DatabaseAdapter,
+
+    /// Whether to run the migrations on the database.
+    /// This is only used by the postgres database adapter, since
+    /// in production the migrations shouldn't be run by the taskbroker.
+    pub run_migrations: bool,
+
+    /// The host of the postgres database to use for the activation store.
+    pub pg_host: String,
+
+    /// The port of the postgres database to use for the activation store.
+    pub pg_port: u16,
+
+    // User permitted to run DDL operations.
+    pub pg_ddl_username: String,
+
+    /// The username of the postgres database to use for the activation store.
+    pub pg_username: String,
+
+    /// The password of the postgres database to use for the activation store.
+    pub pg_password: String,
+
+    /// Password for the user permitted to run DDL operations.
+    pub pg_ddl_password: String,
+
+    /// The name of the postgres database to use for the activation store.
+    pub pg_database_name: String,
+
+    /// The default postgres database to use for migrations..
+    pub pg_default_database_name: String,
+
+    /// Extra query parameters that can be added to the postgres connection string. Should be in the format of "key=value&key2=value2".
+    /// For example, "sslmode=require&sslrootcert=/path/to/root.crt".
+    pub pg_extra_query_params: Option<String>,
+
+    /// The path to the sqlite database
+    pub db_path: String,
+
+    /// The amount of time to wait before retrying writes to db when write fails.
+    pub db_write_failure_backoff_ms: u64,
+
+    /// The maximum number of times to retry a transient database query error
+    /// before surfacing the error. When None, queries are not retried.
+    pub db_query_max_retries: Option<u32>,
+
+    /// The delay in milliseconds between query retry attempts.
+    pub db_query_retry_delay_ms: u64,
+
+    /// The maximum number of tasks that are buffered
+    /// before being written to ActivationStore (sqlite).
+    pub db_insert_batch_max_len: usize,
+
+    /// The maximum number of bytes that are buffered
+    /// before being written to ActivationStore (sqlite).
+    pub db_insert_batch_max_size: usize,
+
+    /// The time in milliseconds to buffer tasks
+    /// before being written to ActivationStore (sqlite).
+    pub db_insert_batch_max_time_ms: u64,
+
+    /// The maximum size of the sqlite database in bytes.
+    /// If the database reaches or exceeds this size, ingestion will
+    /// pause until the database size is reduced.
+    pub db_max_size: Option<u64>,
+
+    /// The maximum number of pending records that can be
+    /// in the ActivationStore (sqlite)
+    pub max_pending_count: usize,
+
+    /// The maximum number of delay records that can be
+    /// in the ActivationStore (sqlite)
+    pub max_delay_count: usize,
+
+    /// The maximum number of processing records that can be
+    /// in the ActivationStore (sqlite)
+    pub max_processing_count: usize,
+
+    /// The maximum number of times a task can be reset from
+    /// processing back to pending. When this limit is reached,
+    /// the activation will be discarded/deadlettered.
+    pub max_processing_attempts: usize,
+
+    /// The number of additional seconds that processing deadlines
+    /// are extended by. This helps reduce broker deadline resets when
+    /// brokers are under load, or there are small networking delays.
+    pub processing_deadline_grace_sec: u64,
+
+    /// The number of pages to vacuum from sqlite when vacuum is run.
+    /// If None, all pages will be vacuumed.
+    pub vacuum_page_count: Option<usize>,
+
+    /// Enable additional metrics for the sqlite.
+    pub enable_sqlite_status_metrics: bool,
+}
+
+impl Default for StoreConfig {
+    fn default() -> Self {
+        Self {
+            db_path: "./taskbroker-inflight.sqlite".to_owned(),
+            database_adapter: DatabaseAdapter::Sqlite,
+            run_migrations: false,
+            pg_host: "sentry-postgres-1".to_owned(),
+            pg_port: 5432,
+            pg_ddl_username: "postgres".to_owned(),
+            pg_ddl_password: "password".to_owned(),
+            pg_username: "postgres".to_owned(),
+            pg_password: "password".to_owned(),
+            pg_database_name: "default".to_owned(),
+            pg_default_database_name: "postgres".to_owned(),
+            pg_extra_query_params: None,
+            db_write_failure_backoff_ms: 4000,
+            db_query_max_retries: Some(3),
+            db_query_retry_delay_ms: 100,
+            db_insert_batch_max_len: 256,
+            db_insert_batch_max_size: 16_000_000,
+            db_insert_batch_max_time_ms: 1000,
+            db_max_size: Some(3000000000),
+            max_pending_count: 2048,
+            max_delay_count: 8192,
+            max_processing_count: 2048,
+            max_processing_attempts: 5,
+            processing_deadline_grace_sec: 3,
+            vacuum_page_count: None,
+            enable_sqlite_status_metrics: true,
+        }
+    }
+}

--- a/src/kafka/activation_batcher.rs
+++ b/src/kafka/activation_batcher.rs
@@ -37,9 +37,9 @@ impl ActivationBatcherConfig {
             kafka_topic: topic_name.to_owned(),
             kafka_long_topic: config.kafka_long_topic.clone(),
             send_timeout_ms: config.kafka_send_timeout_ms,
-            max_batch_time_ms: config.db_insert_batch_max_time_ms,
-            max_batch_len: config.db_insert_batch_max_len,
-            max_batch_size: config.db_insert_batch_max_size,
+            max_batch_time_ms: config.store.db_insert_batch_max_time_ms,
+            max_batch_len: config.store.db_insert_batch_max_len,
+            max_batch_size: config.store.db_insert_batch_max_size,
         }
     }
 }
@@ -244,6 +244,7 @@ mod tests {
     use chrono::Utc;
     use tempfile::NamedTempFile;
 
+    use crate::config::store::StoreConfig;
     use crate::store::activation::ActivationBuilder;
     use crate::test_utils::{TaskActivationBuilder, generate_unique_namespace};
 
@@ -314,8 +315,11 @@ demoted_namespaces:
     async fn test_close_by_bytes_limit() {
         let runtime_config = Arc::new(RuntimeConfigManager::new(None).await);
         let mut config = Config {
-            db_insert_batch_max_size: 1,
-            db_insert_batch_max_len: 2,
+            store: StoreConfig {
+                db_insert_batch_max_size: 1,
+                db_insert_batch_max_len: 2,
+                ..StoreConfig::default()
+            },
             ..Default::default()
         };
         config.normalize_and_validate().unwrap();
@@ -344,8 +348,11 @@ demoted_namespaces:
     async fn test_close_by_rows_limit() {
         let runtime_config = Arc::new(RuntimeConfigManager::new(None).await);
         let mut config = Config {
-            db_insert_batch_max_size: 100000,
-            db_insert_batch_max_len: 2,
+            store: StoreConfig {
+                db_insert_batch_max_size: 100000,
+                db_insert_batch_max_len: 2,
+                ..StoreConfig::default()
+            },
             ..Default::default()
         };
         config.normalize_and_validate().unwrap();

--- a/src/kafka/activation_writer.rs
+++ b/src/kafka/activation_writer.rs
@@ -33,12 +33,12 @@ impl ActivationWriterConfig {
     pub fn from_topic(config: &Config, topic: &str) -> Self {
         Self {
             topic: topic.to_owned(),
-            db_max_size: config.db_max_size,
-            max_buf_len: config.db_insert_batch_max_len,
-            max_pending_activations: config.max_pending_count,
-            max_processing_activations: config.max_processing_count,
-            max_delay_activations: config.max_delay_count,
-            write_failure_backoff_ms: config.db_write_failure_backoff_ms,
+            db_max_size: config.store.db_max_size,
+            max_buf_len: config.store.db_insert_batch_max_len,
+            max_pending_activations: config.store.max_pending_count,
+            max_processing_activations: config.store.max_processing_count,
+            max_delay_activations: config.store.max_delay_count,
+            write_failure_backoff_ms: config.store.db_write_failure_backoff_ms,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,15 +67,19 @@ async fn main() -> Result<(), Error> {
     metrics::init(metrics::MetricsConfig::from_config(&config));
 
     if args.run == Run::Migrations {
-        return config.database_adapter.migrate(&config).await;
+        return config.store.database_adapter.migrate(&config).await;
     }
 
-    let store: Arc<dyn ActivationStore> = match config.database_adapter {
+    let store: Arc<dyn ActivationStore> = match config.store.database_adapter {
         DatabaseAdapter::Sqlite => Arc::new(
-            SqliteStore::new(&config.db_path, SqliteStoreConfig::from_config(&config)).await?,
+            SqliteStore::new(
+                &config.store.db_path,
+                SqliteStoreConfig::from_config(&config),
+            )
+            .await?,
         ),
         DatabaseAdapter::Postgres => {
-            if config.run_migrations {
+            if config.store.run_migrations {
                 postgres::migrate(&config).await?;
             }
 

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -27,12 +27,12 @@ use crate::store::types::{BucketRange, DepthCounts, FailedTasksForwarder};
 /// Run migrations.
 pub async fn migrate(config: &Config) -> Result<()> {
     let mut conn_opts = PgConnectOptions::new()
-        .username(&config.pg_ddl_username)
-        .password(&config.pg_ddl_password)
-        .host(&config.pg_host)
-        .port(config.pg_port);
+        .username(&config.store.pg_ddl_username)
+        .password(&config.store.pg_ddl_password)
+        .host(&config.store.pg_host)
+        .port(config.store.pg_port);
 
-    if let Some(extra_query_params) = config.pg_extra_query_params.as_ref() {
+    if let Some(extra_query_params) = config.store.pg_extra_query_params.as_ref() {
         let url = conn_opts.to_url_lossy();
         let new_url =
             url.as_ref().split('?').next().unwrap().to_string() + "?" + extra_query_params;
@@ -40,18 +40,18 @@ pub async fn migrate(config: &Config) -> Result<()> {
     }
 
     let default_pool =
-        create_default_postgres_pool(&conn_opts, &config.pg_default_database_name).await?;
+        create_default_postgres_pool(&conn_opts, &config.store.pg_default_database_name).await?;
 
     // Create the database if it doesn't exist
     let row: (bool,) =
         sqlx::query_as("SELECT EXISTS ( SELECT 1 FROM pg_catalog.pg_database WHERE datname = $1 )")
-            .bind(&config.pg_database_name)
+            .bind(&config.store.pg_database_name)
             .fetch_one(&default_pool)
             .await?;
 
     if !row.0 {
-        println!("Creating database {}", &config.pg_database_name);
-        sqlx::query(format!("CREATE DATABASE {}", &config.pg_database_name).as_str())
+        println!("Creating database {}", &config.store.pg_database_name);
+        sqlx::query(format!("CREATE DATABASE {}", &config.store.pg_database_name).as_str())
             .execute(&default_pool)
             .await?;
     }
@@ -60,7 +60,7 @@ pub async fn migrate(config: &Config) -> Result<()> {
 
     let migration_pool = PgPoolOptions::new()
         .max_connections(1)
-        .connect_with(conn_opts.database(&config.pg_database_name))
+        .connect_with(conn_opts.database(&config.store.pg_database_name))
         .await?;
 
     println!("Running migrations on database");
@@ -239,12 +239,12 @@ pub struct PostgresStoreConfig {
 impl PostgresStoreConfig {
     pub fn from_config(config: &Config) -> Self {
         let mut conn_opts = PgConnectOptions::new()
-            .username(&config.pg_username)
-            .password(&config.pg_password)
-            .host(&config.pg_host)
-            .port(config.pg_port);
+            .username(&config.store.pg_username)
+            .password(&config.store.pg_password)
+            .host(&config.store.pg_host)
+            .port(config.store.pg_port);
 
-        if let Some(extra_query_params) = config.pg_extra_query_params.as_ref() {
+        if let Some(extra_query_params) = config.store.pg_extra_query_params.as_ref() {
             let url = conn_opts.to_url_lossy();
             let new_url =
                 url.as_ref().split('?').next().unwrap().to_string() + "?" + extra_query_params;
@@ -253,14 +253,14 @@ impl PostgresStoreConfig {
 
         Self {
             pg_connection: conn_opts,
-            pg_database_name: config.pg_database_name.clone(),
-            pg_default_database_name: config.pg_default_database_name.clone(),
-            run_migrations: config.run_migrations,
-            max_processing_attempts: config.max_processing_attempts,
-            vacuum_page_count: config.vacuum_page_count,
-            processing_deadline_grace_sec: config.processing_deadline_grace_sec,
+            pg_database_name: config.store.pg_database_name.clone(),
+            pg_default_database_name: config.store.pg_default_database_name.clone(),
+            run_migrations: config.store.run_migrations,
+            max_processing_attempts: config.store.max_processing_attempts,
+            vacuum_page_count: config.store.vacuum_page_count,
+            processing_deadline_grace_sec: config.store.processing_deadline_grace_sec,
             claim_lease_ms: compute_claim_lease_ms(config),
-            enable_sqlite_status_metrics: config.enable_sqlite_status_metrics,
+            enable_sqlite_status_metrics: config.store.enable_sqlite_status_metrics,
             retry_config: RetryConfig::from_config(config),
         }
     }

--- a/src/store/adapters/sqlite.rs
+++ b/src/store/adapters/sqlite.rs
@@ -191,11 +191,11 @@ pub struct SqliteStoreConfig {
 impl SqliteStoreConfig {
     pub fn from_config(config: &Config) -> Self {
         Self {
-            max_processing_attempts: config.max_processing_attempts,
-            vacuum_page_count: config.vacuum_page_count,
-            processing_deadline_grace_sec: config.processing_deadline_grace_sec,
+            max_processing_attempts: config.store.max_processing_attempts,
+            vacuum_page_count: config.store.vacuum_page_count,
+            processing_deadline_grace_sec: config.store.processing_deadline_grace_sec,
             claim_lease_ms: compute_claim_lease_ms(config),
-            enable_sqlite_status_metrics: config.enable_sqlite_status_metrics,
+            enable_sqlite_status_metrics: config.store.enable_sqlite_status_metrics,
         }
     }
 }

--- a/src/store/retry.rs
+++ b/src/store/retry.rs
@@ -16,8 +16,8 @@ pub struct RetryConfig {
 impl RetryConfig {
     pub fn from_config(config: &Config) -> Self {
         Self {
-            max_retries: config.db_query_max_retries.unwrap_or(0),
-            retry_delay: Duration::from_millis(config.db_query_retry_delay_ms),
+            max_retries: config.store.db_query_max_retries.unwrap_or(0),
+            retry_delay: Duration::from_millis(config.store.db_query_retry_delay_ms),
         }
     }
 }
@@ -79,6 +79,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::config::store::StoreConfig;
+
     use super::*;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -222,7 +224,10 @@ mod tests {
     #[test]
     fn test_config_none_means_zero_retries() {
         let config = RetryConfig::from_config(&Arc::new(Config {
-            db_query_max_retries: None,
+            store: StoreConfig {
+                db_query_max_retries: None,
+                ..StoreConfig::default()
+            },
             ..Config::default()
         }));
         assert_eq!(config.max_retries, 0);
@@ -231,7 +236,10 @@ mod tests {
     #[test]
     fn test_config_uses_configured_retries() {
         let config = RetryConfig::from_config(&Arc::new(Config {
-            db_query_max_retries: Some(5),
+            store: StoreConfig {
+                db_query_max_retries: Some(5),
+                ..StoreConfig::default()
+            },
             ..Config::default()
         }));
         assert_eq!(config.max_retries, 5);

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -13,6 +13,7 @@ use tokio::sync::broadcast;
 use tokio::task::JoinSet;
 
 use crate::config::Config;
+use crate::config::store::StoreConfig;
 use crate::store::activation::{ActivationBuilder, ActivationStatus};
 use crate::store::adapters::postgres::PostgresStoreConfig;
 use crate::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig, create_sqlite_pool};
@@ -1394,14 +1395,14 @@ async fn test_processing_attempts_exceeded(#[case] adapter: &str) {
     let mut batch = make_activations(3);
     batch[0].status = ActivationStatus::Pending;
     batch[0].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
-    batch[0].processing_attempts = config.max_processing_attempts as i32;
+    batch[0].processing_attempts = config.store.max_processing_attempts as i32;
 
     batch[1].status = ActivationStatus::Complete;
     batch[1].added_at += Duration::from_secs(1);
 
     batch[2].status = ActivationStatus::Pending;
     batch[2].processing_deadline = Some(Utc.with_ymd_and_hms(2024, 11, 14, 21, 22, 23).unwrap());
-    batch[2].processing_attempts = config.max_processing_attempts as i32;
+    batch[2].processing_attempts = config.store.max_processing_attempts as i32;
 
     assert!(store.store(&batch).await.is_ok());
     assert_counts(
@@ -1846,7 +1847,10 @@ async fn test_vacuum_db_no_limit(#[case] adapter: &str) {
 #[tokio::test]
 async fn test_vacuum_db_incremental() {
     let config = Config {
-        vacuum_page_count: Some(10),
+        store: StoreConfig {
+            vacuum_page_count: Some(10),
+            ..StoreConfig::default()
+        },
         ..Config::default()
     };
     let store = SqliteStore::new(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -322,7 +322,7 @@ pub fn create_integration_config_from_base(base: Config) -> Config {
             pg_password: get_pg_password(),
             pg_database_name: get_pg_database_name(),
             run_migrations: true,
-            ..StoreConfig::default()
+            ..base.store
         },
         kafka_auto_offset_reset: "earliest".into(),
         ..base

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 
 use crate::config::Config;
 use crate::config::deprecated::DeprecatedConfig;
+use crate::config::store::StoreConfig;
 use crate::store::activation::{Activation, ActivationBuilder, ActivationStatus};
 use crate::store::adapters::postgres::{self, PostgresStore, PostgresStoreConfig};
 use crate::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig};
@@ -314,12 +315,15 @@ pub fn create_integration_config_from_base(base: Config) -> Config {
             kafka_consumer_group: Some("taskworker".into()),
             ..base.deprecated
         },
-        pg_host: get_pg_host(),
-        pg_port: get_pg_port(),
-        pg_username: get_pg_username(),
-        pg_password: get_pg_password(),
-        pg_database_name: get_pg_database_name(),
-        run_migrations: true,
+        store: StoreConfig {
+            pg_host: get_pg_host(),
+            pg_port: get_pg_port(),
+            pg_username: get_pg_username(),
+            pg_password: get_pg_password(),
+            pg_database_name: get_pg_database_name(),
+            run_migrations: true,
+            ..StoreConfig::default()
+        },
         kafka_auto_offset_reset: "earliest".into(),
         ..base
     };
@@ -349,7 +353,10 @@ pub fn create_integration_config_with_ssl() -> Arc<Config> {
             kafka_topic: Some("taskbroker-test".into()),
             ..DeprecatedConfig::default()
         },
-        pg_extra_query_params: Some("sslmode=require".to_string()),
+        store: StoreConfig {
+            pg_extra_query_params: Some("sslmode=require".to_string()),
+            ..StoreConfig::default()
+        },
         ..Config::default()
     }))
 }

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -434,8 +434,8 @@ pub async fn do_upkeep(
     let (depth_counts, max_lag, db_file_meta, wal_file_meta) = join!(
         store.count_depths_per_partition(),
         store.pending_activation_max_lag(&now),
-        fs::metadata(config.db_path.clone()),
-        fs::metadata(config.db_path.clone() + "-wal")
+        fs::metadata(config.store.db_path.clone()),
+        fs::metadata(config.store.db_path.clone() + "-wal")
     );
 
     if let Ok(ref depths) = depth_counts {
@@ -1021,12 +1021,12 @@ mod tests {
 
         let mut batch = make_activations(3);
         // Because 1 is complete and has a higher offset than 0, index 2 can be discarded
-        batch[0].processing_attempts = config.max_processing_attempts as i32;
+        batch[0].processing_attempts = config.store.max_processing_attempts as i32;
 
         batch[1].status = ActivationStatus::Complete;
         batch[1].added_at += Duration::from_secs(1);
 
-        batch[2].processing_attempts = config.max_processing_attempts as i32;
+        batch[2].processing_attempts = config.store.max_processing_attempts as i32;
         batch[2].added_at += Duration::from_secs(2);
 
         assert!(store.store(&batch).await.is_ok());


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 6** of my configuration improvement effort. We are finally getting to the juicy part. This PR...

- Introduces a new `StoreConfig` struct that contains all the database-related configuration options
- Adds all the currently used database-related configuration options to `DeprecatedConfig` and maps them to the new nested versions (e.g. `pg_host` becomes `store.pg_host`) using a shiny new `deprecated::map!` macro

Here's what will come in the following PRs, roughly in order...

1. Create a `PgConfig` struct
2. Create a `SqliteConfig` struct
3. Rename fields to be shorter since they are now nested (e.g. `store.pg.pg_host` will become `store.pg.host`)
4. Eliminate `PostgresStoreConfig` in `postgres.rs` and `SqliteStoreConfig` in `sqlite.rs`
5. Derive builders for the configuration structs to make tests less verbose
6. Clean up spacing and comments for increased readability and understanding