### PR TITLE
ref(config): (16) Simplify `Store` Field Names

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -447,39 +447,39 @@ impl Config {
         }
 
         // Map deprecated store configuration options
-        if !user_provided(builder, "store.database_adapter") {
+        if !user_provided(builder, "store.adapter") {
             deprecated::map! {
-                self.deprecated.database_adapter => self.store.database_adapter
+                self.deprecated.database_adapter => self.store.adapter
             };
         }
 
-        if !user_provided(builder, "store.db_write_failure_backoff_ms") {
+        if !user_provided(builder, "store.insert_failure_backoff_ms") {
             deprecated::map! {
-                self.deprecated.db_write_failure_backoff_ms => self.store.db_write_failure_backoff_ms
+                self.deprecated.db_write_failure_backoff_ms => self.store.insert_failure_backoff_ms
             };
         }
 
-        if !user_provided(builder, "store.db_insert_batch_max_len") {
+        if !user_provided(builder, "store.insert_batch_max_length") {
             deprecated::map! {
-                self.deprecated.db_insert_batch_max_len => self.store.db_insert_batch_max_len
+                self.deprecated.db_insert_batch_max_len => self.store.insert_batch_max_length
             };
         }
 
-        if !user_provided(builder, "store.db_insert_batch_max_size") {
+        if !user_provided(builder, "store.insert_batch_max_bytes") {
             deprecated::map! {
-                self.deprecated.db_insert_batch_max_size => self.store.db_insert_batch_max_size
+                self.deprecated.db_insert_batch_max_size => self.store.insert_batch_max_bytes
             };
         }
 
-        if !user_provided(builder, "store.db_insert_batch_max_time_ms") {
+        if !user_provided(builder, "store.insert_batch_max_time_ms") {
             deprecated::map! {
-                self.deprecated.db_insert_batch_max_time_ms => self.store.db_insert_batch_max_time_ms
+                self.deprecated.db_insert_batch_max_time_ms => self.store.insert_batch_max_time_ms
             };
         }
 
-        if !user_provided(builder, "store.db_max_size") {
+        if !user_provided(builder, "store.max_size") {
             deprecated::map! {
-                self.deprecated.db_max_size => some(self.store.db_max_size)
+                self.deprecated.db_max_size => some(self.store.max_size)
             };
         }
 
@@ -762,7 +762,7 @@ impl Config {
         // avoid that contention (e.g. filtering by (topic, partition) or another
         // mechanism entirely). Reject the combination here, before any consumer
         // spawns.
-        if consumable.len() > 1 && self.store.database_adapter == DatabaseAdapter::Postgres {
+        if consumable.len() > 1 && self.store.adapter == DatabaseAdapter::Postgres {
             return Err(anyhow!(
                 "multi-topic consumption ({} consumable topics) is not supported with the \
                  postgres database adapter; use the sqlite adapter or a single consumable topic",
@@ -1190,7 +1190,7 @@ mod tests {
             assert_eq!(config.kafka_auto_offset_reset, "earliest".to_owned());
             assert_eq!(config.kafka_session_timeout_ms, 6000.to_owned());
             assert_eq!(config.kafka_deadletter_topic, "error-tasks-dlq".to_owned());
-            assert_eq!(config.store.database_adapter, DatabaseAdapter::Postgres);
+            assert_eq!(config.store.adapter, DatabaseAdapter::Postgres);
             assert_eq!(
                 config.store.sqlite.path,
                 "./taskbroker-error.sqlite".to_owned()
@@ -1199,7 +1199,7 @@ mod tests {
             assert_eq!(config.store.max_processing_count, 512);
             assert_eq!(config.store.max_processing_attempts, 5);
             assert_eq!(config.store.sqlite.vacuum_page_count, Some(1000));
-            assert_eq!(config.store.db_max_size, Some(3_000_000_000));
+            assert_eq!(config.store.max_size, Some(3_000_000_000));
             assert!(config.full_vacuum_on_start);
             assert_eq!(
                 config.worker_map,
@@ -1229,7 +1229,7 @@ mod tests {
             };
             let config = Config::from_args(&args).unwrap();
             assert_eq!(config.log_filter, "error");
-            assert_eq!(config.store.database_adapter, DatabaseAdapter::Postgres);
+            assert_eq!(config.store.adapter, DatabaseAdapter::Postgres);
             assert_eq!(config.store.max_processing_attempts, 5);
 
             Ok(())

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -129,7 +129,7 @@ impl Default for RetryConfig {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct StoreConfig {
     /// The database adapter to use for the activation store.
-    pub database_adapter: DatabaseAdapter,
+    pub adapter: DatabaseAdapter,
 
     /// Postgres configuration.
     pub pg: PgConfig,
@@ -141,24 +141,24 @@ pub struct StoreConfig {
     pub retry: RetryConfig,
 
     /// The amount of time to wait before retrying writes to db when write fails.
-    pub db_write_failure_backoff_ms: u64,
+    pub insert_failure_backoff_ms: u64,
 
     /// The maximum number of tasks that are buffered
     /// before being written to ActivationStore (sqlite).
-    pub db_insert_batch_max_len: usize,
+    pub insert_batch_max_length: usize,
 
     /// The maximum number of bytes that are buffered
     /// before being written to ActivationStore (sqlite).
-    pub db_insert_batch_max_size: usize,
+    pub insert_batch_max_bytes: usize,
 
     /// The time in milliseconds to buffer tasks
     /// before being written to ActivationStore (sqlite).
-    pub db_insert_batch_max_time_ms: u64,
+    pub insert_batch_max_time_ms: u64,
 
     /// The maximum size of the sqlite database in bytes.
     /// If the database reaches or exceeds this size, ingestion will
     /// pause until the database size is reduced.
-    pub db_max_size: Option<u64>,
+    pub max_size: Option<u64>,
 
     /// The maximum number of pending records that can be
     /// in the ActivationStore (sqlite)
@@ -186,15 +186,15 @@ pub struct StoreConfig {
 impl Default for StoreConfig {
     fn default() -> Self {
         Self {
-            database_adapter: DatabaseAdapter::Sqlite,
+            adapter: DatabaseAdapter::Sqlite,
             pg: PgConfig::default(),
             sqlite: SqliteConfig::default(),
             retry: RetryConfig::default(),
-            db_write_failure_backoff_ms: 4000,
-            db_insert_batch_max_len: 256,
-            db_insert_batch_max_size: 16_000_000,
-            db_insert_batch_max_time_ms: 1000,
-            db_max_size: Some(3000000000),
+            insert_failure_backoff_ms: 4000,
+            insert_batch_max_length: 256,
+            insert_batch_max_bytes: 16_000_000,
+            insert_batch_max_time_ms: 1000,
+            max_size: Some(3000000000),
             max_pending_count: 2048,
             max_delay_count: 8192,
             max_processing_count: 2048,

--- a/src/kafka/activation_batcher.rs
+++ b/src/kafka/activation_batcher.rs
@@ -37,9 +37,9 @@ impl ActivationBatcherConfig {
             kafka_topic: topic_name.to_owned(),
             kafka_long_topic: config.kafka_long_topic.clone(),
             send_timeout_ms: config.kafka_send_timeout_ms,
-            max_batch_time_ms: config.store.db_insert_batch_max_time_ms,
-            max_batch_len: config.store.db_insert_batch_max_len,
-            max_batch_size: config.store.db_insert_batch_max_size,
+            max_batch_time_ms: config.store.insert_batch_max_time_ms,
+            max_batch_len: config.store.insert_batch_max_length,
+            max_batch_size: config.store.insert_batch_max_bytes,
         }
     }
 }
@@ -316,8 +316,8 @@ demoted_namespaces:
         let runtime_config = Arc::new(RuntimeConfigManager::new(None).await);
         let mut config = Config {
             store: StoreConfig {
-                db_insert_batch_max_size: 1,
-                db_insert_batch_max_len: 2,
+                insert_batch_max_bytes: 1,
+                insert_batch_max_length: 2,
                 ..StoreConfig::default()
             },
             ..Default::default()
@@ -349,8 +349,8 @@ demoted_namespaces:
         let runtime_config = Arc::new(RuntimeConfigManager::new(None).await);
         let mut config = Config {
             store: StoreConfig {
-                db_insert_batch_max_size: 100000,
-                db_insert_batch_max_len: 2,
+                insert_batch_max_bytes: 100000,
+                insert_batch_max_length: 2,
                 ..StoreConfig::default()
             },
             ..Default::default()

--- a/src/kafka/activation_writer.rs
+++ b/src/kafka/activation_writer.rs
@@ -33,12 +33,12 @@ impl ActivationWriterConfig {
     pub fn from_topic(config: &Config, topic: &str) -> Self {
         Self {
             topic: topic.to_owned(),
-            db_max_size: config.store.db_max_size,
-            max_buf_len: config.store.db_insert_batch_max_len,
+            db_max_size: config.store.max_size,
+            max_buf_len: config.store.insert_batch_max_length,
             max_pending_activations: config.store.max_pending_count,
             max_processing_activations: config.store.max_processing_count,
             max_delay_activations: config.store.max_delay_count,
-            write_failure_backoff_ms: config.store.db_write_failure_backoff_ms,
+            write_failure_backoff_ms: config.store.insert_failure_backoff_ms,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,10 +67,10 @@ async fn main() -> Result<(), Error> {
     metrics::init(metrics::MetricsConfig::from_config(&config));
 
     if args.run == Run::Migrations {
-        return config.store.database_adapter.migrate(&config).await;
+        return config.store.adapter.migrate(&config).await;
     }
 
-    let store: Arc<dyn ActivationStore> = match config.store.database_adapter {
+    let store: Arc<dyn ActivationStore> = match config.store.adapter {
         DatabaseAdapter::Sqlite => Arc::new(SqliteStore::new(&config).await?),
 
         DatabaseAdapter::Postgres => {

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -15,7 +15,7 @@ use crate::worker::WorkerMap;
 mod thread;
 pub mod updater;
 
-/// Approximately the longest time it should take to perform a task update query (used by `compute_claim_lease_ms`).
+/// Approximately the longest time it should take to perform a task update query (used by `compute_claim_duration_ms`).
 /// Setting this too low will not impact correctness, but in the worst case, it may cause tasks to excute more than once.
 const QUERY_MS: u64 = 1000;
 
@@ -34,7 +34,7 @@ const QUERY_MS: u64 = 1000;
 /// This computation could definitely use some refinement, but it's more accurate than
 /// what we had before, and it's located in one place rather than being copied between
 /// the SQLite and Postgres adapters.
-pub fn compute_claim_lease_ms(config: &Config) -> u64 {
+pub fn compute_claim_duration_ms(config: &Config) -> u64 {
     // Imagine we are computing the lease for some task in a batch of N tasks
     let fetch_batch_size = config.fetch_batch_size.max(1) as u64;
     let push_threads = config.push_threads.max(1) as u64;

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -19,7 +19,7 @@ use tracing::{instrument, warn};
 
 use crate::config::Config;
 use crate::config::store::StoreConfig;
-use crate::push::compute_claim_lease_ms;
+use crate::push::compute_claim_duration_ms;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::retry::retry_query;
 use crate::store::traits::ActivationStore;
@@ -230,7 +230,7 @@ pub struct PostgresStore {
     write_pool: PgPool,
     config: StoreConfig,
     partitions: RwLock<Vec<i32>>,
-    claim_lease_ms: u64,
+    claim_duration_ms: u64,
 }
 
 impl PostgresStore {
@@ -282,7 +282,7 @@ impl PostgresStore {
             write_pool,
             config: config.store.clone(),
             partitions: RwLock::new(vec![]),
-            claim_lease_ms: compute_claim_lease_ms(config),
+            claim_duration_ms: compute_claim_duration_ms(config),
         })
     }
 
@@ -481,7 +481,7 @@ impl ActivationStore for PostgresStore {
         mark_processing: bool,
     ) -> Result<Vec<Activation>, Error> {
         let grace_period = self.config.processing_deadline_grace_sec;
-        let claim_lease_ms = self.claim_lease_ms as i64;
+        let claim_duration_ms = self.claim_duration_ms as i64;
 
         retry_query(&self.config.retry, "claim_activations", || async {
             let now = Utc::now();
@@ -542,7 +542,7 @@ impl ActivationStore for PostgresStore {
             } else {
                 query_builder.push(format!(
                     "UPDATE inflight_taskactivations
-                     SET claim_expires_at = now() + ({claim_lease_ms} * interval '1 millisecond'),
+                     SET claim_expires_at = now() + ({claim_duration_ms} * interval '1 millisecond'),
                          processing_deadline = NULL,
                          status = "
                 ));

--- a/src/store/adapters/sqlite.rs
+++ b/src/store/adapters/sqlite.rs
@@ -27,7 +27,7 @@ use tracing::{debug, instrument, warn};
 
 use crate::config::Config;
 use crate::config::store::StoreConfig;
-use crate::push::compute_claim_lease_ms;
+use crate::push::compute_claim_duration_ms;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::traits::ActivationStore;
 use crate::store::types::{BucketRange, FailedTasksForwarder};
@@ -185,7 +185,7 @@ pub struct SqliteStore {
     read_pool: SqlitePool,
     write_pool: SqlitePool,
     config: StoreConfig,
-    claim_lease_ms: u64,
+    claim_duration_ms: u64,
 }
 
 impl SqliteStore {
@@ -200,7 +200,7 @@ impl SqliteStore {
             read_pool,
             write_pool,
             config: config.store.clone(),
-            claim_lease_ms: compute_claim_lease_ms(config),
+            claim_duration_ms: compute_claim_duration_ms(config),
         })
     }
 
@@ -587,7 +587,7 @@ impl ActivationStore for SqliteStore {
         } else {
             query_builder.push(format!(
                 "claim_expires_at = unixepoch('now', '+' || {:.3} || ' seconds'), processing_deadline = NULL, status = ",
-                self.claim_lease_ms as f64 / 1000.0,
+                self.claim_duration_ms as f64 / 1000.0,
             ));
 
             query_builder.push_bind(ActivationStatus::Claimed);


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 16** of my configuration improvement effort. It's a super quick one. Now that the database-related config options are all nested inside `store`, it's not necessary to prefix them with `db_` and `database_` and so on.