### PR TITLE
ref(store): Validate database_name before CREATE DATABASE

### DIFF
--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -51,6 +51,21 @@ pub async fn migrate(config: &StoreConfig) -> Result<()> {
             .await?;
 
     if !row.0 {
+        // `CREATE DATABASE` does not accept bind parameters for the database
+        // name, so it has to be interpolated into the statement. Restrict it to
+        // a safe identifier charset to rule out SQL injection.
+        if !config
+            .pg
+            .database_name
+            .chars()
+            .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_'))
+        {
+            return Err(anyhow!(
+                "invalid database_name {:?}: only ASCII alphanumerics and underscores are allowed",
+                &config.pg.database_name
+            ));
+        }
+
         println!("Creating database {}", &config.pg.database_name);
         sqlx::query(format!("CREATE DATABASE {}", &config.pg.database_name).as_str())
             .execute(&default_pool)

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -52,8 +52,8 @@ pub async fn migrate(config: &StoreConfig) -> Result<()> {
 
     if !row.0 {
         // `CREATE DATABASE` does not accept bind parameters for the database
-        // name, so it has to be interpolated into the statement. Restrict it to
-        // a safe identifier charset to rule out SQL injection.
+        // name. but this is not a critical SQL injection as the database name is not untrusted
+        // user input. nevertheless, let's validate DB identifiers to prevent the worst.
         if !config
             .pg
             .database_name


### PR DESCRIPTION
`CREATE DATABASE` cannot use bind parameters for the database name, so the name has to be interpolated directly into the statement. This restricts it to a safe identifier charset (ASCII alphanumerics and underscores) before interpolation, ruling out SQL injection via `database_name`.

This PR mainly exists to pacify security scanners, not because this is a real issue.

ref STREAM-1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)