### PR TITLE
fix(TaskProducer): call close() on shutdown

### DIFF
--- a/clients/python/src/taskbroker_client/types.py
+++ b/clients/python/src/taskbroker_client/types.py
@@ -1,6 +1,7 @@
 import contextlib
 import dataclasses
 from collections.abc import MutableMapping
+from concurrent.futures import Future
 from typing import Any, Callable, Protocol
 
 from arroyo.backends.abstract import ProducerFuture
@@ -40,6 +41,16 @@ class ProducerProtocol(Protocol):
     def produce(
         self, dest: Topic | Partition, payload: KafkaPayload
     ) -> ProducerFuture[BrokerValue[KafkaPayload]]: ...
+
+
+class CloseableProducerProtocol(Protocol):
+    """Interface used by TaskProducer. Represents a producer that has a shutdown method."""
+
+    def produce(
+        self, dest: Topic | Partition, payload: KafkaPayload
+    ) -> ProducerFuture[BrokerValue[KafkaPayload]]: ...
+
+    def close(self) -> Future[None]: ...
 
 
 ProducerFactory = Callable[[str], ProducerProtocol]

--- a/clients/python/src/taskbroker_client/worker/producer.py
+++ b/clients/python/src/taskbroker_client/worker/producer.py
@@ -1,3 +1,4 @@
+import atexit
 from collections import deque
 from collections.abc import Callable
 from concurrent.futures import Future
@@ -9,7 +10,7 @@ from arroyo.types import BrokerValue, Partition, Topic
 
 from taskbroker_client.constants import TASK_PRODUCER_MAX_PENDING_FUTURES
 from taskbroker_client.metrics import MetricsBackend, NoOpMetricsBackend
-from taskbroker_client.types import ProducerProtocol
+from taskbroker_client.types import CloseableProducerProtocol
 
 # This is global as TaskWorker needs to be able to call TaskProducer.collect_futures()
 # without a reference to a task's specific instance of TaskProducer.
@@ -39,17 +40,18 @@ class TaskProducer:
     def __init__(
         self,
         name: str,
-        producer_factory: Callable[[], ProducerProtocol],
+        producer_factory: Callable[[], CloseableProducerProtocol],
         metrics_backend: MetricsBackend | None = None,
     ) -> None:
         self.name = name
         self._producer_factory = producer_factory
-        self._inner_producer: ProducerProtocol | None = None
+        self._inner_producer: CloseableProducerProtocol | None = None
         self.metrics = metrics_backend if metrics_backend is not None else NoOpMetricsBackend()
 
-    def _get(self) -> ProducerProtocol:
+    def _get(self) -> CloseableProducerProtocol:
         if self._inner_producer is None:
             self._inner_producer = self._producer_factory()
+            atexit.register(self._shutdown)
         return self._inner_producer
 
     def track_future(self, future: ProducerFuture[BrokerValue[KafkaPayload]]) -> None:
@@ -99,3 +101,7 @@ class TaskProducer:
                         "or instantiate your producer with `use_simple_futures=False`."
                     )
                 )
+
+    def _shutdown(self) -> None:
+        if self._inner_producer is not None:
+            self._inner_producer.close().result()

--- a/clients/python/tests/worker/test_producer.py
+++ b/clients/python/tests/worker/test_producer.py
@@ -36,6 +36,11 @@ class DummyProducer:
         future.set_result(make_broker_value())
         return future
 
+    def close(self) -> Future[None]:
+        f: Future[None] = Future()
+        f.set_result(None)
+        return f
+
 
 def get_dummy_producer(use_simple_futures: bool) -> DummyProducer:
     return DummyProducer(use_simple_futures=use_simple_futures)


### PR DESCRIPTION
This PR adds a new `CloseableProducerProtocol` interface for TaskProducer.
Previously, TaskProducer was never calling the arroyo producer [close() method](https://github.com/getsentry/arroyo/blob/main/arroyo/backends/kafka/consumer.py#L846-L848),  meaning the inner Confluent producer would never `flush()`.