### PR TITLE
ref(config): (18) Create `FetchConfig` Struct

### DIFF
--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -209,4 +209,13 @@ pub struct DeprecatedConfig {
 
     /// Maximum time in milliseconds to wait when submitting an activation to the push pool.
     pub push_queue_timeout_ms: Option<u64>,
+
+    /// The number of concurrent fetch loops in push mode, which should be ≤ `MAX_FETCH_THREADS` and a power of two.
+    pub fetch_threads: Option<usize>,
+
+    /// Time in milliseconds to wait between fetch attempts when no pending activation is found.
+    pub fetch_wait_ms: Option<u64>,
+
+    /// The number of activations to claim with a single fetch query.
+    pub fetch_batch_size: Option<i32>,
 }

--- a/src/config/fetch.rs
+++ b/src/config/fetch.rs
@@ -1,0 +1,40 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use validator::{Validate, ValidationError};
+
+use crate::fetch::MAX_FETCH_THREADS;
+
+// (TODO) Create a `validate` module to keep all of our custom validators (there are now at least two).
+fn validate_power_of_two(n: usize) -> Result<(), ValidationError> {
+    if n.is_power_of_two() {
+        Ok(())
+    } else {
+        Err(ValidationError::new("not_power_of_two"))
+    }
+}
+
+#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
+pub struct FetchConfig {
+    /// The number of concurrent fetch loops in push mode, which should be ≤ `MAX_FETCH_THREADS` and a power of two.
+    #[validate(range(min = 1, max = MAX_FETCH_THREADS), custom(function = "validate_power_of_two"))]
+    pub threads: usize,
+
+    /// Time in milliseconds to wait between fetch attempts when no pending activation is found.
+    #[serde(with = "crate::serde::duration")]
+    pub backoff: Duration,
+
+    /// The number of activations to claim with a single fetch query.
+    #[validate(range(min = 1))]
+    pub batch_length: i32,
+}
+
+impl Default for FetchConfig {
+    fn default() -> Self {
+        Self {
+            threads: 1,
+            backoff: Duration::from_millis(100),
+            batch_length: 1,
+        }
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,15 +9,16 @@ use figment::{Figment, Metadata, Profile, Provider};
 use rdkafka::ClientConfig;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
-use validator::{Validate, ValidationError};
+use validator::Validate;
 
 use crate::Args;
+use crate::config::fetch::FetchConfig;
 use crate::config::push::PushConfig;
 use crate::config::store::StoreConfig;
-use crate::fetch::MAX_FETCH_THREADS;
 use crate::logging::LogFormat;
 
 pub mod deprecated;
+pub mod fetch;
 pub mod kafka;
 pub mod push;
 pub mod raw;
@@ -175,16 +176,9 @@ pub struct Config {
     /// How to deliver tasks to workers: "push" or "pull".
     pub delivery_mode: DeliveryMode,
 
-    /// The number of concurrent fetch loops in push mode, which should be ≤ `MAX_FETCH_THREADS` and a power of two.
-    #[validate(range(min = 1, max = MAX_FETCH_THREADS), custom(function = "validate_power_of_two"))]
-    pub fetch_threads: usize,
-
-    /// Time in milliseconds to wait between fetch attempts when no pending activation is found.
-    pub fetch_wait_ms: u64,
-
-    /// The number of activations to claim with a single fetch query.
-    #[validate(range(min = 1))]
-    pub fetch_batch_size: i32,
+    /// Fetch pool / thread configuration.
+    #[validate(nested)]
+    pub fetch: FetchConfig,
 
     /// Push pool / thread configuration.
     #[validate(nested)]
@@ -282,9 +276,7 @@ impl Default for Config {
             vacuum_interval_ms: 30000,
             log_async_backtrace: false,
             delivery_mode: DeliveryMode::Pull,
-            fetch_threads: 1,
-            fetch_wait_ms: 100,
-            fetch_batch_size: 1,
+            fetch: FetchConfig::default(),
             push: PushConfig::default(),
             batch_status_updates: false,
             status_update_batch_size: 1,
@@ -341,6 +333,24 @@ impl Config {
         }
 
         // Map deprecated push mode configuration options
+        if !user_provided(builder, "fetch.threads") {
+            deprecated::map! {
+                self.deprecated.fetch_threads => self.fetch.threads
+            };
+        }
+
+        if !user_provided(builder, "fetch.backoff")
+            && let Some(v) = self.deprecated.fetch_wait_ms
+        {
+            self.fetch.backoff = Duration::from_millis(v);
+        }
+
+        if !user_provided(builder, "fetch.batch_length") {
+            deprecated::map! {
+                self.deprecated.fetch_batch_size => self.fetch.batch_length
+            };
+        }
+
         if !user_provided(builder, "push.threads") {
             deprecated::map! {
                 self.deprecated.push_threads => self.push.threads
@@ -1031,15 +1041,6 @@ impl Provider for Config {
     }
 }
 
-/// Ensures that `n` is a power of two, used to validate `fetch_threads`.
-fn validate_power_of_two(n: usize) -> Result<(), ValidationError> {
-    if n.is_power_of_two() {
-        Ok(())
-    } else {
-        Err(ValidationError::new("not_power_of_two"))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
@@ -1049,6 +1050,7 @@ mod tests {
     use figment::Jail;
     use validator::Validate;
 
+    use crate::config::fetch::FetchConfig;
     use crate::logging::LogFormat;
     use crate::{Args, Run};
 
@@ -1077,35 +1079,38 @@ mod tests {
     #[test]
     fn test_validate_rejects_invalid_fields() {
         let mut config = Config {
-            fetch_threads: 0,
-            ..Config::default()
+            fetch: FetchConfig {
+                threads: 0,
+                ..Default::default()
+            },
+            ..Default::default()
         };
 
         // Fetch threads cannot be zero
         assert!(config.validate().is_err());
 
-        config.fetch_threads = 1;
+        config.fetch.threads = 1;
         assert!(config.validate().is_ok());
 
         // Fetch threads must be a power of two
-        config.fetch_threads = 3;
+        config.fetch.threads = 3;
         assert!(config.validate().is_err());
 
-        config.fetch_threads = 4;
+        config.fetch.threads = 4;
         assert!(config.validate().is_ok());
 
         // Fetch threads must be ≤ 256
-        config.fetch_threads = 512;
+        config.fetch.threads = 512;
         assert!(config.validate().is_err());
 
-        config.fetch_threads = 1;
+        config.fetch.threads = 1;
         assert!(config.validate().is_ok());
 
         // Fetch batch size cannot be zero
-        config.fetch_batch_size = 0;
+        config.fetch.batch_length = 0;
         assert!(config.validate().is_err());
 
-        config.fetch_batch_size = 1;
+        config.fetch.batch_length = 1;
         assert!(config.validate().is_ok());
 
         // Push threads cannot be zero

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use anyhow::Result;
 use async_backtrace::framed;
@@ -62,15 +62,15 @@ impl FetchPool {
     /// Spawns one task per effective fetch thread ([`normalize_fetch_threads`]), each claiming pending work only in its bucket subrange.
     #[framed]
     pub async fn start(&self) -> Result<()> {
-        let fetch_wait_ms = self.config.fetch_wait_ms;
-        let fetch_threads = self.config.fetch_threads;
+        let fetch_backoff = self.config.fetch.backoff;
+        let fetch_threads = self.config.fetch.threads;
 
         let mut fetch_pool = crate::tokio::spawn_pool(fetch_threads, |thread_index| {
             let store = self.store.clone();
             let sender = self.sender.clone();
             let config = self.config.clone();
 
-            let limit = Some(config.fetch_batch_size);
+            let limit = Some(config.fetch.batch_length);
             let bucket = Some(bucket_range_for_fetch_thread(thread_index, fetch_threads));
 
             let guard = get_shutdown_guard().shutdown_on_drop();
@@ -179,7 +179,7 @@ impl FetchPool {
                                 .record(start.elapsed());
 
                             if backoff {
-                                sleep(Duration::from_millis(fetch_wait_ms)).await;
+                                sleep(fetch_backoff).await;
                             }
                         } => {}
                     }

--- a/src/fetch/tests.rs
+++ b/src/fetch/tests.rs
@@ -7,6 +7,7 @@ use tokio::time::{Duration, sleep};
 use tonic::async_trait;
 
 use crate::config::Config;
+use crate::config::fetch::FetchConfig;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::traits::ActivationStore;
 use crate::store::types::{BucketRange, FailedTasksForwarder};
@@ -194,9 +195,12 @@ impl ActivationStore for MockStore {
 
 fn test_config() -> Arc<Config> {
     Arc::new(Config {
-        fetch_threads: 1,
-        fetch_wait_ms: 5,
-        ..Config::default()
+        fetch: FetchConfig {
+            threads: 1,
+            backoff: Duration::from_millis(5),
+            ..Default::default()
+        },
+        ..Default::default()
     })
 }
 

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -36,7 +36,7 @@ const QUERY_MS: u64 = 1000;
 /// the SQLite and Postgres adapters.
 pub fn compute_claim_duration_ms(config: &Config) -> u64 {
     // Imagine we are computing the lease for some task in a batch of N tasks
-    let fetch_batch_size = config.fetch_batch_size.max(1) as u64;
+    let fetch_batch_size = config.fetch.batch_length.max(1) as u64;
     let push_threads = config.push.threads.max(1) as u64;
     let push_queue_size = config.push.queue.size.max(1) as u64;
 


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 18** of my configuration improvement effort. The original motivation for nesting the configuration was to manage all the new Postgres and push mode related configuration fields. In #710 we replace the top-level push mode fields with a single `push` field containing a `PushConfig`. Now let's do the same thing for fetch fields by defining a `FetchConfig` struct.