### PR TITLE
ref(config): (19) Move Push Update Batching Config into `PushConfig`

### DIFF
--- a/src/config/batch.rs
+++ b/src/config/batch.rs
@@ -1,0 +1,20 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
+pub struct BatchConfig {
+    /// The maximum or desired length of a batch, depending on context.
+    #[validate(range(min = 1))]
+    pub length: usize,
+
+    /// The maximum or desired size in bytes of a batch, depending on context.
+    #[validate(range(min = 1))]
+    pub size: usize,
+
+    /// How often the batch should be flushed. If set to zero, it will be flushed repeatedly without waiting.
+
+    #[serde(with = "crate::serde::duration")]
+    pub interval: Duration,
+}

--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -210,6 +210,15 @@ pub struct DeprecatedConfig {
     /// Maximum time in milliseconds to wait when submitting an activation to the push pool.
     pub push_queue_timeout_ms: Option<u64>,
 
+    /// Update claimed → processing updates in batches? Only applies in PUSH mode.
+    pub batch_push_updates: Option<bool>,
+
+    /// The size of a batch of dispatch updates.
+    pub push_update_batch_size: Option<usize>,
+
+    /// Maximum milliseconds to wait before flushing a batch of dispatch updates.
+    pub push_update_interval_ms: Option<u32>,
+
     /// The number of concurrent fetch loops in push mode, which should be ≤ `MAX_FETCH_THREADS` and a power of two.
     pub fetch_threads: Option<usize>,
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,6 +17,7 @@ use crate::config::push::PushConfig;
 use crate::config::store::StoreConfig;
 use crate::logging::LogFormat;
 
+pub mod batch;
 pub mod deprecated;
 pub mod fetch;
 pub mod kafka;
@@ -195,17 +196,6 @@ pub struct Config {
     #[validate(range(min = 1))]
     pub status_update_interval_ms: u64,
 
-    /// Update claimed → processing updates in batches? Only applies in PUSH mode.
-    pub batch_push_updates: bool,
-
-    /// The size of a batch of dispatch updates.
-    #[validate(range(min = 1))]
-    pub push_update_batch_size: usize,
-
-    /// Maximum milliseconds to wait before flushing a batch of dispatch updates.
-    #[validate(range(min = 1))]
-    pub push_update_interval_ms: u32,
-
     /// Maps every application to its worker endpoint, both represented as strings.
     pub worker_map: BTreeMap<String, String>,
 
@@ -281,9 +271,6 @@ impl Default for Config {
             batch_status_updates: false,
             status_update_batch_size: 1,
             status_update_interval_ms: 100,
-            batch_push_updates: false,
-            push_update_batch_size: 1,
-            push_update_interval_ms: 100,
             worker_map: [("sentry".into(), "http://127.0.0.1:50052".into())].into(),
             raw_namespace: None,
             raw_application: None,
@@ -373,6 +360,24 @@ impl Config {
             && let Some(v) = self.deprecated.push_queue_timeout_ms
         {
             self.push.queue.timeout = Duration::from_millis(v);
+        }
+
+        if !user_provided(builder, "push.update.batched") {
+            deprecated::map! {
+                self.deprecated.batch_push_updates => self.push.update.batched
+            };
+        }
+
+        if !user_provided(builder, "push.update.batch.length") {
+            deprecated::map! {
+                self.deprecated.push_update_batch_size => self.push.update.batch.length
+            };
+        }
+
+        if !user_provided(builder, "push.update.batch.interval")
+            && let Some(v) = self.deprecated.push_update_interval_ms
+        {
+            self.push.update.batch.interval = Duration::from_millis(v.into());
         }
 
         // Map deprecated Postgres configuration options

--- a/src/config/push.rs
+++ b/src/config/push.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError};
 
+use crate::config::batch::BatchConfig;
+
 // (TODO) Create a `validate` module to keep all of our custom validators (there are now at least two).
 fn validate_nonzero_duration(duration: &Duration) -> Result<(), ValidationError> {
     if duration.is_zero() {
@@ -34,6 +36,29 @@ impl Default for PushQueueConfig {
 }
 
 #[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
+pub struct PushUpdateConfig {
+    // Update claimed → processing updates in batches?
+    pub batched: bool,
+
+    /// Describes update batching behavior if enabled by `batched`.
+    #[validate(nested)]
+    pub batch: BatchConfig,
+}
+
+impl Default for PushUpdateConfig {
+    fn default() -> Self {
+        Self {
+            batched: false,
+            batch: BatchConfig {
+                length: 1,
+                interval: Duration::from_millis(100),
+                size: 1, // We don't use size here
+            },
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
 pub struct PushConfig {
     /// The number of concurrent push threads to run.
     #[validate(range(min = 1))]
@@ -47,6 +72,10 @@ pub struct PushConfig {
     /// The push queue configuration.
     #[validate(nested)]
     pub queue: PushQueueConfig,
+
+    // Configure how claimed → processing updates are performed.
+    #[validate(nested)]
+    pub update: PushUpdateConfig,
 }
 
 impl Default for PushConfig {
@@ -55,6 +84,7 @@ impl Default for PushConfig {
             threads: 1,
             timeout: Duration::from_millis(30000),
             queue: PushQueueConfig::default(),
+            update: PushUpdateConfig::default(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,7 +325,7 @@ async fn main() -> Result<(), Error> {
         }
 
         // Create the correct kind of push updater
-        let updater = if config.batch_push_updates {
+        let updater = if config.push.update.batched {
             let lazy = LazyUpdater::new(config.clone(), store.clone());
             Arc::new(lazy) as Arc<dyn Updater>
         } else {

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -56,8 +56,8 @@ pub fn compute_claim_duration_ms(config: &Config) -> u64 {
     let update_query_ms = rounds * QUERY_MS;
 
     // Batched push updates can wait in the updater buffer until either the batch fills or the periodic flush runs
-    let batch_delay_ms = if config.batch_push_updates {
-        config.push_update_interval_ms as u64
+    let batch_delay_ms = if config.push.update.batched {
+        config.push.update.batch.interval.as_millis() as u64
     } else {
         0
     };

--- a/src/push/updater.rs
+++ b/src/push/updater.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -131,7 +130,7 @@ impl Updater for LazyUpdater {
         let guard = get_shutdown_guard();
 
         // Flush every `interval` milliseconds
-        let period = Duration::from_millis(self.config.push_update_interval_ms as u64);
+        let period = self.config.push.update.batch.interval;
         let mut interval = tokio::time::interval(period);
 
         loop {
@@ -141,7 +140,7 @@ impl Updater for LazyUpdater {
                     break;
                 }
 
-                _ = interval.tick(), if self.config.batch_push_updates => {
+                _ = interval.tick(), if self.config.push.update.batched => {
                     // Lock the ID buffer
                     let mut buffer = self.lock_buffer("tick").await;
 
@@ -149,7 +148,7 @@ impl Updater for LazyUpdater {
                     let now = Utc::now().timestamp_millis();
                     let elapsed = now - self.last_flush.read().await.timestamp_millis();
 
-                    if elapsed < (self.config.push_update_interval_ms as i64) {
+                    if elapsed < (self.config.push.update.batch.interval.as_millis() as i64) {
                         // Too soon!
                         continue;
                     }
@@ -196,7 +195,7 @@ impl Updater for LazyUpdater {
         // Lock the ID buffer
         let mut buffer = self.lock_buffer("update").await;
 
-        if buffer.len() >= self.config.push_update_batch_size {
+        if buffer.len() >= self.config.push.update.batch.length {
             // Flush first
             match self.flush(&mut buffer).await {
                 Ok(_) => {


### PR DESCRIPTION
## Linear
Refs [STREAM-843](https://linear.app/getsentry/issue/STREAM-843/better-configuration-organization)

## Description
This is **PART 19** of my configuration improvement effort. In this PR, I move the remaining push mode config -- update batch settings -- into the nested `PushConfig` struct.