### PR TITLE
ref(deps): Drop hard redis-py-cluster dependency to allow redis>=4

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "orjson>=3.10.10",
     "protobuf>=5.28.3",
     "redis>=3.4.1",
-    "redis-py-cluster>=2.1.0",
     "zstandard>=0.18.0",
 ]
 
@@ -34,6 +33,11 @@ dev = [
     "types-protobuf>=5.27.0.20240626,<6.0.0",
 ]
 [project.optional-dependencies]
+# redis<4 does not bundle cluster support; pull in redis-py-cluster (EOL) for it.
+# Not needed on redis>=4.1, which provides redis.RedisCluster natively.
+cluster = [
+    "redis-py-cluster>=2.1.0",
+]
 examples = [
     "click>=8.3",
     "setuptools>=80.0",

--- a/clients/python/src/taskbroker_client/scheduler/storage.py
+++ b/clients/python/src/taskbroker_client/scheduler/storage.py
@@ -111,9 +111,7 @@ class RunStorage(RunStorageProtocol):
     Redis backed scheduler storage
     """
 
-    def __init__(
-        self, metrics: MetricsBackend, redis: RedisCluster | StrictRedis
-    ) -> None:
+    def __init__(self, metrics: MetricsBackend, redis: RedisCluster | StrictRedis) -> None:
         self._redis = redis
         self._metrics = metrics
 
@@ -132,9 +130,7 @@ class RunStorage(RunStorageProtocol):
         # next_runtime & now could be the same second, and redis gets sad if ex=0
         duration = max(int((next_runtime - now).total_seconds()), 1)
 
-        result = self._redis.set(
-            self._make_key(key), now.isoformat(), ex=duration, nx=True
-        )
+        result = self._redis.set(self._make_key(key), now.isoformat(), ex=duration, nx=True)
         return bool(result)
 
     def read(self, key: str) -> datetime | None:
@@ -146,9 +142,7 @@ class RunStorage(RunStorageProtocol):
         if result:
             return datetime.fromisoformat(result)
 
-        self._metrics.incr(
-            "taskworker.scheduler.run_storage.read.miss", tags={"taskname": key}
-        )
+        self._metrics.incr("taskworker.scheduler.run_storage.read.miss", tags={"taskname": key})
         return None
 
     def read_many(

--- a/clients/python/src/taskbroker_client/scheduler/storage.py
+++ b/clients/python/src/taskbroker_client/scheduler/storage.py
@@ -2,15 +2,21 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from datetime import UTC, datetime
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from redis.client import StrictRedis
 
-try:
-    # redis>=4.1 ships cluster support natively
-    from redis import RedisCluster
-except ImportError:  # pragma: no cover - redis<4 fallback via the `cluster` extra
-    from rediscluster import RedisCluster
+if TYPE_CHECKING:
+    # Type-checking only: RedisCluster is used solely in annotations (this module
+    # never constructs it), and `from __future__ import annotations` keeps them
+    # unevaluated at runtime. Guarding the import here avoids breaking default
+    # (non-`cluster`-extra) installs where neither redis.RedisCluster (redis<4.1)
+    # nor the rediscluster fallback is importable.
+    try:
+        # redis>=4.1 ships cluster support natively
+        from redis import RedisCluster
+    except ImportError:  # pragma: no cover - redis<4 fallback via the `cluster` extra
+        from rediscluster import RedisCluster
 
 from taskbroker_client.metrics import MetricsBackend
 
@@ -131,7 +137,9 @@ class RunStorage(RunStorageProtocol):
         # next_runtime & now could be the same second, and redis gets sad if ex=0
         duration = max(int((next_runtime - now).total_seconds()), 1)
 
-        result = self._redis.set(self._make_key(key), now.isoformat(), ex=duration, nx=True)
+        result = self._redis.set(
+            self._make_key(key), now.isoformat(), ex=duration, nx=True
+        )
         return bool(result)
 
     def read(self, key: str) -> datetime | None:
@@ -143,7 +151,9 @@ class RunStorage(RunStorageProtocol):
         if result:
             return datetime.fromisoformat(result)
 
-        self._metrics.incr("taskworker.scheduler.run_storage.read.miss", tags={"taskname": key})
+        self._metrics.incr(
+            "taskworker.scheduler.run_storage.read.miss", tags={"taskname": key}
+        )
         return None
 
     def read_many(

--- a/clients/python/src/taskbroker_client/scheduler/storage.py
+++ b/clients/python/src/taskbroker_client/scheduler/storage.py
@@ -7,11 +7,6 @@ from typing import TYPE_CHECKING, Protocol
 from redis.client import StrictRedis
 
 if TYPE_CHECKING:
-    # Type-checking only: RedisCluster is used solely in annotations (this module
-    # never constructs it), and `from __future__ import annotations` keeps them
-    # unevaluated at runtime. Guarding the import here avoids breaking default
-    # (non-`cluster`-extra) installs where neither redis.RedisCluster (redis<4.1)
-    # nor the rediscluster fallback is importable.
     try:
         # redis>=4.1 ships cluster support natively
         from redis import RedisCluster

--- a/clients/python/src/taskbroker_client/scheduler/storage.py
+++ b/clients/python/src/taskbroker_client/scheduler/storage.py
@@ -5,7 +5,12 @@ from datetime import UTC, datetime
 from typing import Protocol
 
 from redis.client import StrictRedis
-from rediscluster import RedisCluster
+
+try:
+    # redis>=4.1 ships cluster support natively
+    from redis import RedisCluster
+except ImportError:  # pragma: no cover - redis<4 fallback via the `cluster` extra
+    from rediscluster import RedisCluster
 
 from taskbroker_client.metrics import MetricsBackend
 
@@ -106,7 +111,7 @@ class RunStorage(RunStorageProtocol):
     """
 
     def __init__(
-        self, metrics: MetricsBackend, redis: RedisCluster[str] | StrictRedis[str]
+        self, metrics: MetricsBackend, redis: RedisCluster | StrictRedis
     ) -> None:
         self._redis = redis
         self._metrics = metrics


### PR DESCRIPTION
Drop hard redis-py-cluster dependency to allow redis>=4. Mirrors the behavior of https://github.com/getsentry/sentry-redis-tools/blob/main/sentry_redis_tools/clients.py.