### PR TITLE
ref(config): (7) Move Postgres Configuration Into `PgConfig`

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -361,61 +361,61 @@ impl Config {
 
         if !user_provided(builder, "store.run_migrations") {
             deprecated::map! {
-                self.deprecated.run_migrations => self.store.run_migrations
+                self.deprecated.run_migrations => self.store.pg.run_migrations
             };
         }
 
         if !user_provided(builder, "store.pg_host") {
             deprecated::map! {
-                self.deprecated.pg_host => self.store.pg_host
+                self.deprecated.pg_host => self.store.pg.pg_host
             };
         }
 
         if !user_provided(builder, "store.pg_port") {
             deprecated::map! {
-                self.deprecated.pg_port => self.store.pg_port
+                self.deprecated.pg_port => self.store.pg.pg_port
             };
         }
 
         if !user_provided(builder, "store.pg_ddl_username") {
             deprecated::map! {
-                self.deprecated.pg_ddl_username => self.store.pg_ddl_username
+                self.deprecated.pg_ddl_username => self.store.pg.pg_ddl_username
             };
         }
 
         if !user_provided(builder, "store.pg_username") {
             deprecated::map! {
-                self.deprecated.pg_username => self.store.pg_username
+                self.deprecated.pg_username => self.store.pg.pg_username
             };
         }
 
         if !user_provided(builder, "store.pg_password") {
             deprecated::map! {
-                self.deprecated.pg_password => self.store.pg_password
+                self.deprecated.pg_password => self.store.pg.pg_password
             };
         }
 
         if !user_provided(builder, "store.pg_ddl_password") {
             deprecated::map! {
-                self.deprecated.pg_ddl_password => self.store.pg_ddl_password
+                self.deprecated.pg_ddl_password => self.store.pg.pg_ddl_password
             };
         }
 
         if !user_provided(builder, "store.pg_database_name") {
             deprecated::map! {
-                self.deprecated.pg_database_name => self.store.pg_database_name
+                self.deprecated.pg_database_name => self.store.pg.pg_database_name
             };
         }
 
         if !user_provided(builder, "store.pg_default_database_name") {
             deprecated::map! {
-                self.deprecated.pg_default_database_name => self.store.pg_default_database_name
+                self.deprecated.pg_default_database_name => self.store.pg.pg_default_database_name
             };
         }
 
         if !user_provided(builder, "store.pg_extra_query_params") {
             deprecated::map! {
-                self.deprecated.pg_extra_query_params => some(self.store.pg_extra_query_params)
+                self.deprecated.pg_extra_query_params => some(self.store.pg.pg_extra_query_params)
             };
         }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -359,61 +359,61 @@ impl Config {
             };
         }
 
