### PR TITLE
ref(config): (17) Create `PushConfig` Struct

### DIFF
--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use validator::Validate;
 
 use crate::config::store::DatabaseAdapter;
 
@@ -20,7 +21,7 @@ macro_rules! map {
 
 pub(crate) use map;
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Default)]
+#[derive(PartialEq, Debug, Deserialize, Serialize, Default, Validate)]
 pub struct DeprecatedConfig {
     /// The topic to fetch task messages from.
     /// Deprecated: use kafka_topics instead. Mutually exclusive with the new
@@ -197,4 +198,10 @@ pub struct DeprecatedConfig {
 
     /// Enable additional metrics for the sqlite.
     pub enable_sqlite_status_metrics: Option<bool>,
+
+    /// The number of concurrent push threads to run.
+    pub push_threads: Option<usize>,
+
+    /// Maximum time in milliseconds for a single push RPC to the worker service. This should be greater than the worker's internal timeout.
+    pub push_timeout_ms: Option<u64>,
 }

--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use validator::Validate;
 
 use crate::config::store::DatabaseAdapter;
 

--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -21,7 +21,7 @@ macro_rules! map {
 
 pub(crate) use map;
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Default, Validate)]
+#[derive(PartialEq, Debug, Deserialize, Serialize, Default)]
 pub struct DeprecatedConfig {
     /// The topic to fetch task messages from.
     /// Deprecated: use kafka_topics instead. Mutually exclusive with the new
@@ -206,10 +206,8 @@ pub struct DeprecatedConfig {
     pub push_timeout_ms: Option<u64>,
 
     /// The size of the push queue.
-    #[validate(range(min = 1))]
     pub push_queue_size: Option<usize>,
 
     /// Maximum time in milliseconds to wait when submitting an activation to the push pool.
-    #[validate(range(min = 1))]
     pub push_queue_timeout_ms: Option<u64>,
 }

--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -204,4 +204,12 @@ pub struct DeprecatedConfig {
 
     /// Maximum time in milliseconds for a single push RPC to the worker service. This should be greater than the worker's internal timeout.
     pub push_timeout_ms: Option<u64>,
+
+    /// The size of the push queue.
+    #[validate(range(min = 1))]
+    pub push_queue_size: usize,
+
+    /// Maximum time in milliseconds to wait when submitting an activation to the push pool.
+    #[validate(range(min = 1))]
+    pub push_queue_timeout_ms: u64,
 }

--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -207,9 +207,9 @@ pub struct DeprecatedConfig {
 
     /// The size of the push queue.
     #[validate(range(min = 1))]
-    pub push_queue_size: usize,
+    pub push_queue_size: Option<usize>,
 
     /// Maximum time in milliseconds to wait when submitting an activation to the push pool.
     #[validate(range(min = 1))]
-    pub push_queue_timeout_ms: u64,
+    pub push_queue_timeout_ms: Option<u64>,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -350,7 +350,7 @@ impl Config {
         if !user_provided(builder, "push.timeout")
             && let Some(v) = self.deprecated.push_timeout_ms
         {
-            self.store.db_query_retry_delay = Duration::from_millis(v);
+            self.push.timeout = Duration::from_millis(v);
         }
 
         if !user_provided(builder, "push.queue.size") {
@@ -360,9 +360,9 @@ impl Config {
         }
 
         if !user_provided(builder, "push.queue.timeout")
-            && let Some(v) = self.deprecated.push_timeout_ms
+            && let Some(v) = self.deprecated.push_queue_timeout_ms
         {
-            self.push.timeout = Duration::from_millis(v);
+            self.push.queue.timeout = Duration::from_millis(v);
         }
 
         // Map deprecated Postgres configuration options

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -353,6 +353,18 @@ impl Config {
             self.store.db_query_retry_delay = Duration::from_millis(v);
         }
 
+        if !user_provided(builder, "push.queue.size") {
+            deprecated::map! {
+                self.deprecated.push_queue_size => self.push.queue.size
+            };
+        }
+
+        if !user_provided(builder, "push.queue.timeout")
+            && let Some(v) = self.deprecated.push_timeout_ms
+        {
+            self.push.timeout = Duration::from_millis(v);
+        }
+
         // Map deprecated Postgres configuration options
         if !user_provided(builder, "store.pg.run_migrations") {
             deprecated::map! {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,12 +12,14 @@ use tracing::warn;
 use validator::{Validate, ValidationError};
 
 use crate::Args;
+use crate::config::push::PushConfig;
 use crate::config::store::StoreConfig;
 use crate::fetch::MAX_FETCH_THREADS;
 use crate::logging::LogFormat;
 
 pub mod deprecated;
 pub mod kafka;
+pub mod push;
 pub mod raw;
 pub mod store;
 
@@ -184,9 +186,9 @@ pub struct Config {
     #[validate(range(min = 1))]
     pub fetch_batch_size: i32,
 
-    /// The number of concurrent push threads to run.
-    #[validate(range(min = 1))]
-    pub push_threads: usize,
+    /// Push pool / thread configuration.
+    #[validate(nested)]
+    pub push: PushConfig,
 
     /// The size of the push queue.
     #[validate(range(min = 1))]
@@ -195,10 +197,6 @@ pub struct Config {
     /// Maximum time in milliseconds to wait when submitting an activation to the push pool.
     #[validate(range(min = 1))]
     pub push_queue_timeout_ms: u64,
-
-    /// Maximum time in milliseconds for a single push RPC to the worker service. This should be greater than the worker's internal timeout.
-    #[validate(range(min = 1))]
-    pub push_timeout_ms: u64,
 
     /// Update statuses from the gRPC server in batches?
     pub batch_status_updates: bool,
@@ -295,10 +293,9 @@ impl Default for Config {
             fetch_threads: 1,
             fetch_wait_ms: 100,
             fetch_batch_size: 1,
-            push_threads: 1,
+            push: PushConfig::default(),
             push_queue_size: 1,
             push_queue_timeout_ms: 5000,
-            push_timeout_ms: 30000,
             batch_status_updates: false,
             status_update_batch_size: 1,
             status_update_interval_ms: 100,
@@ -351,6 +348,19 @@ impl Config {
             builder
                 .find_metadata(key)
                 .is_some_and(|metadata| metadata.name != DEFAULT_CONFIG_PROVIDER)
+        }
+
+        // Map deprecated push mode configuration options
+        if !user_provided(builder, "push.threads") {
+            deprecated::map! {
+                self.deprecated.push_threads => self.push.threads
+            };
+        }
+
+        if !user_provided(builder, "push.timeout")
+            && let Some(v) = self.deprecated.push_timeout_ms
+        {
+            self.store.db_query_retry_delay = Duration::from_millis(v);
         }
 
         // Map deprecated Postgres configuration options
@@ -1031,6 +1041,7 @@ fn validate_power_of_two(n: usize) -> Result<(), ValidationError> {
 mod tests {
     use std::borrow::Cow;
     use std::collections::BTreeMap;
+    use std::time::Duration;
 
     use figment::Jail;
     use validator::Validate;
@@ -1095,10 +1106,10 @@ mod tests {
         assert!(config.validate().is_ok());
 
         // Push threads cannot be zero
-        config.push_threads = 0;
+        config.push.threads = 0;
         assert!(config.validate().is_err());
 
-        config.push_threads = 1;
+        config.push.threads = 1;
         assert!(config.validate().is_ok());
 
         // Push queue size cannot be zero
@@ -1116,10 +1127,10 @@ mod tests {
         assert!(config.validate().is_ok());
 
         // Push timeout cannot be zero
-        config.push_timeout_ms = 0;
+        config.push.timeout = Duration::from_millis(0);
         assert!(config.validate().is_err());
 
-        config.push_timeout_ms = 1;
+        config.push.timeout = Duration::from_millis(1);
         assert!(config.validate().is_ok());
 
         // Status update batch size cannot be zero

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -190,14 +190,6 @@ pub struct Config {
     #[validate(nested)]
     pub push: PushConfig,
 
-    /// The size of the push queue.
-    #[validate(range(min = 1))]
-    pub push_queue_size: usize,
-
-    /// Maximum time in milliseconds to wait when submitting an activation to the push pool.
-    #[validate(range(min = 1))]
-    pub push_queue_timeout_ms: u64,
-
     /// Update statuses from the gRPC server in batches?
     pub batch_status_updates: bool,
 
@@ -294,8 +286,6 @@ impl Default for Config {
             fetch_wait_ms: 100,
             fetch_batch_size: 1,
             push: PushConfig::default(),
-            push_queue_size: 1,
-            push_queue_timeout_ms: 5000,
             batch_status_updates: false,
             status_update_batch_size: 1,
             status_update_interval_ms: 100,
@@ -1113,17 +1103,17 @@ mod tests {
         assert!(config.validate().is_ok());
 
         // Push queue size cannot be zero
-        config.push_queue_size = 0;
+        config.push.queue.size = 0;
         assert!(config.validate().is_err());
 
-        config.push_queue_size = 1;
+        config.push.queue.size = 1;
         assert!(config.validate().is_ok());
 
         // Push queue timeout cannot be zero
-        config.push_queue_timeout_ms = 0;
+        config.push.queue.timeout = Duration::from_millis(0);
         assert!(config.validate().is_err());
 
-        config.push_queue_timeout_ms = 1;
+        config.push.queue.timeout = Duration::from_millis(1);
         assert!(config.validate().is_ok());
 
         // Push timeout cannot be zero

--- a/src/config/push.rs
+++ b/src/config/push.rs
@@ -11,6 +11,7 @@ fn validate_nonzero_duration(duration: &Duration) -> Result<(), ValidationError>
         Ok(())
     }
 }
+
 #[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
 pub struct PushQueueConfig {
     /// The size of the push queue.

--- a/src/config/push.rs
+++ b/src/config/push.rs
@@ -1,0 +1,33 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use validator::{Validate, ValidationError};
+
+#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
+pub struct PushConfig {
+    /// The number of concurrent push threads to run.
+    #[validate(range(min = 1))]
+    pub threads: usize,
+
+    /// Maximum time for a single push RPC to the worker service. This should be greater than the worker's internal timeout.
+    #[serde(with = "crate::serde::duration")]
+    #[validate(custom(function = "validate_nonzero_duration"))]
+    pub timeout: Duration,
+}
+
+fn validate_nonzero_duration(duration: &Duration) -> Result<(), ValidationError> {
+    if duration.is_zero() {
+        Err(ValidationError::new("nonzero_duration"))
+    } else {
+        Ok(())
+    }
+}
+
+impl Default for PushConfig {
+    fn default() -> Self {
+        Self {
+            threads: 1,
+            timeout: Duration::from_millis(30000),
+        }
+    }
+}

--- a/src/config/push.rs
+++ b/src/config/push.rs
@@ -3,6 +3,35 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError};
 
+// (TODO) Create a `validate` module to keep all of our custom validators (there are now at least two).
+fn validate_nonzero_duration(duration: &Duration) -> Result<(), ValidationError> {
+    if duration.is_zero() {
+        Err(ValidationError::new("nonzero_duration"))
+    } else {
+        Ok(())
+    }
+}
+#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
+pub struct PushQueueConfig {
+    /// The size of the push queue.
+    #[validate(range(min = 1))]
+    pub size: usize,
+
+    /// Maximum time to wait when submitting an activation to the push pool.
+    #[serde(with = "crate::serde::duration")]
+    #[validate(custom(function = "validate_nonzero_duration"))]
+    pub timeout: Duration,
+}
+
+impl Default for PushQueueConfig {
+    fn default() -> Self {
+        Self {
+            size: 1,
+            timeout: Duration::from_millis(5000),
+        }
+    }
+}
+
 #[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
 pub struct PushConfig {
     /// The number of concurrent push threads to run.
@@ -13,14 +42,10 @@ pub struct PushConfig {
     #[serde(with = "crate::serde::duration")]
     #[validate(custom(function = "validate_nonzero_duration"))]
     pub timeout: Duration,
-}
 
-fn validate_nonzero_duration(duration: &Duration) -> Result<(), ValidationError> {
-    if duration.is_zero() {
-        Err(ValidationError::new("nonzero_duration"))
-    } else {
-        Ok(())
-    }
+    /// The push queue configuration.
+    #[validate(nested)]
+    pub queue: PushQueueConfig,
 }
 
 impl Default for PushConfig {
@@ -28,6 +53,7 @@ impl Default for PushConfig {
         Self {
             threads: 1,
             timeout: Duration::from_millis(30000),
+            queue: PushQueueConfig::default(),
         }
     }
 }

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -140,7 +140,7 @@ impl FetchPool {
                                                 warn!(
                                                     task_id = %id,
                                                     "Submit to push pool timed out after {} milliseconds",
-                                                    config.push_queue_timeout_ms
+                                                    config.push.queue.timeout.as_millis()
                                                 );
 
                                                 // Wait for push queue to empty
@@ -205,8 +205,9 @@ async fn push_task(
 ) -> Result<(), QueueError> {
     metrics::gauge!("push.queue.depth").set(sender.len() as f64);
 
-    let duration = Duration::from_millis(config.push_queue_timeout_ms);
-    let timeout = tokio::time::timeout(duration, sender.send_async((activation, time)));
+    let duration = config.push.queue.timeout;
+    let future = sender.send_async((activation, time));
+    let timeout = tokio::time::timeout(duration, future);
 
     match timed!(timeout, "push.queue.wait_duration") {
         // The channel was full so the send timed out

--- a/src/fetch/tests.rs
+++ b/src/fetch/tests.rs
@@ -206,7 +206,7 @@ async fn fetch_pool_fetch_and_enqueue() {
     let store: Arc<dyn ActivationStore> = Arc::new(MockStore::one(activation.clone()));
 
     let config = test_config();
-    let (sender, receiver) = flume::bounded(config.push_queue_size);
+    let (sender, receiver) = flume::bounded(config.push.queue.size);
 
     let pool = FetchPool::new(sender, store, config);
     let handle = tokio::spawn(async move { pool.start().await });
@@ -222,7 +222,7 @@ async fn fetch_pool_store_error() {
     let store: Arc<dyn ActivationStore> = Arc::new(MockStore::error());
 
     let config = test_config();
-    let (sender, receiver) = flume::bounded(config.push_queue_size);
+    let (sender, receiver) = flume::bounded(config.push.queue.size);
 
     let pool = FetchPool::new(sender.clone(), store, config);
     let handle = tokio::spawn(async move { pool.start().await });
@@ -238,7 +238,7 @@ async fn fetch_pool_no_pending() {
     let store: Arc<dyn ActivationStore> = Arc::new(MockStore::empty());
 
     let config = test_config();
-    let (sender, receiver) = flume::bounded(config.push_queue_size);
+    let (sender, receiver) = flume::bounded(config.push.queue.size);
 
     let pool = FetchPool::new(sender, store, config);
     let handle = tokio::spawn(async move { pool.start().await });

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,7 +307,7 @@ async fn main() -> Result<(), Error> {
         let mut workers: Vec<WorkerMap> = vec![];
 
         // For every push thread, create a map from applications to worker connections
-        for _ in 0..config.push_threads {
+        for _ in 0..config.push.threads {
             let mut map = HashMap::new();
 
             for (application, endpoint) in config.worker_map.clone() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,7 +296,7 @@ async fn main() -> Result<(), Error> {
     };
 
     // Initialize push queue
-    let (sender, receiver) = flume::bounded(config.push_queue_size);
+    let (sender, receiver) = flume::bounded(config.push.queue.size);
 
     // Initialize push and fetch pools
     let push_pool = PushPool::new(receiver, config.clone());

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -37,7 +37,7 @@ const QUERY_MS: u64 = 1000;
 pub fn compute_claim_lease_ms(config: &Config) -> u64 {
     // Imagine we are computing the lease for some task in a batch of N tasks
     let fetch_batch_size = config.fetch_batch_size.max(1) as u64;
-    let push_threads = config.push_threads.max(1) as u64;
+    let push_threads = config.push.threads.max(1) as u64;
     let push_queue_size = config.push_queue_size.max(1) as u64;
 
     // In the worst case, this task is the last in a batch where every queue push times out
@@ -49,7 +49,7 @@ pub fn compute_claim_lease_ms(config: &Config) -> u64 {
     let rounds = push_queue_size.div_ceil(push_threads) + 1;
 
     // In the worst case, every task in the push queue will time out when pushing
-    let drain_ms = rounds * config.push_timeout_ms;
+    let drain_ms = rounds * config.push.timeout.as_millis() as u64;
 
     // In the worst case, the tasks in the push queue will take `QUERY_MS` time to update from claimed to processing
     // Since query timeouts aren't actually enforced right now, this is merely an approximation
@@ -75,7 +75,7 @@ pub enum QueueError {
     Closed,
 }
 
-/// Wrapper around `config.push_threads` asynchronous tasks, each of which receives an activation from the channel, sends it to the worker service, and repeats.
+/// Wrapper around `config.push.threads` asynchronous tasks, each of which receives an activation from the channel, sends it to the worker service, and repeats.
 pub struct PushPool {
     /// The receiving end of a channel that accepts task activations.
     receiver: Receiver<PushItem>,
@@ -90,7 +90,7 @@ impl PushPool {
         Self { receiver, config }
     }
 
-    /// Spawn `config.push_threads` asynchronous tasks, each of which repeatedly moves pending activations from the channel to the worker service until the shutdown signal is received.
+    /// Spawn `config.push.threads` asynchronous tasks, each of which repeatedly moves pending activations from the channel to the worker service until the shutdown signal is received.
     #[framed]
     pub async fn start(
         &self,
@@ -106,7 +106,7 @@ impl PushPool {
             async move { updater.start().await }
         });
 
-        let mut threads: JoinSet<Result<()>> = spawn_pool(self.config.push_threads, |_| {
+        let mut threads: JoinSet<Result<()>> = spawn_pool(self.config.push.threads, |_| {
             let mut thread = PushThread {
                 workers: workers.next().unwrap(),
                 receiver: self.receiver.clone(),

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -38,10 +38,10 @@ pub fn compute_claim_lease_ms(config: &Config) -> u64 {
     // Imagine we are computing the lease for some task in a batch of N tasks
     let fetch_batch_size = config.fetch_batch_size.max(1) as u64;
     let push_threads = config.push.threads.max(1) as u64;
-    let push_queue_size = config.push_queue_size.max(1) as u64;
+    let push_queue_size = config.push.queue.size.max(1) as u64;
 
     // In the worst case, this task is the last in a batch where every queue push times out
-    let queue_ms = fetch_batch_size * config.push_queue_timeout_ms;
+    let queue_ms = fetch_batch_size * config.push.queue.timeout.as_millis() as u64;
 
     // The push queue drains in "rounds" since there are multiple push threads
     // If there are 5 push threads and the queue has 10 slots, it will only take ⌈10 / 5⌉ = 2 rounds to drain it

--- a/src/push/tests.rs
+++ b/src/push/tests.rs
@@ -8,6 +8,7 @@ use tokio::sync::Notify;
 use tokio::time::{Duration, timeout};
 
 use crate::config::Config;
+use crate::config::push::PushConfig;
 use crate::push::updater::test_eager_updater;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::traits::ActivationStore;
@@ -174,7 +175,10 @@ async fn push_pool_start_marks_activation_processing_on_first_attempt() {
     let notify = Arc::new(Notify::new());
     let config = Arc::new(Config {
         worker_map: [("sentry".into(), "unused".into())].into(),
-        push_threads: 1,
+        push: PushConfig {
+            threads: 1,
+            ..PushConfig::default()
+        },
         push_queue_size: 10,
         ..Config::default()
     });
@@ -220,7 +224,10 @@ async fn push_pool_start_marks_activation_processing_on_retry() {
     let notify = Arc::new(Notify::new());
     let config = Arc::new(Config {
         worker_map: [("sentry".into(), "unused".into())].into(),
-        push_threads: 1,
+        push: PushConfig {
+            threads: 1,
+            ..PushConfig::default()
+        },
         push_queue_size: 10,
         ..Config::default()
     });
@@ -263,7 +270,10 @@ async fn push_pool_start_does_not_mark_activation_processing_on_push_failure() {
     let notify = Arc::new(Notify::new());
     let config = Arc::new(Config {
         worker_map: [("sentry".into(), "unused".into())].into(),
-        push_threads: 1,
+        push: PushConfig {
+            threads: 1,
+            ..PushConfig::default()
+        },
         push_queue_size: 10,
         ..Config::default()
     });

--- a/src/push/tests.rs
+++ b/src/push/tests.rs
@@ -8,7 +8,7 @@ use tokio::sync::Notify;
 use tokio::time::{Duration, timeout};
 
 use crate::config::Config;
-use crate::config::push::PushConfig;
+use crate::config::push::{PushConfig, PushQueueConfig};
 use crate::push::updater::test_eager_updater;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::traits::ActivationStore;
@@ -173,17 +173,22 @@ impl ActivationStore for MockStore {
 #[tokio::test]
 async fn push_pool_start_marks_activation_processing_on_first_attempt() {
     let notify = Arc::new(Notify::new());
+
     let config = Arc::new(Config {
         worker_map: [("sentry".into(), "unused".into())].into(),
         push: PushConfig {
             threads: 1,
-            ..PushConfig::default()
+            queue: PushQueueConfig {
+                size: 10,
+                ..Default::default()
+            },
+            ..Default::default()
         },
-        push_queue_size: 10,
-        ..Config::default()
+        ..Default::default()
     });
+
     let store = Arc::new(MockStore::default());
-    let (sender, receiver) = flume::bounded(config.push_queue_size);
+    let (sender, receiver) = flume::bounded(config.push.queue.size);
     let pool = Arc::new(PushPool::new(receiver, config));
 
     let workers = vec![test_worker_map(false, notify.clone())];
@@ -222,17 +227,22 @@ async fn push_pool_start_marks_activation_processing_on_first_attempt() {
 #[tokio::test]
 async fn push_pool_start_marks_activation_processing_on_retry() {
     let notify = Arc::new(Notify::new());
+
     let config = Arc::new(Config {
         worker_map: [("sentry".into(), "unused".into())].into(),
         push: PushConfig {
             threads: 1,
-            ..PushConfig::default()
+            queue: PushQueueConfig {
+                size: 10,
+                ..Default::default()
+            },
+            ..Default::default()
         },
-        push_queue_size: 10,
-        ..Config::default()
+        ..Default::default()
     });
+
     let store = Arc::new(MockStore::default());
-    let (sender, receiver) = flume::bounded(config.push_queue_size);
+    let (sender, receiver) = flume::bounded(config.push.queue.size);
     let pool = Arc::new(PushPool::new(receiver, config));
 
     let workers = vec![test_worker_map(false, notify.clone())];
@@ -268,17 +278,22 @@ async fn push_pool_start_marks_activation_processing_on_retry() {
 #[tokio::test]
 async fn push_pool_start_does_not_mark_activation_processing_on_push_failure() {
     let notify = Arc::new(Notify::new());
+
     let config = Arc::new(Config {
         worker_map: [("sentry".into(), "unused".into())].into(),
         push: PushConfig {
             threads: 1,
-            ..PushConfig::default()
+            queue: PushQueueConfig {
+                size: 10,
+                ..Default::default()
+            },
+            ..Default::default()
         },
-        push_queue_size: 10,
-        ..Config::default()
+        ..Default::default()
     });
+
     let store = Arc::new(MockStore::default());
-    let (sender, receiver) = flume::bounded(config.push_queue_size);
+    let (sender, receiver) = flume::bounded(config.push.queue.size);
     let pool = Arc::new(PushPool::new(receiver, config));
 
     let workers = vec![test_worker_map(true, notify.clone())];

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -65,12 +65,11 @@ impl Worker {
             .max_decoding_message_size(config.grpc_max_message_size);
 
         let secrets = config.grpc_shared_secret.clone();
-        let timeout = Duration::from_millis(config.push_timeout_ms);
 
         Ok(Self {
             client,
             secrets,
-            timeout,
+            timeout: config.push.timeout,
         })
     }
 }


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 17** of my configuration improvement effort. The original motivation for nesting the configuration was to manage all the new Postgres and push mode related configuration fields. So let's replace the top-level push mode fields with a single `push` field containing a `PushConfig`.