### PR TITLE
ref(config): (8) Simplify Postgres Configuration Names

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -367,55 +367,55 @@ impl Config {
 
         if !user_provided(builder, "store.pg.pg_host") {
             deprecated::map! {
-                self.deprecated.pg_host => self.store.pg.pg_host
+                self.deprecated.pg_host => self.store.pg.host
             };
         }
 
         if !user_provided(builder, "store.pg.pg_port") {
             deprecated::map! {
-                self.deprecated.pg_port => self.store.pg.pg_port
+                self.deprecated.pg_port => self.store.pg.port
             };
         }
 
         if !user_provided(builder, "store.pg.pg_ddl_username") {
             deprecated::map! {
-                self.deprecated.pg_ddl_username => self.store.pg.pg_ddl_username
+                self.deprecated.pg_ddl_username => self.store.pg.ddl_username
             };
         }
 
         if !user_provided(builder, "store.pg.pg_username") {
             deprecated::map! {
-                self.deprecated.pg_username => self.store.pg.pg_username
+                self.deprecated.pg_username => self.store.pg.username
             };
         }
 
         if !user_provided(builder, "store.pg.pg_password") {
             deprecated::map! {
-                self.deprecated.pg_password => self.store.pg.pg_password
+                self.deprecated.pg_password => self.store.pg.password
             };
         }
 
         if !user_provided(builder, "store.pg.pg_ddl_password") {
             deprecated::map! {
-                self.deprecated.pg_ddl_password => self.store.pg.pg_ddl_password
+                self.deprecated.pg_ddl_password => self.store.pg.ddl_password
             };
         }
 
         if !user_provided(builder, "store.pg.pg_database_name") {
             deprecated::map! {
-                self.deprecated.pg_database_name => self.store.pg.pg_database_name
+                self.deprecated.pg_database_name => self.store.pg.database_name
             };
         }
 
         if !user_provided(builder, "store.pg.pg_default_database_name") {
             deprecated::map! {
-                self.deprecated.pg_default_database_name => self.store.pg.pg_default_database_name
+                self.deprecated.pg_default_database_name => self.store.pg.default_database_name
             };
         }
 
         if !user_provided(builder, "store.pg.pg_extra_query_params") {
             deprecated::map! {
-                self.deprecated.pg_extra_query_params => some(self.store.pg.pg_extra_query_params)
+                self.deprecated.pg_extra_query_params => some(self.store.pg.query_params)
             };
         }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -413,7 +413,7 @@ impl Config {
             };
         }
 