-        if !user_provided(builder, "store.run_migrations") {
+        if !user_provided(builder, "store.pg.run_migrations") {
             deprecated::map! {
                 self.deprecated.run_migrations => self.store.pg.run_migrations
             };
         }
 
-        if !user_provided(builder, "store.pg_host") {
+        if !user_provided(builder, "store.pg.pg_host") {
             deprecated::map! {
                 self.deprecated.pg_host => self.store.pg.pg_host
             };
         }
 
-        if !user_provided(builder, "store.pg_port") {
+        if !user_provided(builder, "store.pg.pg_port") {
             deprecated::map! {
                 self.deprecated.pg_port => self.store.pg.pg_port
             };
         }
 
-        if !user_provided(builder, "store.pg_ddl_username") {
+        if !user_provided(builder, "store.pg.pg_ddl_username") {
             deprecated::map! {
                 self.deprecated.pg_ddl_username => self.store.pg.pg_ddl_username
             };
         }
 
-        if !user_provided(builder, "store.pg_username") {
+        if !user_provided(builder, "store.pg.pg_username") {
             deprecated::map! {
                 self.deprecated.pg_username => self.store.pg.pg_username
             };
         }
 
-        if !user_provided(builder, "store.pg_password") {
+        if !user_provided(builder, "store.pg.pg_password") {
             deprecated::map! {
                 self.deprecated.pg_password => self.store.pg.pg_password
             };
         }
 
-        if !user_provided(builder, "store.pg_ddl_password") {
+        if !user_provided(builder, "store.pg.pg_ddl_password") {
             deprecated::map! {
                 self.deprecated.pg_ddl_password => self.store.pg.pg_ddl_password
             };
         }
 
-        if !user_provided(builder, "store.pg_database_name") {
+        if !user_provided(builder, "store.pg.pg_database_name") {
             deprecated::map! {
                 self.deprecated.pg_database_name => self.store.pg.pg_database_name
             };
         }
 
-        if !user_provided(builder, "store.pg_default_database_name") {
+        if !user_provided(builder, "store.pg.pg_default_database_name") {
             deprecated::map! {
                 self.deprecated.pg_default_database_name => self.store.pg.pg_default_database_name
             };
         }
 
-        if !user_provided(builder, "store.pg_extra_query_params") {
+        if !user_provided(builder, "store.pg.pg_extra_query_params") {
             deprecated::map! {
                 self.deprecated.pg_extra_query_params => some(self.store.pg.pg_extra_query_params)
             };

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -28,10 +28,7 @@ impl DatabaseAdapter {
 }
 
 #[derive(PartialEq, Debug, Deserialize, Serialize)]
-pub struct StoreConfig {
-    /// The database adapter to use for the activation store.
-    pub database_adapter: DatabaseAdapter,
-
+pub struct PgConfig {
     /// Whether to run the migrations on the database.
     /// This is only used by the postgres database adapter, since
     /// in production the migrations shouldn't be run by the taskbroker.
@@ -64,6 +61,32 @@ pub struct StoreConfig {
     /// Extra query parameters that can be added to the postgres connection string. Should be in the format of "key=value&key2=value2".
     /// For example, "sslmode=require&sslrootcert=/path/to/root.crt".
     pub pg_extra_query_params: Option<String>,
+}
+
+impl Default for PgConfig {
+    fn default() -> Self {
+        Self {
+            run_migrations: false,
+            pg_host: "sentry-postgres-1".to_owned(),
+            pg_port: 5432,
+            pg_ddl_username: "postgres".to_owned(),
+            pg_ddl_password: "password".to_owned(),
+            pg_username: "postgres".to_owned(),
+            pg_password: "password".to_owned(),
+            pg_database_name: "default".to_owned(),
+            pg_default_database_name: "postgres".to_owned(),
+            pg_extra_query_params: None,
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Deserialize, Serialize)]
+pub struct StoreConfig {
+    /// The database adapter to use for the activation store.
+    pub database_adapter: DatabaseAdapter,
+
+    /// Postgres configuration.
+    pub pg: PgConfig,
 
     /// The path to the sqlite database
     pub db_path: String,
@@ -130,16 +153,7 @@ impl Default for StoreConfig {
         Self {
             db_path: "./taskbroker-inflight.sqlite".to_owned(),
             database_adapter: DatabaseAdapter::Sqlite,
-            run_migrations: false,
-            pg_host: "sentry-postgres-1".to_owned(),
-            pg_port: 5432,
-            pg_ddl_username: "postgres".to_owned(),
-            pg_ddl_password: "password".to_owned(),
-            pg_username: "postgres".to_owned(),
-            pg_password: "password".to_owned(),
-            pg_database_name: "default".to_owned(),
-            pg_default_database_name: "postgres".to_owned(),
-            pg_extra_query_params: None,
+            pg: PgConfig::default(),
             db_write_failure_backoff_ms: 4000,
             db_query_max_retries: Some(3),
             db_query_retry_delay_ms: 100,

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Error> {
             .await?,
         ),
         DatabaseAdapter::Postgres => {
-            if config.store.run_migrations {
+            if config.store.pg.run_migrations {
                 postgres::migrate(&config).await?;
             }
 

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -27,12 +27,12 @@ use crate::store::types::{BucketRange, DepthCounts, FailedTasksForwarder};
 /// Run migrations.
 pub async fn migrate(config: &Config) -> Result<()> {
     let mut conn_opts = PgConnectOptions::new()
-        .username(&config.store.pg_ddl_username)
-        .password(&config.store.pg_ddl_password)
-        .host(&config.store.pg_host)
-        .port(config.store.pg_port);
+        .username(&config.store.pg.pg_ddl_username)
+        .password(&config.store.pg.pg_ddl_password)
+        .host(&config.store.pg.pg_host)
+        .port(config.store.pg.pg_port);
 
-    if let Some(extra_query_params) = config.store.pg_extra_query_params.as_ref() {
+    if let Some(extra_query_params) = config.store.pg.pg_extra_query_params.as_ref() {
         let url = conn_opts.to_url_lossy();
         let new_url =
             url.as_ref().split('?').next().unwrap().to_string() + "?" + extra_query_params;
@@ -40,18 +40,18 @@ pub async fn migrate(config: &Config) -> Result<()> {
     }
 
     let default_pool =
-        create_default_postgres_pool(&conn_opts, &config.store.pg_default_database_name).await?;
+        create_default_postgres_pool(&conn_opts, &config.store.pg.pg_default_database_name).await?;
 
     // Create the database if it doesn't exist
     let row: (bool,) =
         sqlx::query_as("SELECT EXISTS ( SELECT 1 FROM pg_catalog.pg_database WHERE datname = $1 )")
-            .bind(&config.store.pg_database_name)
+            .bind(&config.store.pg.pg_database_name)
             .fetch_one(&default_pool)
             .await?;
 
     if !row.0 {
-        println!("Creating database {}", &config.store.pg_database_name);
-        sqlx::query(format!("CREATE DATABASE {}", &config.store.pg_database_name).as_str())
+        println!("Creating database {}", &config.store.pg.pg_database_name);
+        sqlx::query(format!("CREATE DATABASE {}", &config.store.pg.pg_database_name).as_str())
             .execute(&default_pool)
             .await?;
     }
@@ -60,7 +60,7 @@ pub async fn migrate(config: &Config) -> Result<()> {
 
     let migration_pool = PgPoolOptions::new()
         .max_connections(1)
-        .connect_with(conn_opts.database(&config.store.pg_database_name))
+        .connect_with(conn_opts.database(&config.store.pg.pg_database_name))
         .await?;
 
     println!("Running migrations on database");
@@ -239,12 +239,12 @@ pub struct PostgresStoreConfig {
 impl PostgresStoreConfig {
     pub fn from_config(config: &Config) -> Self {
         let mut conn_opts = PgConnectOptions::new()
-            .username(&config.store.pg_username)
-            .password(&config.store.pg_password)
-            .host(&config.store.pg_host)
-            .port(config.store.pg_port);
+            .username(&config.store.pg.pg_username)
+            .password(&config.store.pg.pg_password)
+            .host(&config.store.pg.pg_host)
+            .port(config.store.pg.pg_port);
 
-        if let Some(extra_query_params) = config.store.pg_extra_query_params.as_ref() {
+        if let Some(extra_query_params) = config.store.pg.pg_extra_query_params.as_ref() {
             let url = conn_opts.to_url_lossy();
             let new_url =
                 url.as_ref().split('?').next().unwrap().to_string() + "?" + extra_query_params;
@@ -253,9 +253,9 @@ impl PostgresStoreConfig {
 
         Self {
             pg_connection: conn_opts,
-            pg_database_name: config.store.pg_database_name.clone(),
-            pg_default_database_name: config.store.pg_default_database_name.clone(),
-            run_migrations: config.store.run_migrations,
+            pg_database_name: config.store.pg.pg_database_name.clone(),
+            pg_default_database_name: config.store.pg.pg_default_database_name.clone(),
+            run_migrations: config.store.pg.run_migrations,
             max_processing_attempts: config.store.max_processing_attempts,
             vacuum_page_count: config.store.vacuum_page_count,
             processing_deadline_grace_sec: config.store.processing_deadline_grace_sec,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::config::Config;
 use crate::config::deprecated::DeprecatedConfig;
-use crate::config::store::StoreConfig;
+use crate::config::store::{PgConfig, StoreConfig};
 use crate::store::activation::{Activation, ActivationBuilder, ActivationStatus};
 use crate::store::adapters::postgres::{self, PostgresStore, PostgresStoreConfig};
 use crate::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig};
@@ -316,12 +316,15 @@ pub fn create_integration_config_from_base(base: Config) -> Config {
             ..base.deprecated
         },
         store: StoreConfig {
-            pg_host: get_pg_host(),
-            pg_port: get_pg_port(),
-            pg_username: get_pg_username(),
-            pg_password: get_pg_password(),
-            pg_database_name: get_pg_database_name(),
-            run_migrations: true,
+            pg: PgConfig {
+                pg_host: get_pg_host(),
+                pg_port: get_pg_port(),
+                pg_username: get_pg_username(),
+                pg_password: get_pg_password(),
+                pg_database_name: get_pg_database_name(),
+                run_migrations: true,
+                ..base.store.pg
+            },
             ..base.store
         },
         kafka_auto_offset_reset: "earliest".into(),
@@ -354,7 +357,10 @@ pub fn create_integration_config_with_ssl() -> Arc<Config> {
             ..DeprecatedConfig::default()
         },
         store: StoreConfig {
-            pg_extra_query_params: Some("sslmode=require".to_string()),
+            pg: PgConfig {
+                pg_extra_query_params: Some("sslmode=require".to_string()),
+                ..PgConfig::default()
+            },
             ..StoreConfig::default()
         },
         ..Config::default()


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 7** of my configuration improvement effort. In the last PR, we nested the store configuration into its own `StoreConfig` struct. We continue moving along this path by moving Postgres configuration into a `PgConfig` struct. This will eventually replace the `PostgresStoreConfig` struct in `postgres.rs` entirely... but that's for another PR.

The next step will be to fix the naming, as the `pg_` prefix is no longer necessary. Here's what we've done...

* `pg_host` became...
* `store.pg_host` became...
* `store.pg.pg_host` will become...
* `store.pg.host`