### PR TITLE
ref(config): (9) Move SQLite Configuration Into `SqliteConfig`

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -423,12 +423,6 @@ impl Config {
             };
         }
 
-        if !user_provided(builder, "store.db_path") {
-            deprecated::map! {
-                self.deprecated.db_path => self.store.db_path
-            };
-        }
-
         if !user_provided(builder, "store.db_write_failure_backoff_ms") {
             deprecated::map! {
                 self.deprecated.db_write_failure_backoff_ms => self.store.db_write_failure_backoff_ms
@@ -501,15 +495,21 @@ impl Config {
             };
         }
 
-        if !user_provided(builder, "store.vacuum_page_count") {
+        if !user_provided(builder, "store.sqlite.path") {
             deprecated::map! {
-                self.deprecated.vacuum_page_count => some(self.store.vacuum_page_count)
+                self.deprecated.db_path => self.store.sqlite.path
             };
         }
 
-        if !user_provided(builder, "store.enable_sqlite_status_metrics") {
+        if !user_provided(builder, "store.sqlite.vacuum_page_count") {
             deprecated::map! {
-                self.deprecated.enable_sqlite_status_metrics => self.store.enable_sqlite_status_metrics
+                self.deprecated.vacuum_page_count => some(self.store.sqlite.vacuum_page_count)
+            };
+        }
+
+        if !user_provided(builder, "store.sqlite.enable_status_metrics") {
+            deprecated::map! {
+                self.deprecated.enable_sqlite_status_metrics => self.store.sqlite.enable_status_metrics
             };
         }
     }
@@ -1051,10 +1051,10 @@ mod tests {
         assert_eq!(config.log_filter, "info,librdkafka=warn,h2=off");
         assert_eq!(config.log_format, LogFormat::Text);
         assert_eq!(config.grpc_port, 50051);
-        assert_eq!(config.store.db_path, "./taskbroker-inflight.sqlite");
+        assert_eq!(config.store.sqlite.path, "./taskbroker-inflight.sqlite");
         assert_eq!(config.store.max_pending_count, 2048);
         assert_eq!(config.store.max_processing_count, 2048);
-        assert_eq!(config.store.vacuum_page_count, None);
+        assert_eq!(config.store.sqlite.vacuum_page_count, None);
         assert_eq!(
             config.worker_map.get("sentry").map(String::as_str),
             Some("http://127.0.0.1:50052")
@@ -1191,11 +1191,14 @@ mod tests {
             assert_eq!(config.kafka_session_timeout_ms, 6000.to_owned());
             assert_eq!(config.kafka_deadletter_topic, "error-tasks-dlq".to_owned());
             assert_eq!(config.store.database_adapter, DatabaseAdapter::Postgres);
-            assert_eq!(config.store.db_path, "./taskbroker-error.sqlite".to_owned());
+            assert_eq!(
+                config.store.sqlite.path,
+                "./taskbroker-error.sqlite".to_owned()
+            );
             assert_eq!(config.store.max_pending_count, 512);
             assert_eq!(config.store.max_processing_count, 512);
             assert_eq!(config.store.max_processing_attempts, 5);
-            assert_eq!(config.store.vacuum_page_count, Some(1000));
+            assert_eq!(config.store.sqlite.vacuum_page_count, Some(1000));
             assert_eq!(config.store.db_max_size, Some(3_000_000_000));
             assert!(config.full_vacuum_on_start);
             assert_eq!(
@@ -1256,7 +1259,7 @@ mod tests {
             );
             assert_eq!(config.kafka_deadletter_topic, "taskworker-dlq".to_owned());
             assert_eq!(
-                config.store.db_path,
+                config.store.sqlite.path,
                 "./taskbroker-inflight.sqlite".to_owned()
             );
             assert_eq!(config.store.max_pending_count, 2048);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -413,7 +413,11 @@ impl Config {
             };
         }
 
+<<<<<<< HEAD
         if !user_provided(builder, "store.pg.query_params") {
+=======
+        if !user_provided(builder, "store.pg.extra_query_params") {
+>>>>>>> d1088f4 (Fix Deprecated Options Mapping)
             deprecated::map! {
                 self.deprecated.pg_extra_query_params => some(self.store.pg.query_params)
             };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -352,13 +352,7 @@ impl Config {
                 .is_some_and(|metadata| metadata.name != DEFAULT_CONFIG_PROVIDER)
         }
 
-        // This field was not provided, so use the deprecated version instead
-        if !user_provided(builder, "store.database_adapter") {
-            deprecated::map! {
-                self.deprecated.database_adapter => self.store.database_adapter
-            };
-        }
-
+        // Map deprecated Postgres configuration options
         if !user_provided(builder, "store.pg.run_migrations") {
             deprecated::map! {
                 self.deprecated.run_migrations => self.store.pg.run_migrations
@@ -416,6 +410,32 @@ impl Config {
         if !user_provided(builder, "store.pg.query_params") {
             deprecated::map! {
                 self.deprecated.pg_extra_query_params => some(self.store.pg.query_params)
+            };
+        }
+
+        // Map deprecated SQLite configuration options
+        if !user_provided(builder, "store.sqlite.path") {
+            deprecated::map! {
+                self.deprecated.db_path => self.store.sqlite.path
+            };
+        }
+
+        if !user_provided(builder, "store.sqlite.vacuum_page_count") {
+            deprecated::map! {
+                self.deprecated.vacuum_page_count => some(self.store.sqlite.vacuum_page_count)
+            };
+        }
+
+        if !user_provided(builder, "store.sqlite.enable_status_metrics") {
+            deprecated::map! {
+                self.deprecated.enable_sqlite_status_metrics => self.store.sqlite.enable_status_metrics
+            };
+        }
+
+        // Map deprecated store configuration options
+        if !user_provided(builder, "store.database_adapter") {
+            deprecated::map! {
+                self.deprecated.database_adapter => self.store.database_adapter
             };
         }
 
@@ -488,24 +508,6 @@ impl Config {
         if !user_provided(builder, "store.processing_deadline_grace_sec") {
             deprecated::map! {
                 self.deprecated.processing_deadline_grace_sec => self.store.processing_deadline_grace_sec
-            };
-        }
-
-        if !user_provided(builder, "store.sqlite.path") {
-            deprecated::map! {
-                self.deprecated.db_path => self.store.sqlite.path
-            };
-        }
-
-        if !user_provided(builder, "store.sqlite.vacuum_page_count") {
-            deprecated::map! {
-                self.deprecated.vacuum_page_count => some(self.store.sqlite.vacuum_page_count)
-            };
-        }
-
-        if !user_provided(builder, "store.sqlite.enable_status_metrics") {
-            deprecated::map! {
-                self.deprecated.enable_sqlite_status_metrics => self.store.sqlite.enable_status_metrics
             };
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -413,11 +413,7 @@ impl Config {
             };
         }
 
-<<<<<<< HEAD
         if !user_provided(builder, "store.pg.query_params") {
-=======
-        if !user_provided(builder, "store.pg.extra_query_params") {
->>>>>>> d1088f4 (Fix Deprecated Options Mapping)
             deprecated::map! {
                 self.deprecated.pg_extra_query_params => some(self.store.pg.query_params)
             };

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -81,6 +81,29 @@ impl Default for PgConfig {
 }
 
 #[derive(PartialEq, Debug, Deserialize, Serialize)]
+pub struct SqliteConfig {
+    /// The path to the sqlite database
+    pub path: String,
+
+    /// Enable additional metrics for the sqlite.
+    pub enable_status_metrics: bool,
+
+    /// The number of pages to vacuum from SQLite when vacuum is run.
+    /// If None, all pages will be vacuumed.
+    pub vacuum_page_count: Option<usize>,
+}
+
+impl Default for SqliteConfig {
+    fn default() -> Self {
+        Self {
+            path: "./taskbroker-inflight.sqlite".to_owned(),
+            vacuum_page_count: None,
+            enable_status_metrics: true,
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Deserialize, Serialize)]
 pub struct StoreConfig {
     /// The database adapter to use for the activation store.
     pub database_adapter: DatabaseAdapter,
@@ -88,8 +111,8 @@ pub struct StoreConfig {
     /// Postgres configuration.
     pub pg: PgConfig,
 
-    /// The path to the sqlite database
-    pub db_path: String,
+    /// SQLite configuration.
+    pub sqlite: SqliteConfig,
 
     /// The amount of time to wait before retrying writes to db when write fails.
     pub db_write_failure_backoff_ms: u64,
@@ -139,21 +162,14 @@ pub struct StoreConfig {
     /// are extended by. This helps reduce broker deadline resets when
     /// brokers are under load, or there are small networking delays.
     pub processing_deadline_grace_sec: u64,
-
-    /// The number of pages to vacuum from sqlite when vacuum is run.
-    /// If None, all pages will be vacuumed.
-    pub vacuum_page_count: Option<usize>,
-
-    /// Enable additional metrics for the sqlite.
-    pub enable_sqlite_status_metrics: bool,
 }
 
 impl Default for StoreConfig {
     fn default() -> Self {
         Self {
-            db_path: "./taskbroker-inflight.sqlite".to_owned(),
             database_adapter: DatabaseAdapter::Sqlite,
             pg: PgConfig::default(),
+            sqlite: SqliteConfig::default(),
             db_write_failure_backoff_ms: 4000,
             db_query_max_retries: Some(3),
             db_query_retry_delay_ms: 100,
@@ -166,8 +182,6 @@ impl Default for StoreConfig {
             max_processing_count: 2048,
             max_processing_attempts: 5,
             processing_deadline_grace_sec: 3,
-            vacuum_page_count: None,
-            enable_sqlite_status_metrics: true,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Error> {
     let store: Arc<dyn ActivationStore> = match config.store.database_adapter {
         DatabaseAdapter::Sqlite => Arc::new(
             SqliteStore::new(
-                &config.store.db_path,
+                &config.store.sqlite.path,
                 SqliteStoreConfig::from_config(&config),
             )
             .await?,

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -231,8 +231,6 @@ pub struct PostgresStoreConfig {
     pub max_processing_attempts: usize,
     pub processing_deadline_grace_sec: u64,
     pub claim_lease_ms: u64,
-    pub vacuum_page_count: Option<usize>,
-    pub enable_sqlite_status_metrics: bool,
     pub retry_config: RetryConfig,
 }
 
@@ -257,10 +255,8 @@ impl PostgresStoreConfig {
             pg_default_database_name: config.store.pg.default_database_name.clone(),
             run_migrations: config.store.pg.run_migrations,
             max_processing_attempts: config.store.max_processing_attempts,
-            vacuum_page_count: config.store.vacuum_page_count,
             processing_deadline_grace_sec: config.store.processing_deadline_grace_sec,
             claim_lease_ms: compute_claim_lease_ms(config),
-            enable_sqlite_status_metrics: config.store.enable_sqlite_status_metrics,
             retry_config: RetryConfig::from_config(config),
         }
     }

--- a/src/store/adapters/sqlite.rs
+++ b/src/store/adapters/sqlite.rs
@@ -192,10 +192,10 @@ impl SqliteStoreConfig {
     pub fn from_config(config: &Config) -> Self {
         Self {
             max_processing_attempts: config.store.max_processing_attempts,
-            vacuum_page_count: config.store.vacuum_page_count,
+            vacuum_page_count: config.store.sqlite.vacuum_page_count,
             processing_deadline_grace_sec: config.store.processing_deadline_grace_sec,
             claim_lease_ms: compute_claim_lease_ms(config),
-            enable_sqlite_status_metrics: config.store.enable_sqlite_status_metrics,
+            enable_sqlite_status_metrics: config.store.sqlite.enable_status_metrics,
         }
     }
 }

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -13,7 +13,7 @@ use tokio::sync::broadcast;
 use tokio::task::JoinSet;
 
 use crate::config::Config;
-use crate::config::store::StoreConfig;
+use crate::config::store::{SqliteConfig, StoreConfig};
 use crate::store::activation::{ActivationBuilder, ActivationStatus};
 use crate::store::adapters::postgres::PostgresStoreConfig;
 use crate::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig, create_sqlite_pool};
@@ -1848,7 +1848,10 @@ async fn test_vacuum_db_no_limit(#[case] adapter: &str) {
 async fn test_vacuum_db_incremental() {
     let config = Config {
         store: StoreConfig {
-            vacuum_page_count: Some(10),
+            sqlite: SqliteConfig {
+                vacuum_page_count: Some(10),
+                ..SqliteConfig::default()
+            },
             ..StoreConfig::default()
         },
         ..Config::default()

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -434,8 +434,8 @@ pub async fn do_upkeep(
     let (depth_counts, max_lag, db_file_meta, wal_file_meta) = join!(
         store.count_depths_per_partition(),
         store.pending_activation_max_lag(&now),
-        fs::metadata(config.store.db_path.clone()),
-        fs::metadata(config.store.db_path.clone() + "-wal")
+        fs::metadata(config.store.sqlite.path.clone()),
+        fs::metadata(config.store.sqlite.path.clone() + "-wal")
     );
 
     if let Ok(ref depths) = depth_counts {


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 9** of my configuration improvement effort. In #700, we moved Postgres configuration into its own `PgConfig` struct. Now we do the same thing for SQLite by introducing `SqliteConfig`, which will eventually replace the `SqliteStoreConfig` struct in `sqlite.rs` entirely.