### PR TITLE
ref(config): (10) Move Claim Lease Field to Config

### DIFF
--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -5,12 +5,12 @@ use crate::config::store::DatabaseAdapter;
 macro_rules! map {
     () => {};
 
-    // An optional deprecated value always wins
+    // An optional deprecated value ALWAYS wins
     ($deprecated:expr => some($current:expr)) => {
         $current = $deprecated.take();
     };
 
-    // A plain deprecated value only wins when it's provided
+    // A plain deprecated value ONLY wins when it's provided
     ($deprecated:expr => $current:expr) => {
         if let Some(v) = $deprecated.take() {
             $current = v;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -351,6 +351,9 @@ impl Config {
         // Validate all other values
         self.validate()?;
 
+        // Ensure `claim_lease_ms` is computed
+        self.store.claim_lease_ms = compute_claim_lease_ms(self);
+
         Ok(())
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -332,16 +332,23 @@ impl Config {
         // Map deprecated fields to current fields
         config.map_deprecated_options(&mut builder);
 
-        // Normalize and validate Kafka values
-        config.normalize_and_validate()?;
-
-        // Validate all other values
-        config.validate()?;
-
-        // Compute derived fields, such as claim duration
-        config.store.claim_lease_ms = compute_claim_lease_ms(&config);
+        config.finalize()?;
 
         Ok(config)
+    }
+
+    /// Normalize, validate, and compute derived configuration fields.
+    pub(crate) fn finalize(&mut self) -> Result<()> {
+        // Normalize and validate Kafka values
+        self.normalize_and_validate()?;
+
+        // Validate all other values
+        self.validate()?;
+
+        // Compute derived fields, such as claim duration
+        self.store.claim_lease_ms = compute_claim_lease_ms(self);
+
+        Ok(())
     }
 
     /// Map deprecated options to maintain backwards compatability.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -252,11 +252,11 @@ pub struct Config {
 }
 
 impl Default for Config {
-    /// Field defaults. `kafka_topics`/`kafka_clusters` are left empty; call
-    /// [`Config::normalize_and_validate`] (as `from_args` does) to populate
-    /// them from the legacy fields before using the kafka helpers.
+    /// Field defaults. Note that `kafka_topics` and `kafka_clusters` are left empty.
+    /// Call `finalize` (as `from_args` does) to populate them from the legacy fields
+    /// before using the Kafka helpers.
     fn default() -> Self {
-        Self {
+        let mut config = Self {
             deprecated: DeprecatedConfig::default(),
             sentry_dsn: None,
             sentry_env: None,
@@ -312,7 +312,12 @@ impl Default for Config {
             raw_processing_deadline_duration: 30,
             kafka_topics: BTreeMap::new(),
             kafka_clusters: BTreeMap::new(),
-        }
+        };
+
+        // Compute `claim_lease_ms` before returning
+        config.store.claim_lease_ms = compute_claim_lease_ms(&config);
+
+        config
     }
 }
 
@@ -332,6 +337,7 @@ impl Config {
         // Map deprecated fields to current fields
         config.map_deprecated_options(&mut builder);
 
+        // Normalize and validate
         config.finalize()?;
 
         Ok(config)
@@ -344,9 +350,6 @@ impl Config {
 
         // Validate all other values
         self.validate()?;
-
-        // Compute derived fields, such as claim duration
-        self.store.claim_lease_ms = compute_claim_lease_ms(self);
 
         Ok(())
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,6 +14,7 @@ use crate::Args;
 use crate::config::store::StoreConfig;
 use crate::fetch::MAX_FETCH_THREADS;
 use crate::logging::LogFormat;
+use crate::push::compute_claim_lease_ms;
 
 pub mod deprecated;
 pub mod kafka;
@@ -336,6 +337,9 @@ impl Config {
 
         // Validate all other values
         config.validate()?;
+
+        // Compute derived fields, such as claim duration
+        config.store.claim_lease_ms = compute_claim_lease_ms(&config);
 
         Ok(config)
     }

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -162,6 +162,11 @@ pub struct StoreConfig {
     /// are extended by. This helps reduce broker deadline resets when
     /// brokers are under load, or there are small networking delays.
     pub processing_deadline_grace_sec: u64,
+
+    /// Number of milliseconds to wait before reverting a claimed activation
+    /// back to pending. This MUST be computed when constructing the configuration.
+    #[serde(skip)]
+    pub claim_lease_ms: u64,
 }
 
 impl Default for StoreConfig {
@@ -182,6 +187,7 @@ impl Default for StoreConfig {
             max_processing_count: 2048,
             max_processing_attempts: 5,
             processing_deadline_grace_sec: 3,
+            claim_lease_ms: 0, // This default is OK because we compute it later anyways
         }
     }
 }

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -18,7 +18,6 @@ use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivation};
 use tracing::{instrument, warn};
 
 use crate::config::Config;
-use crate::push::compute_claim_lease_ms;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::retry::{RetryConfig, retry_query};
 use crate::store::traits::ActivationStore;
@@ -256,7 +255,7 @@ impl PostgresStoreConfig {
             run_migrations: config.store.pg.run_migrations,
             max_processing_attempts: config.store.max_processing_attempts,
             processing_deadline_grace_sec: config.store.processing_deadline_grace_sec,
-            claim_lease_ms: compute_claim_lease_ms(config),
+            claim_lease_ms: config.store.claim_lease_ms,
             retry_config: RetryConfig::from_config(config),
         }
     }

--- a/src/store/adapters/sqlite.rs
+++ b/src/store/adapters/sqlite.rs
@@ -26,7 +26,6 @@ use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivation};
 use tracing::{debug, instrument, warn};
 
 use crate::config::Config;
-use crate::push::compute_claim_lease_ms;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::traits::ActivationStore;
 use crate::store::types::{BucketRange, FailedTasksForwarder};
@@ -194,7 +193,7 @@ impl SqliteStoreConfig {
             max_processing_attempts: config.store.max_processing_attempts,
             vacuum_page_count: config.store.sqlite.vacuum_page_count,
             processing_deadline_grace_sec: config.store.processing_deadline_grace_sec,
-            claim_lease_ms: compute_claim_lease_ms(config),
+            claim_lease_ms: config.store.claim_lease_ms,
             enable_sqlite_status_metrics: config.store.sqlite.enable_status_metrics,
         }
     }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -531,19 +531,3 @@ pub async fn assert_counts(expected: StatusCount, store: &dyn ActivationStore) {
         "difference in failure count",
     );
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn integration_config_computes_claim_lease() {
-        let config = create_integration_config();
-
-        assert_eq!(
-            config.store.claim_lease_ms,
-            crate::push::compute_claim_lease_ms(&config)
-        );
-        assert_ne!(config.store.claim_lease_ms, 0);
-    }
-}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -330,7 +330,7 @@ pub fn create_integration_config_from_base(base: Config) -> Config {
         kafka_auto_offset_reset: "earliest".into(),
         ..base
     };
-    config.normalize_and_validate().unwrap();
+    config.finalize().unwrap();
     config
 }
 
@@ -530,4 +530,20 @@ pub async fn assert_counts(expected: StatusCount, store: &dyn ActivationStore) {
             .unwrap(),
         "difference in failure count",
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn integration_config_computes_claim_lease() {
+        let config = create_integration_config();
+
+        assert_eq!(
+            config.store.claim_lease_ms,
+            crate::push::compute_claim_lease_ms(&config)
+        );
+        assert_ne!(config.store.claim_lease_ms, 0);
+    }
 }


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 10** of my configuration improvement effort. PRs #699 and #701 introduce new `PgConfig` and `SqliteConfig` structs nested inside `StoreConfig`, making the existing `SqliteStoreConfig` and `PostgresStoreConfig` structs unnecessary. But I can't delete them outright yet because `claim_lease_ms` is created within the constructors for these structs.

In this PR, we add a new `claim_lease_ms` field to `StoreConfig` and calculate it on startup. Now we are free to get rid of `SqliteStoreConfig` and `PostgresStoreConfig` in the coming PRs.