### PR TITLE
ref(config): (15) Eliminate `SqliteStoreConfig`

### DIFF
--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -3,17 +3,19 @@ use std::sync::Arc;
 use chrono::Utc;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::Rng;
+use taskbroker::config::Config;
+use taskbroker::config::store::{SqliteConfig, StoreConfig};
 use tokio::task::JoinSet;
 
 use taskbroker::store::activation::ActivationStatus;
-use taskbroker::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig};
+use taskbroker::store::adapters::sqlite::SqliteStore;
 use taskbroker::store::traits::ActivationStore;
 use taskbroker::test_utils::{
     generate_temp_filename, generate_unique_namespace, make_activations_with_namespace,
 };
 
 async fn get_pending_activations(num_activations: u32, num_workers: u32) {
-    let url = if cfg!(feature = "bench-with-mnt-disk") {
+    let path = if cfg!(feature = "bench-with-mnt-disk") {
         let mut rng = rand::thread_rng();
         format!(
             "/mnt/disks/sqlite/{}-{}.sqlite",
@@ -23,20 +25,22 @@ async fn get_pending_activations(num_activations: u32, num_workers: u32) {
     } else {
         generate_temp_filename()
     };
-    let store = Arc::new(
-        SqliteStore::new(
-            &url,
-            SqliteStoreConfig {
-                max_processing_attempts: 1,
+
+    let config = Config {
+        store: StoreConfig {
+            sqlite: SqliteConfig {
+                path,
                 vacuum_page_count: None,
-                processing_deadline_grace_sec: 3,
-                claim_lease_ms: 5000,
-                enable_sqlite_status_metrics: false,
+                enable_status_metrics: false,
             },
-        )
-        .await
-        .unwrap(),
-    );
+            max_processing_attempts: 1,
+            processing_deadline_grace_sec: 3,
+            ..StoreConfig::default()
+        },
+        ..Config::default()
+    };
+
+    let store = Arc::new(SqliteStore::new(&config).await.unwrap());
 
     let namespace = generate_unique_namespace();
 
@@ -77,7 +81,7 @@ async fn get_pending_activations(num_activations: u32, num_workers: u32) {
 async fn set_status(num_activations: u32, num_workers: u32) {
     assert!(num_activations.is_multiple_of(num_workers));
 
-    let url = if cfg!(feature = "bench-with-mnt-disk") {
+    let path = if cfg!(feature = "bench-with-mnt-disk") {
         let mut rng = rand::thread_rng();
         format!(
             "/mnt/disks/sqlite/{}-{}.sqlite",
@@ -88,20 +92,21 @@ async fn set_status(num_activations: u32, num_workers: u32) {
         generate_temp_filename()
     };
 
-    let store = Arc::new(
-        SqliteStore::new(
-            &url,
-            SqliteStoreConfig {
-                max_processing_attempts: 1,
+    let config = Config {
+        store: StoreConfig {
+            sqlite: SqliteConfig {
+                path,
                 vacuum_page_count: None,
-                processing_deadline_grace_sec: 3,
-                claim_lease_ms: 5000,
-                enable_sqlite_status_metrics: false,
+                enable_status_metrics: false,
             },
-        )
-        .await
-        .unwrap(),
-    );
+            max_processing_attempts: 1,
+            processing_deadline_grace_sec: 3,
+            ..StoreConfig::default()
+        },
+        ..Config::default()
+    };
+
+    let store = Arc::new(SqliteStore::new(&config).await.unwrap());
 
     let namespace = generate_unique_namespace();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use taskbroker::processing_strategy;
 use taskbroker::push::PushPool;
 use taskbroker::runtime_config::RuntimeConfigManager;
 use taskbroker::store::adapters::postgres::{self, PostgresStore};
-use taskbroker::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig};
+use taskbroker::store::adapters::sqlite::SqliteStore;
 use taskbroker::store::traits::ActivationStore;
 use taskbroker::upkeep::upkeep;
 use taskbroker::{Args, get_version};
@@ -71,13 +71,8 @@ async fn main() -> Result<(), Error> {
     }
 
     let store: Arc<dyn ActivationStore> = match config.store.database_adapter {
-        DatabaseAdapter::Sqlite => Arc::new(
-            SqliteStore::new(
-                &config.store.sqlite.path,
-                SqliteStoreConfig::from_config(&config),
-            )
-            .await?,
-        ),
+        DatabaseAdapter::Sqlite => Arc::new(SqliteStore::new(&config).await?),
+
         DatabaseAdapter::Postgres => {
             if config.store.pg.run_migrations {
                 postgres::migrate(&config.store).await?;

--- a/src/store/adapters/sqlite.rs
+++ b/src/store/adapters/sqlite.rs
@@ -26,6 +26,7 @@ use sentry_protos::taskbroker::v1::{OnAttemptsExceeded, TaskActivation};
 use tracing::{debug, instrument, warn};
 
 use crate::config::Config;
+use crate::config::store::StoreConfig;
 use crate::push::compute_claim_lease_ms;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::traits::ActivationStore;
@@ -180,35 +181,16 @@ pub async fn create_sqlite_pool(url: &str) -> Result<(Pool<Sqlite>, Pool<Sqlite>
     Ok((read_pool, write_pool))
 }
 
-pub struct SqliteStoreConfig {
-    pub max_processing_attempts: usize,
-    pub processing_deadline_grace_sec: u64,
-    pub claim_lease_ms: u64,
-    pub vacuum_page_count: Option<usize>,
-    pub enable_sqlite_status_metrics: bool,
-}
-
-impl SqliteStoreConfig {
-    pub fn from_config(config: &Config) -> Self {
-        Self {
-            max_processing_attempts: config.store.max_processing_attempts,
-            vacuum_page_count: config.store.sqlite.vacuum_page_count,
-            processing_deadline_grace_sec: config.store.processing_deadline_grace_sec,
-            claim_lease_ms: compute_claim_lease_ms(config),
-            enable_sqlite_status_metrics: config.store.sqlite.enable_status_metrics,
-        }
-    }
-}
-
 pub struct SqliteStore {
     read_pool: SqlitePool,
     write_pool: SqlitePool,
-    config: SqliteStoreConfig,
+    config: StoreConfig,
+    claim_lease_ms: u64,
 }
 
 impl SqliteStore {
-    pub async fn new(url: &str, config: SqliteStoreConfig) -> Result<Self, Error> {
-        let (read_pool, write_pool) = create_sqlite_pool(url).await?;
+    pub async fn new(config: &Config) -> Result<Self, Error> {
+        let (read_pool, write_pool) = create_sqlite_pool(&config.store.sqlite.path).await?;
 
         sqlx::migrate!("./migrations/sqlite")
             .run(&write_pool)
@@ -217,7 +199,8 @@ impl SqliteStore {
         Ok(Self {
             read_pool,
             write_pool,
-            config,
+            config: config.store.clone(),
+            claim_lease_ms: compute_claim_lease_ms(config),
         })
     }
 
@@ -244,7 +227,7 @@ impl SqliteStore {
     }
 
     async fn emit_db_status_metrics(&self) {
-        if !self.config.enable_sqlite_status_metrics {
+        if !self.config.sqlite.enable_status_metrics {
             return;
         }
 
@@ -398,7 +381,7 @@ impl ActivationStore for SqliteStore {
     async fn vacuum_db(&self) -> Result<(), Error> {
         let timer = Instant::now();
 
-        if let Some(page_count) = self.config.vacuum_page_count {
+        if let Some(page_count) = self.config.sqlite.vacuum_page_count {
             let mut conn = self.acquire_write_conn_metric("vacuum_db").await?;
             sqlx::query(format!("PRAGMA incremental_vacuum({page_count})").as_str())
                 .execute(&mut *conn)
@@ -604,7 +587,7 @@ impl ActivationStore for SqliteStore {
         } else {
             query_builder.push(format!(
                 "claim_expires_at = unixepoch('now', '+' || {:.3} || ' seconds'), processing_deadline = NULL, status = ",
-                self.config.claim_lease_ms as f64 / 1000.0,
+                self.claim_lease_ms as f64 / 1000.0,
             ));
 
             query_builder.push_bind(ActivationStatus::Claimed);

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -14,7 +14,7 @@ use tokio::task::JoinSet;
 use crate::config::Config;
 use crate::config::store::{SqliteConfig, StoreConfig};
 use crate::store::activation::{ActivationBuilder, ActivationStatus};
-use crate::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig, create_sqlite_pool};
+use crate::store::adapters::sqlite::{SqliteStore, create_sqlite_pool};
 use crate::store::traits::ActivationStore;
 use crate::test_utils::{
     StatusCount, TaskActivationBuilder, assert_counts, create_integration_config,
@@ -63,14 +63,10 @@ fn test_activation_status_from() {
 
 #[tokio::test]
 async fn test_sqlite_create_db() {
-    assert!(
-        SqliteStore::new(
-            &generate_temp_filename(),
-            SqliteStoreConfig::from_config(&create_integration_config())
-        )
-        .await
-        .is_ok()
-    )
+    let mut config = create_integration_config();
+    config.store.sqlite.path = generate_temp_filename();
+
+    assert!(SqliteStore::new(&config).await.is_ok())
 }
 
 #[tokio::test]
@@ -1838,6 +1834,7 @@ async fn test_vacuum_db_incremental() {
     let config = Config {
         store: StoreConfig {
             sqlite: SqliteConfig {
+                path: generate_temp_filename(),
                 vacuum_page_count: Some(10),
                 ..SqliteConfig::default()
             },
@@ -1845,12 +1842,10 @@ async fn test_vacuum_db_incremental() {
         },
         ..Config::default()
     };
-    let store = SqliteStore::new(
-        &generate_temp_filename(),
-        SqliteStoreConfig::from_config(&config),
-    )
-    .await
-    .expect("could not create store");
+
+    let store = SqliteStore::new(&config)
+        .await
+        .expect("could not create store");
 
     let batch = make_activations(2);
     assert!(store.store(&batch).await.is_ok());
@@ -2000,18 +1995,21 @@ async fn test_db_status_calls_ok() {
     let url = format!("sqlite:{db_path}");
 
     // Initialize a store to create the database and run migrations
-    SqliteStore::new(
-        &url,
-        SqliteStoreConfig {
+    let config = Config {
+        store: StoreConfig {
             max_processing_attempts: 3,
             processing_deadline_grace_sec: 0,
-            claim_lease_ms: 5000,
-            vacuum_page_count: None,
-            enable_sqlite_status_metrics: false,
+            sqlite: SqliteConfig {
+                vacuum_page_count: None,
+                enable_status_metrics: false,
+                ..SqliteConfig::default()
+            },
+            ..StoreConfig::default()
         },
-    )
-    .await
-    .expect("store init");
+        ..Config::default()
+    };
+
+    SqliteStore::new(&config).await.expect("store init");
 
     // Acquire a fresh read connection from a temporary pool, since store.read_pool is private
     let (read_pool, _write_pool) = create_sqlite_pool(&url).await.expect("pool");

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -2000,6 +2000,7 @@ async fn test_db_status_calls_ok() {
             max_processing_attempts: 3,
             processing_deadline_grace_sec: 0,
             sqlite: SqliteConfig {
+                path: db_path,
                 vacuum_page_count: None,
                 enable_status_metrics: false,
                 ..SqliteConfig::default()

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -2003,7 +2003,6 @@ async fn test_db_status_calls_ok() {
                 path: db_path,
                 vacuum_page_count: None,
                 enable_status_metrics: false,
-                ..SqliteConfig::default()
             },
             ..StoreConfig::default()
         },

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -20,7 +20,7 @@ use crate::config::deprecated::DeprecatedConfig;
 use crate::config::store::{PgConfig, StoreConfig};
 use crate::store::activation::{Activation, ActivationBuilder, ActivationStatus};
 use crate::store::adapters::postgres::{self, PostgresStore};
-use crate::store::adapters::sqlite::{SqliteStore, SqliteStoreConfig};
+use crate::store::adapters::sqlite::SqliteStore;
 use crate::store::traits::ActivationStore;
 
 /// Builder for `TaskActivation`. We cannot generate a builder automatically because `TaskActivation` is defined in `sentry-protos`.
@@ -276,17 +276,13 @@ pub fn create_config() -> Arc<Config> {
 
 /// Create an ActivationStore instance
 pub async fn create_test_store(adapter: &str) -> Arc<dyn ActivationStore> {
+    let mut config = create_integration_config();
+    config.store.sqlite.path = generate_temp_filename();
+
     match adapter {
-        "sqlite" => Arc::new(
-            SqliteStore::new(
-                &generate_temp_filename(),
-                SqliteStoreConfig::from_config(&create_integration_config()),
-            )
-            .await
-            .unwrap(),
-        ) as Arc<dyn ActivationStore>,
+        "sqlite" => Arc::new(SqliteStore::new(&config).await.unwrap()) as Arc<dyn ActivationStore>,
+
         "postgres" => {
-            let config = create_integration_config();
             postgres::migrate(&config.store).await.unwrap();
 
             let store =
@@ -334,14 +330,14 @@ pub fn create_integration_config_from_base(base: Config) -> Config {
 /// Create a Config instance that uses a testing topic
 /// and earliest auto_offset_reset. This is intended to be combined
 /// with [`reset_topic`]
-pub fn create_integration_config() -> Arc<Config> {
-    Arc::new(create_integration_config_from_base(Config {
+pub fn create_integration_config() -> Config {
+    create_integration_config_from_base(Config {
         deprecated: DeprecatedConfig {
             kafka_topic: Some("taskbroker-test".into()),
             ..DeprecatedConfig::default()
         },
         ..Config::default()
-    }))
+    })
 }
 
 /// Create a kafka producer for a given config


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 15** of my configuration improvement effort. In #707, we nested `RetryConfig` to `StoreConfig`. Now, we can finally eliminate `SqliteStoreConfig` and just use `StoreConfig` directly.