-        if !user_provided(builder, "store.pg.extra_query_params") {
+        if !user_provided(builder, "store.pg.query_params") {
             deprecated::map! {
                 self.deprecated.pg_extra_query_params => some(self.store.pg.query_params)
             };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -365,55 +365,55 @@ impl Config {
             };
         }
 
-        if !user_provided(builder, "store.pg.pg_host") {
+        if !user_provided(builder, "store.pg.host") {
             deprecated::map! {
                 self.deprecated.pg_host => self.store.pg.host
             };
         }
 
-        if !user_provided(builder, "store.pg.pg_port") {
+        if !user_provided(builder, "store.pg.port") {
             deprecated::map! {
                 self.deprecated.pg_port => self.store.pg.port
             };
         }
 
-        if !user_provided(builder, "store.pg.pg_ddl_username") {
+        if !user_provided(builder, "store.pg.ddl_username") {
             deprecated::map! {
                 self.deprecated.pg_ddl_username => self.store.pg.ddl_username
             };
         }
 
-        if !user_provided(builder, "store.pg.pg_username") {
+        if !user_provided(builder, "store.pg.username") {
             deprecated::map! {
                 self.deprecated.pg_username => self.store.pg.username
             };
         }
 
-        if !user_provided(builder, "store.pg.pg_password") {
+        if !user_provided(builder, "store.pg.password") {
             deprecated::map! {
                 self.deprecated.pg_password => self.store.pg.password
             };
         }
 
-        if !user_provided(builder, "store.pg.pg_ddl_password") {
+        if !user_provided(builder, "store.pg.ddl_password") {
             deprecated::map! {
                 self.deprecated.pg_ddl_password => self.store.pg.ddl_password
             };
         }
 
-        if !user_provided(builder, "store.pg.pg_database_name") {
+        if !user_provided(builder, "store.pg.database_name") {
             deprecated::map! {
                 self.deprecated.pg_database_name => self.store.pg.database_name
             };
         }
 
-        if !user_provided(builder, "store.pg.pg_default_database_name") {
+        if !user_provided(builder, "store.pg.default_database_name") {
             deprecated::map! {
                 self.deprecated.pg_default_database_name => self.store.pg.default_database_name
             };
         }
 
-        if !user_provided(builder, "store.pg.pg_extra_query_params") {
+        if !user_provided(builder, "store.pg.extra_query_params") {
             deprecated::map! {
                 self.deprecated.pg_extra_query_params => some(self.store.pg.query_params)
             };

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -35,47 +35,47 @@ pub struct PgConfig {
     pub run_migrations: bool,
 
     /// The host of the postgres database to use for the activation store.
-    pub pg_host: String,
+    pub host: String,
 
     /// The port of the postgres database to use for the activation store.
-    pub pg_port: u16,
+    pub port: u16,
 
     // User permitted to run DDL operations.
-    pub pg_ddl_username: String,
+    pub ddl_username: String,
 
     /// The username of the postgres database to use for the activation store.
-    pub pg_username: String,
+    pub username: String,
 
     /// The password of the postgres database to use for the activation store.
-    pub pg_password: String,
+    pub password: String,
 
     /// Password for the user permitted to run DDL operations.
-    pub pg_ddl_password: String,
+    pub ddl_password: String,
 
     /// The name of the postgres database to use for the activation store.
-    pub pg_database_name: String,
+    pub database_name: String,
 
     /// The default postgres database to use for migrations..
-    pub pg_default_database_name: String,
+    pub default_database_name: String,
 
     /// Extra query parameters that can be added to the postgres connection string. Should be in the format of "key=value&key2=value2".
     /// For example, "sslmode=require&sslrootcert=/path/to/root.crt".
-    pub pg_extra_query_params: Option<String>,
+    pub query_params: Option<String>,
 }
 
 impl Default for PgConfig {
     fn default() -> Self {
         Self {
             run_migrations: false,
-            pg_host: "sentry-postgres-1".to_owned(),
-            pg_port: 5432,
-            pg_ddl_username: "postgres".to_owned(),
-            pg_ddl_password: "password".to_owned(),
-            pg_username: "postgres".to_owned(),
-            pg_password: "password".to_owned(),
-            pg_database_name: "default".to_owned(),
-            pg_default_database_name: "postgres".to_owned(),
-            pg_extra_query_params: None,
+            host: "sentry-postgres-1".to_owned(),
+            port: 5432,
+            ddl_username: "postgres".to_owned(),
+            ddl_password: "password".to_owned(),
+            username: "postgres".to_owned(),
+            password: "password".to_owned(),
+            database_name: "default".to_owned(),
+            default_database_name: "postgres".to_owned(),
+            query_params: None,
         }
     }
 }

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -27,12 +27,12 @@ use crate::store::types::{BucketRange, DepthCounts, FailedTasksForwarder};
 /// Run migrations.
 pub async fn migrate(config: &Config) -> Result<()> {
     let mut conn_opts = PgConnectOptions::new()
-        .username(&config.store.pg.pg_ddl_username)
-        .password(&config.store.pg.pg_ddl_password)
-        .host(&config.store.pg.pg_host)
-        .port(config.store.pg.pg_port);
+        .username(&config.store.pg.ddl_username)
+        .password(&config.store.pg.ddl_password)
+        .host(&config.store.pg.host)
+        .port(config.store.pg.port);
 
-    if let Some(extra_query_params) = config.store.pg.pg_extra_query_params.as_ref() {
+    if let Some(extra_query_params) = config.store.pg.query_params.as_ref() {
         let url = conn_opts.to_url_lossy();
         let new_url =
             url.as_ref().split('?').next().unwrap().to_string() + "?" + extra_query_params;
@@ -40,18 +40,18 @@ pub async fn migrate(config: &Config) -> Result<()> {
     }
 
     let default_pool =
-        create_default_postgres_pool(&conn_opts, &config.store.pg.pg_default_database_name).await?;
+        create_default_postgres_pool(&conn_opts, &config.store.pg.default_database_name).await?;
 
     // Create the database if it doesn't exist
     let row: (bool,) =
         sqlx::query_as("SELECT EXISTS ( SELECT 1 FROM pg_catalog.pg_database WHERE datname = $1 )")
-            .bind(&config.store.pg.pg_database_name)
+            .bind(&config.store.pg.database_name)
             .fetch_one(&default_pool)
             .await?;
 
     if !row.0 {
-        println!("Creating database {}", &config.store.pg.pg_database_name);
-        sqlx::query(format!("CREATE DATABASE {}", &config.store.pg.pg_database_name).as_str())
+        println!("Creating database {}", &config.store.pg.database_name);
+        sqlx::query(format!("CREATE DATABASE {}", &config.store.pg.database_name).as_str())
             .execute(&default_pool)
             .await?;
     }
@@ -60,7 +60,7 @@ pub async fn migrate(config: &Config) -> Result<()> {
 
     let migration_pool = PgPoolOptions::new()
         .max_connections(1)
-        .connect_with(conn_opts.database(&config.store.pg.pg_database_name))
+        .connect_with(conn_opts.database(&config.store.pg.database_name))
         .await?;
 
     println!("Running migrations on database");
@@ -239,12 +239,12 @@ pub struct PostgresStoreConfig {
 impl PostgresStoreConfig {
     pub fn from_config(config: &Config) -> Self {
         let mut conn_opts = PgConnectOptions::new()
-            .username(&config.store.pg.pg_username)
-            .password(&config.store.pg.pg_password)
-            .host(&config.store.pg.pg_host)
-            .port(config.store.pg.pg_port);
+            .username(&config.store.pg.username)
+            .password(&config.store.pg.password)
+            .host(&config.store.pg.host)
+            .port(config.store.pg.port);
 
-        if let Some(extra_query_params) = config.store.pg.pg_extra_query_params.as_ref() {
+        if let Some(extra_query_params) = config.store.pg.query_params.as_ref() {
             let url = conn_opts.to_url_lossy();
             let new_url =
                 url.as_ref().split('?').next().unwrap().to_string() + "?" + extra_query_params;
@@ -253,8 +253,8 @@ impl PostgresStoreConfig {
 
         Self {
             pg_connection: conn_opts,
-            pg_database_name: config.store.pg.pg_database_name.clone(),
-            pg_default_database_name: config.store.pg.pg_default_database_name.clone(),
+            pg_database_name: config.store.pg.database_name.clone(),
+            pg_default_database_name: config.store.pg.default_database_name.clone(),
             run_migrations: config.store.pg.run_migrations,
             max_processing_attempts: config.store.max_processing_attempts,
             vacuum_page_count: config.store.vacuum_page_count,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -317,11 +317,11 @@ pub fn create_integration_config_from_base(base: Config) -> Config {
         },
         store: StoreConfig {
             pg: PgConfig {
-                pg_host: get_pg_host(),
-                pg_port: get_pg_port(),
-                pg_username: get_pg_username(),
-                pg_password: get_pg_password(),
-                pg_database_name: get_pg_database_name(),
+                host: get_pg_host(),
+                port: get_pg_port(),
+                username: get_pg_username(),
+                password: get_pg_password(),
+                database_name: get_pg_database_name(),
                 run_migrations: true,
                 ..base.store.pg
             },
@@ -358,7 +358,7 @@ pub fn create_integration_config_with_ssl() -> Arc<Config> {
         },
         store: StoreConfig {
             pg: PgConfig {
-                pg_extra_query_params: Some("sslmode=require".to_string()),
+                query_params: Some("sslmode=require".to_string()),
                 ..PgConfig::default()
             },
             ..StoreConfig::default()


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 8** of my configuration improvement effort. In #699, I moved the Postgres configuration options into their own nested `PgConfig` struct. Thus, the `pg_` prefix on all the Postgres configuration fields is no longer needed. Let's get rid of it for readability.