### PR TITLE
feat(killswitch): argument-based fine-grained killswitches

### DIFF
--- a/src/fetch/tests.rs
+++ b/src/fetch/tests.rs
@@ -195,6 +195,13 @@ impl ActivationStore for MockStore {
     async fn remove_killswitched(&self, _killswitched_tasks: Vec<String>) -> Result<u64, Error> {
         unimplemented!()
     }
+
+    async fn remove_killswitched_selectors(
+        &self,
+        _selectors: Vec<crate::killswitch::KillswitchSelector>,
+    ) -> Result<u64, Error> {
+        unimplemented!()
+    }
 }
 
 fn test_config() -> Arc<Config> {

--- a/src/kafka/activation_batcher.rs
+++ b/src/kafka/activation_batcher.rs
@@ -96,11 +96,18 @@ impl Reducer for ActivationBatcher {
         let task_name = &t.taskname;
         let namespace = &t.namespace;
 
-        if runtime_config.drop_task_killswitch.contains(task_name) {
+        // Drop the task if a killswitch matches. `should_drop` only decodes the activation
+        // when a selector targets this task, and fails open on any decode error.
+        if let Some(match_kind) = crate::killswitch::should_drop(
+            &runtime_config.drop_task_killswitch,
+            task_name,
+            &t.activation,
+        ) {
             metrics::counter!(
                 "filter.drop_task_killswitch",
                 "topic" => self.config.kafka_topic.clone(),
                 "taskname" => task_name.clone(),
+                "match" => match_kind,
             )
             .increment(1);
             return Ok(());
@@ -288,6 +295,62 @@ demoted_namespaces:
     }
 
     #[tokio::test]
+    async fn test_drop_task_due_to_selector_killswitch() {
+        let test_yaml = r#"
+drop_task_killswitch:
+  - name: sentry.tasks.unmerge
+    select_kwarg: {project_id: 123}
+demoted_namespaces: []"#;
+
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
+
+        let runtime_config = Arc::new(
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await,
+        );
+        let mut config = Config::default();
+        config.normalize_and_validate().unwrap();
+        let config = Arc::new(config);
+        let mut batcher = ActivationBatcher::new(
+            ActivationBatcherConfig::from_topic(&config, config.consumable_topics().unwrap()[0].0),
+            runtime_config,
+        );
+
+        let namespace = generate_unique_namespace();
+
+        // Encode `{"args": [...], "kwargs": {...}}` (written as YAML) into msgpack bytes.
+        let msgpack_params = |yaml: &str| -> Vec<u8> {
+            let value: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+            rmp_serde::to_vec_named(&value).unwrap()
+        };
+
+        // Matching project_id: dropped.
+        let matching = ActivationBuilder::new()
+            .id("0")
+            .taskname("sentry.tasks.unmerge")
+            .namespace(&namespace)
+            .build(
+                TaskActivationBuilder::new()
+                    .parameters_bytes(msgpack_params("{args: [], kwargs: {project_id: 123}}")),
+            );
+        batcher.reduce(matching).await.unwrap();
+        assert_eq!(batcher.batch.len(), 0);
+
+        // Same task, different project_id: kept.
+        let non_matching = ActivationBuilder::new()
+            .id("1")
+            .taskname("sentry.tasks.unmerge")
+            .namespace(&namespace)
+            .build(
+                TaskActivationBuilder::new()
+                    .parameters_bytes(msgpack_params("{args: [], kwargs: {project_id: 456}}")),
+            );
+        batcher.reduce(non_matching).await.unwrap();
+        assert_eq!(batcher.batch.len(), 1);
+    }
+
+    #[tokio::test]
     async fn test_drop_task_due_to_expiry() {
         let runtime_config = Arc::new(RuntimeConfigManager::new(None).await);
         let mut config = Config::default();
@@ -387,8 +450,7 @@ demoted_namespaces:
     #[tokio::test]
     async fn test_forward_task_due_to_demoted_namespace() {
         let test_yaml = r#"
-drop_task_killswitch:
-  -
+drop_task_killswitch: []
 demoted_namespaces:
   - bad_namespace
 demoted_topic_cluster: 0.0.0.0:9092

--- a/src/kafka/activation_batcher.rs
+++ b/src/kafka/activation_batcher.rs
@@ -1,6 +1,6 @@
 use std::mem::replace;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use futures::future::join_all;
@@ -98,19 +98,32 @@ impl Reducer for ActivationBatcher {
 
         // Drop the task if a killswitch matches. `should_drop` only decodes the activation
         // when a selector targets this task, and fails open on any decode error.
-        if let Some(match_kind) = crate::killswitch::should_drop(
-            &runtime_config.drop_task_killswitch,
-            task_name,
-            &t.activation,
-        ) {
-            metrics::counter!(
-                "filter.drop_task_killswitch",
+        //
+        // Guard on emptiness so the common "no killswitches active" case skips the timing
+        // entirely: when active, the selector path decodes each candidate activation's
+        // msgpack args, so record how long that costs per activation.
+        if !runtime_config.drop_task_killswitch.is_empty() {
+            let should_drop_start = Instant::now();
+            let match_kind = crate::killswitch::should_drop(
+                &runtime_config.drop_task_killswitch,
+                task_name,
+                &t.activation,
+            );
+            metrics::histogram!(
+                "filter.drop_task_killswitch.duration",
                 "topic" => self.config.kafka_topic.clone(),
-                "taskname" => task_name.clone(),
-                "match" => match_kind,
             )
-            .increment(1);
-            return Ok(());
+            .record(should_drop_start.elapsed());
+            if let Some(match_kind) = match_kind {
+                metrics::counter!(
+                    "filter.drop_task_killswitch",
+                    "topic" => self.config.kafka_topic.clone(),
+                    "taskname" => task_name.clone(),
+                    "match" => match_kind,
+                )
+                .increment(1);
+                return Ok(());
+            }
         }
 
         if let Some(expires_at) = t.expires_at

--- a/src/kafka/deserialize_raw.rs
+++ b/src/kafka/deserialize_raw.rs
@@ -24,8 +24,8 @@ struct RawParams<'a> {
 /// Header key and value identifying zstd-compressed `parameters_bytes`. Must match the
 /// producer/worker contract (`CompressionType.ZSTD` in the Python client) so the worker
 /// decompresses payloads taskbroker compresses in raw mode.
-const COMPRESSION_HEADER: &str = "compression-type";
-const COMPRESSION_ZSTD: &str = "zstd";
+pub(crate) const COMPRESSION_HEADER: &str = "compression-type";
+pub(crate) const COMPRESSION_ZSTD: &str = "zstd";
 
 /// Default zstd level for raw-mode payloads, matching the producer's zstandard default.
 const DEFAULT_COMPRESSION_LEVEL: i32 = 3;

--- a/src/killswitch.rs
+++ b/src/killswitch.rs
@@ -1,0 +1,351 @@
+//! Fine-grained task killswitches.
+//!
+//! The `drop_task_killswitch` runtime config is a list of rules. A rule is either:
+//!
+//! * a bare task name (`KillswitchRule::Name`) — drop every activation of that task, or
+//! * a selector (`KillswitchRule::Selector`) — drop an activation only when its arguments
+//!   match, so we can e.g. drop `sentry.tasks.unmerge` for a single `project_id`.
+//!
+//! Selectors match against the activation's `parameters_bytes`, which is msgpack-encoded
+//! as `{"args": [...], "kwargs": {...}}` and may be zstd-compressed (see
+//! `headers["compression-type"]`). All parsing **fails open**: any decode error means the
+//! task is *not* dropped, so a killswitch can never take down traffic it wasn't meant to.
+
+use std::collections::HashMap;
+
+use sentry_protos::taskbroker::v1::TaskActivation;
+use serde::Deserialize;
+
+use crate::kafka::deserialize_raw::{COMPRESSION_HEADER, COMPRESSION_ZSTD};
+
+/// Upper bound for decompressing `parameters_bytes`, mirroring the worker's limit in
+/// `deserialize_raw`.
+const MAX_DECOMPRESSED_SIZE: usize = 64 * 1024 * 1024;
+
+/// A single entry in `drop_task_killswitch`.
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum KillswitchRule {
+    /// A bare task name: drop every activation of this task.
+    Name(String),
+    /// An argument selector: drop only activations whose arguments match.
+    Selector(KillswitchSelector),
+}
+
+/// Drop activations of `name` whose arguments match any of the listed conditions.
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct KillswitchSelector {
+    /// The task name this selector applies to.
+    pub name: String,
+    /// Match by positional argument index, e.g. `{0: 123}` for "first arg == 123".
+    #[serde(default)]
+    pub select_arg: HashMap<usize, serde_yaml::Value>,
+    /// Match by keyword argument name, e.g. `{project_id: 123}`.
+    #[serde(default)]
+    pub select_kwarg: HashMap<String, serde_yaml::Value>,
+}
+
+impl KillswitchRule {
+    /// The task name this rule applies to, regardless of variant.
+    pub fn taskname(&self) -> &str {
+        match self {
+            KillswitchRule::Name(name) => name,
+            KillswitchRule::Selector(selector) => &selector.name,
+        }
+    }
+}
+
+/// Split a rule list into the whole-task names (handled by a fast `taskname IN (...)` SQL
+/// path) and the argument selectors (which require decoding each activation).
+pub fn partition_rules(rules: &[KillswitchRule]) -> (Vec<String>, Vec<KillswitchSelector>) {
+    let mut names = Vec::new();
+    let mut selectors = Vec::new();
+    for rule in rules {
+        match rule {
+            KillswitchRule::Name(name) => names.push(name.clone()),
+            KillswitchRule::Selector(selector) => selectors.push(selector.clone()),
+        }
+    }
+    (names, selectors)
+}
+
+/// Decoded `{"args": [...], "kwargs": {...}}` from an activation's `parameters_bytes`.
+#[derive(Debug, Deserialize)]
+struct DecodedParams {
+    #[serde(default)]
+    args: Vec<serde_yaml::Value>,
+    #[serde(default)]
+    kwargs: HashMap<String, serde_yaml::Value>,
+}
+
+/// Decode (and zstd-decompress if needed) an activation's `parameters_bytes`. Returns
+/// `None` on any error so callers fail open.
+fn decode_params(activation: &TaskActivation) -> Option<DecodedParams> {
+    let is_zstd = activation
+        .headers
+        .get(COMPRESSION_HEADER)
+        .map(String::as_str)
+        == Some(COMPRESSION_ZSTD);
+
+    let decompressed;
+    let raw: &[u8] = if is_zstd {
+        decompressed =
+            zstd::bulk::decompress(&activation.parameters_bytes, MAX_DECOMPRESSED_SIZE).ok()?;
+        &decompressed
+    } else {
+        &activation.parameters_bytes
+    };
+
+    rmp_serde::from_slice::<DecodedParams>(raw).ok()
+}
+
+/// Whether `selector` matches `activation` (so the task should be dropped).
+///
+/// Conditions combine with OR: a match on any listed `select_arg` or `select_kwarg` is
+/// enough. Fails open — any decode error returns `false`.
+pub fn selector_matches(selector: &KillswitchSelector, activation: &TaskActivation) -> bool {
+    let Some(params) = decode_params(activation) else {
+        return false;
+    };
+
+    // `serde_yaml::Value` equality is exact: a positive int from msgpack and the same int
+    // from YAML both deserialize to the `PosInt` variant (sign decides the variant on both
+    // sides), so `==` matches them. Int vs float (`123` vs `123.0`) intentionally does not.
+    let arg_match = selector
+        .select_arg
+        .iter()
+        .any(|(index, want)| params.args.get(*index) == Some(want));
+    let kwarg_match = selector
+        .select_kwarg
+        .iter()
+        .any(|(key, want)| params.kwargs.get(key) == Some(want));
+
+    arg_match || kwarg_match
+}
+
+/// Decide whether an ingested activation should be dropped per `rules`.
+///
+/// Returns the metric `match` label (`"whole_task"` or `"selector"`) when the task should
+/// be dropped, or `None` to keep it. Allocates nothing when no rule targets `taskname`,
+/// and only decodes `activation_bytes` (the raw `TaskActivation` protobuf) when a selector
+/// actually targets the task. Fails open: a protobuf decode error keeps the task.
+pub fn should_drop(
+    rules: &[KillswitchRule],
+    taskname: &str,
+    activation_bytes: &[u8],
+) -> Option<&'static str> {
+    use prost::Message as _;
+
+    // Whole-task killswitch: drop every activation of this task.
+    if rules
+        .iter()
+        .any(|rule| matches!(rule, KillswitchRule::Name(name) if name == taskname))
+    {
+        return Some("whole_task");
+    }
+
+    // Selector killswitch: only decode the activation when a selector targets this task.
+    let has_selector = rules
+        .iter()
+        .any(|rule| matches!(rule, KillswitchRule::Selector(sel) if sel.name == taskname));
+    if has_selector
+        && let Ok(activation) = TaskActivation::decode(activation_bytes)
+        && rules.iter().any(|rule| {
+            matches!(rule, KillswitchRule::Selector(sel)
+                if sel.name == taskname && selector_matches(sel, &activation))
+        })
+    {
+        return Some("selector");
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde::Serialize;
+
+    use crate::test_utils::TaskActivationBuilder;
+
+    use super::*;
+
+    /// Build a `TaskActivation` whose `parameters_bytes` is the msgpack encoding of `params`.
+    fn activation_with_params<T: Serialize>(params: &T) -> TaskActivation {
+        let bytes = rmp_serde::to_vec_named(params).unwrap();
+        TaskActivationBuilder::new()
+            .id("id")
+            .application("sentry")
+            .namespace("ns")
+            .taskname("sentry.tasks.unmerge")
+            .parameters_bytes(bytes)
+            .build()
+    }
+
+    #[derive(Serialize)]
+    struct Params {
+        args: Vec<serde_yaml::Value>,
+        kwargs: HashMap<String, serde_yaml::Value>,
+    }
+
+    fn yaml(value: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(value).unwrap()
+    }
+
+    fn selector(select_arg: &[(usize, &str)], select_kwarg: &[(&str, &str)]) -> KillswitchSelector {
+        KillswitchSelector {
+            name: "sentry.tasks.unmerge".into(),
+            select_arg: select_arg.iter().map(|(i, v)| (*i, yaml(v))).collect(),
+            select_kwarg: select_kwarg
+                .iter()
+                .map(|(k, v)| (k.to_string(), yaml(v)))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn test_match_positional_arg() {
+        let activation = activation_with_params(&Params {
+            args: vec![yaml("123")],
+            kwargs: HashMap::new(),
+        });
+        assert!(selector_matches(&selector(&[(0, "123")], &[]), &activation));
+        assert!(!selector_matches(
+            &selector(&[(0, "999")], &[]),
+            &activation
+        ));
+        // index out of range fails open (no match)
+        assert!(!selector_matches(
+            &selector(&[(5, "123")], &[]),
+            &activation
+        ));
+    }
+
+    #[test]
+    fn test_match_kwarg() {
+        let activation = activation_with_params(&Params {
+            args: vec![],
+            kwargs: HashMap::from([("project_id".to_string(), yaml("123"))]),
+        });
+        assert!(selector_matches(
+            &selector(&[], &[("project_id", "123")]),
+            &activation
+        ));
+        assert!(!selector_matches(
+            &selector(&[], &[("project_id", "999")]),
+            &activation
+        ));
+        // unknown kwarg name does not match
+        assert!(!selector_matches(
+            &selector(&[], &[("org_id", "123")]),
+            &activation
+        ));
+    }
+
+    #[test]
+    fn test_or_semantics() {
+        // Called positionally: kwarg condition misses, arg condition hits -> drop.
+        let activation = activation_with_params(&Params {
+            args: vec![yaml("123")],
+            kwargs: HashMap::new(),
+        });
+        let sel = selector(&[(0, "123")], &[("project_id", "123")]);
+        assert!(selector_matches(&sel, &activation));
+
+        // Called by keyword: arg condition misses, kwarg condition hits -> drop.
+        let activation = activation_with_params(&Params {
+            args: vec![],
+            kwargs: HashMap::from([("project_id".to_string(), yaml("123"))]),
+        });
+        assert!(selector_matches(&sel, &activation));
+
+        // Neither matches -> keep.
+        let activation = activation_with_params(&Params {
+            args: vec![yaml("1")],
+            kwargs: HashMap::from([("project_id".to_string(), yaml("2"))]),
+        });
+        assert!(!selector_matches(&sel, &activation));
+    }
+
+    #[test]
+    fn test_match_wide_and_negative_ints() {
+        // Values that don't fit a small int marker, plus a negative, to confirm direct
+        // `serde_yaml::Value` equality holds across the msgpack encoding.
+        let activation = activation_with_params(&Params {
+            args: vec![],
+            kwargs: HashMap::from([
+                ("project_id".to_string(), yaml("10000000000")),
+                ("delta".to_string(), yaml("-5")),
+            ]),
+        });
+        assert!(selector_matches(
+            &selector(&[], &[("project_id", "10000000000")]),
+            &activation
+        ));
+        assert!(selector_matches(
+            &selector(&[], &[("delta", "-5")]),
+            &activation
+        ));
+        assert!(!selector_matches(
+            &selector(&[], &[("project_id", "10000000001")]),
+            &activation
+        ));
+    }
+
+    #[test]
+    fn test_zstd_compressed() {
+        let bytes = rmp_serde::to_vec_named(&Params {
+            args: vec![],
+            kwargs: HashMap::from([("project_id".to_string(), yaml("123"))]),
+        })
+        .unwrap();
+        let compressed = zstd::bulk::compress(&bytes, 3).unwrap();
+        let activation = TaskActivationBuilder::new()
+            .id("id")
+            .application("sentry")
+            .namespace("ns")
+            .taskname("sentry.tasks.unmerge")
+            .parameters_bytes(compressed)
+            .headers(HashMap::from([(
+                COMPRESSION_HEADER.to_string(),
+                COMPRESSION_ZSTD.to_string(),
+            )]))
+            .build();
+        assert!(selector_matches(
+            &selector(&[], &[("project_id", "123")]),
+            &activation
+        ));
+    }
+
+    #[test]
+    fn test_fail_open_on_garbage() {
+        // Not valid msgpack -> no match.
+        let activation = TaskActivationBuilder::new()
+            .id("id")
+            .application("sentry")
+            .namespace("ns")
+            .taskname("sentry.tasks.unmerge")
+            .parameters_bytes(vec![0xff, 0xff, 0xff])
+            .build();
+        assert!(!selector_matches(
+            &selector(&[(0, "123")], &[("project_id", "123")]),
+            &activation
+        ));
+    }
+
+    #[test]
+    fn test_empty_params() {
+        // Empty msgpack map `{}` (the test default) -> no args/kwargs, no match.
+        let activation = TaskActivationBuilder::new()
+            .id("id")
+            .application("sentry")
+            .namespace("ns")
+            .taskname("sentry.tasks.unmerge")
+            .build();
+        assert!(!selector_matches(
+            &selector(&[(0, "123")], &[("project_id", "123")]),
+            &activation
+        ));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod fetch;
 pub mod flusher;
 pub mod grpc;
 pub mod kafka;
+pub mod killswitch;
 pub mod logging;
 pub mod metrics;
 pub mod push;

--- a/src/push/tests.rs
+++ b/src/push/tests.rs
@@ -167,6 +167,13 @@ impl ActivationStore for MockStore {
         Ok(0)
     }
 
+    async fn remove_killswitched_selectors(
+        &self,
+        _selectors: Vec<crate::killswitch::KillswitchSelector>,
+    ) -> Result<u64> {
+        Ok(0)
+    }
+
     async fn clear(&self) -> Result<()> {
         Ok(())
     }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -7,10 +7,14 @@ use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tracing::{error, info};
 
+use crate::killswitch::KillswitchRule;
+
 #[derive(Debug, Deserialize, Clone, PartialEq, Default)]
 pub struct RuntimeConfig {
-    /// A list of tasks to drop before inserting into sqlite.
-    pub drop_task_killswitch: Vec<String>,
+    /// A list of rules for dropping tasks before inserting into sqlite. Each rule is
+    /// either a bare task name (drop the whole task) or a selector that matches on the
+    /// task's arguments (see [`KillswitchRule`]).
+    pub drop_task_killswitch: Vec<KillswitchRule>,
     /// A list of namespaces that should be demoted to the "long" namespace.
     /// Tasks from these namespaces will be automatically forwarded to the "long" namespace
     /// to prevent them from blocking other tasks in shared namespaces.
@@ -99,14 +103,14 @@ mod tests {
     use tokio::fs;
 
     use super::RuntimeConfigManager;
+    use crate::killswitch::KillswitchRule;
 
     #[tokio::test]
     async fn test_runtime_config_manager() {
         let test_yaml = r#"
 drop_task_killswitch:
   - test:do_nothing
-demoted_namespaces:
-  -"#;
+demoted_namespaces: []"#;
 
         let mut config_file = NamedTempFile::new().unwrap();
         writeln!(config_file, "{}", test_yaml).unwrap();
@@ -116,7 +120,39 @@ demoted_namespaces:
             RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 1);
-        assert_eq!(config.drop_task_killswitch[0], "test:do_nothing");
+        assert_eq!(config.drop_task_killswitch[0].taskname(), "test:do_nothing");
+    }
+
+    #[tokio::test]
+    async fn test_runtime_config_selector_rule() {
+        let test_yaml = r#"
+drop_task_killswitch:
+  - test:do_nothing
+  - name: sentry.tasks.unmerge
+    select_arg: {0: 123}
+    select_kwarg: {project_id: 123}
+demoted_namespaces: []"#;
+
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
+
+        let runtime_config =
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await;
+        let config = runtime_config.read().await;
+        assert_eq!(config.drop_task_killswitch.len(), 2);
+        assert!(matches!(
+            &config.drop_task_killswitch[0],
+            KillswitchRule::Name(name) if name == "test:do_nothing"
+        ));
+        match &config.drop_task_killswitch[1] {
+            KillswitchRule::Selector(sel) => {
+                assert_eq!(sel.name, "sentry.tasks.unmerge");
+                assert_eq!(sel.select_arg.len(), 1);
+                assert_eq!(sel.select_kwarg.len(), 1);
+            }
+            other => panic!("expected selector, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -133,8 +169,7 @@ demoted_namespaces:
         let test_yaml = r#"
 droop_task_killswitch:
   - test:do_nothing
-demoted_namespaces:
-  -"#;
+demoted_namespaces: []"#;
 
         let mut config_file = NamedTempFile::new().unwrap();
         writeln!(config_file, "{}", test_yaml).unwrap();
@@ -151,8 +186,7 @@ demoted_namespaces:
         let test_yaml = r#"
 drop_task_killswitch:
   - test:do_nothing
-demoted_namespaces:
-  -"#;
+demoted_namespaces: []"#;
 
         let mut config_file = NamedTempFile::new().unwrap();
         writeln!(config_file, "{}", test_yaml).unwrap();
@@ -162,7 +196,7 @@ demoted_namespaces:
         let runtime_config = RuntimeConfigManager::new(Some(test_path.clone())).await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 1);
-        assert_eq!(config.drop_task_killswitch[0], "test:do_nothing");
+        assert_eq!(config.drop_task_killswitch[0].taskname(), "test:do_nothing");
 
         let invalid_yaml = r#"
 droop_task_killswitch:
@@ -174,14 +208,13 @@ demoted_namespaces:
         RuntimeConfigManager::reload_config(&Some(test_path), &runtime_config.config).await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 1);
-        assert_eq!(config.drop_task_killswitch[0], "test:do_nothing");
+        assert_eq!(config.drop_task_killswitch[0].taskname(), "test:do_nothing");
     }
 
     #[tokio::test]
     async fn test_demoted_namespaces() {
         let test_yaml = r#"
-drop_task_killswitch:
-  -
+drop_task_killswitch: []
 demoted_namespaces:
   - bad_namespace
 demoted_topic_cluster: kafka:9092
@@ -226,7 +259,7 @@ demoted_namespaces:
             RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await;
         let config = runtime_config.read().await;
         assert_eq!(config.drop_task_killswitch.len(), 1);
-        assert_eq!(config.drop_task_killswitch[0], "test:do_nothing");
+        assert_eq!(config.drop_task_killswitch[0].taskname(), "test:do_nothing");
         assert_eq!(config.demoted_namespaces.len(), 1);
         assert_eq!(config.demoted_namespaces[0], "bad_namespace");
     }

--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -19,6 +19,7 @@ use tracing::{instrument, warn};
 
 use crate::config::Config;
 use crate::config::store::StoreConfig;
+use crate::killswitch::KillswitchSelector;
 use crate::push::compute_claim_duration_ms;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::retry::retry_query;
@@ -1302,6 +1303,55 @@ impl ActivationStore for PostgresStore {
         let mut conn = self
             .acquire_write_conn_metric("remove_killswitched")
             .await?;
+        let query = query_builder.build().execute(&mut *conn).await?;
+
+        Ok(query.rows_affected())
+    }
+
+    /// Remove tasks matching argument-based killswitch selectors. Scans the rows for each
+    /// selector's taskname, decodes the activation, and deletes the ids that match. Decode
+    /// failures fail open (the task is kept).
+    #[instrument(skip_all)]
+    #[framed]
+    async fn remove_killswitched_selectors(
+        &self,
+        selectors: Vec<KillswitchSelector>,
+    ) -> Result<u64, Error> {
+        let mut conn = self
+            .acquire_write_conn_metric("remove_killswitched_selectors")
+            .await?;
+
+        let mut matched_ids: Vec<String> = Vec::new();
+        for selector in selectors.iter() {
+            let mut select_builder = QueryBuilder::new(
+                "SELECT id, activation FROM inflight_taskactivations WHERE taskname = ",
+            );
+            select_builder.push_bind(&selector.name);
+            self.add_partition_condition(&mut select_builder, false);
+            let rows: Vec<PgRow> = select_builder.build().fetch_all(&mut *conn).await?;
+            for row in rows.iter() {
+                let activation_data: &[u8] = row.get("activation");
+                let Ok(activation) = TaskActivation::decode(activation_data) else {
+                    continue; // fail open
+                };
+                if crate::killswitch::selector_matches(selector, &activation) {
+                    matched_ids.push(row.get("id"));
+                }
+            }
+        }
+
+        if matched_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let mut query_builder =
+            QueryBuilder::new("DELETE FROM inflight_taskactivations WHERE id IN (");
+        let mut separated = query_builder.separated(", ");
+        for id in matched_ids.iter() {
+            separated.push_bind(id);
+        }
+        separated.push_unseparated(")");
+        self.add_partition_condition(&mut query_builder, false);
         let query = query_builder.build().execute(&mut *conn).await?;
 
         Ok(query.rows_affected())

--- a/src/store/adapters/sqlite.rs
+++ b/src/store/adapters/sqlite.rs
@@ -27,6 +27,7 @@ use tracing::{debug, instrument, warn};
 
 use crate::config::Config;
 use crate::config::store::StoreConfig;
+use crate::killswitch::KillswitchSelector;
 use crate::push::compute_claim_duration_ms;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::traits::ActivationStore;
@@ -1195,6 +1196,53 @@ impl ActivationStore for SqliteStore {
         let mut conn = self
             .acquire_write_conn_metric("remove_killswitched")
             .await?;
+        let query = query_builder.build().execute(&mut *conn).await?;
+
+        Ok(query.rows_affected())
+    }
+
+    /// Remove tasks matching argument-based killswitch selectors. Scans the rows for each
+    /// selector's taskname, decodes the activation, and deletes the ids that match. Decode
+    /// failures fail open (the task is kept).
+    #[instrument(skip_all)]
+    async fn remove_killswitched_selectors(
+        &self,
+        selectors: Vec<KillswitchSelector>,
+    ) -> Result<u64, Error> {
+        let mut conn = self
+            .acquire_write_conn_metric("remove_killswitched_selectors")
+            .await?;
+
+        let mut matched_ids: Vec<String> = Vec::new();
+        for selector in selectors.iter() {
+            let rows: Vec<SqliteRow> = sqlx::query(
+                "SELECT id, activation FROM inflight_taskactivations WHERE taskname = $1",
+            )
+            .bind(&selector.name)
+            .fetch_all(&mut *conn)
+            .await?;
+            for row in rows.iter() {
+                let activation_data: &[u8] = row.get("activation");
+                let Ok(activation) = TaskActivation::decode(activation_data) else {
+                    continue; // fail open
+                };
+                if crate::killswitch::selector_matches(selector, &activation) {
+                    matched_ids.push(row.get("id"));
+                }
+            }
+        }
+
+        if matched_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let mut query_builder =
+            QueryBuilder::new("DELETE FROM inflight_taskactivations WHERE id IN (");
+        let mut separated = query_builder.separated(", ");
+        for id in matched_ids.iter() {
+            separated.push_bind(id);
+        }
+        separated.push_unseparated(")");
         let query = query_builder.build().execute(&mut *conn).await?;
 
         Ok(query.rows_affected())

--- a/src/store/traits.rs
+++ b/src/store/traits.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Utc};
 use tokio::join;
 use tracing::warn;
 
+use crate::killswitch::KillswitchSelector;
 use crate::store::activation::{Activation, ActivationStatus};
 use crate::store::types::{BucketRange, DepthCounts, FailedTasksForwarder};
 
@@ -191,6 +192,14 @@ pub trait ActivationStore: Send + Sync {
 
     /// Remove killswitched tasks
     async fn remove_killswitched(&self, killswitched_tasks: Vec<String>) -> Result<u64, Error>;
+
+    /// Remove tasks matching argument-based killswitch selectors. Unlike
+    /// [`remove_killswitched`], this must decode each candidate activation's arguments, so
+    /// it scans the rows for each selector's taskname rather than deleting by name alone.
+    async fn remove_killswitched_selectors(
+        &self,
+        selectors: Vec<KillswitchSelector>,
+    ) -> Result<u64, Error>;
 
     /// TEST OPERATIONS
     /// Clear all activations from the store

--- a/src/upkeep.rs
+++ b/src/upkeep.rs
@@ -302,13 +302,26 @@ pub async fn do_upkeep(
     }
     metrics::histogram!("upkeep.remove_completed").record(remove_completed_start.elapsed());
 
-    // 11. Remove killswitched tasks from store
+    // 11. Remove killswitched tasks from store. Guard on emptiness so the common
+    // "no killswitches active" case partitions and clones nothing.
     let runtime_config = runtime_config_manager.read().await;
-    let killswitched_tasks = runtime_config.drop_task_killswitch.clone();
-    if !killswitched_tasks.is_empty() {
+    if !runtime_config.drop_task_killswitch.is_empty() {
         let remove_killswitched_start = Instant::now();
-        if let Ok(count) = store.remove_killswitched(killswitched_tasks).await {
-            result_context.killswitched = count;
+        let (killswitched_tasks, killswitched_selectors) =
+            crate::killswitch::partition_rules(&runtime_config.drop_task_killswitch);
+        if !killswitched_tasks.is_empty()
+            && let Ok(count) = store.remove_killswitched(killswitched_tasks).await
+        {
+            result_context.killswitched += count;
+        }
+        // Selector rules require decoding each candidate activation's arguments, so they
+        // use a separate scan-and-delete path.
+        if !killswitched_selectors.is_empty()
+            && let Ok(count) = store
+                .remove_killswitched_selectors(killswitched_selectors)
+                .await
+        {
+            result_context.killswitched += count;
         }
         metrics::histogram!("upkeep.remove_killswitched")
             .record(remove_killswitched_start.elapsed());
@@ -1343,8 +1356,7 @@ mod tests {
         // Create runtime config with demoted namespaces
         let config = create_config();
         let test_yaml = r#"
-drop_task_killswitch:
-  -
+drop_task_killswitch: []
 demoted_namespaces:
   - bad_namespace1
   - bad_namespace2"#;
@@ -1446,6 +1458,77 @@ demoted_namespaces:
                 .await
                 .unwrap(),
             3
+        );
+    }
+
+    #[tokio::test]
+    #[rstest]
+    #[case::sqlite("sqlite")]
+    #[case::postgres("postgres")]
+    async fn test_remove_killswitched_selectors(#[case] adapter: &str) {
+        use crate::store::activation::ActivationBuilder;
+        use crate::test_utils::{TaskActivationBuilder, generate_unique_namespace};
+
+        let config = create_config();
+        let test_yaml = r#"
+drop_task_killswitch:
+  - name: sentry.tasks.unmerge
+    select_kwarg: {project_id: 123}
+demoted_namespaces: []"#;
+
+        let mut config_file = NamedTempFile::new().unwrap();
+        writeln!(config_file, "{}", test_yaml).unwrap();
+        config_file.flush().unwrap();
+
+        let runtime_config = Arc::new(
+            RuntimeConfigManager::new(Some(config_file.path().to_str().unwrap().to_string())).await,
+        );
+        let producer = create_producer(config.clone());
+        let store = create_test_store(adapter).await;
+        let start_time = Utc::now();
+        let mut last_vacuum = Instant::now();
+
+        let msgpack = |yaml: &str| -> Vec<u8> {
+            let value: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+            rmp_serde::to_vec_named(&value).unwrap()
+        };
+        let namespace = generate_unique_namespace();
+        let make = |id: &str, params: Vec<u8>| {
+            ActivationBuilder::new()
+                .id(id)
+                .taskname("sentry.tasks.unmerge")
+                .namespace(&namespace)
+                .added_at(Utc::now())
+                .received_at(Utc::now())
+                .processing_deadline_duration(10)
+                .build(TaskActivationBuilder::new().parameters_bytes(params))
+        };
+
+        let batch = vec![
+            make("0", msgpack("{args: [], kwargs: {project_id: 123}}")), // dropped
+            make("1", msgpack("{args: [], kwargs: {project_id: 456}}")), // kept
+            make("2", msgpack("{args: [], kwargs: {project_id: 123}}")), // dropped
+        ];
+        assert!(store.store(&batch).await.is_ok());
+
+        let result_context = do_upkeep(
+            config,
+            store.clone(),
+            producer,
+            start_time,
+            runtime_config.clone(),
+            &mut last_vacuum,
+            &mut HashSet::new(),
+        )
+        .await;
+
+        assert_eq!(result_context.killswitched, 2);
+        assert_eq!(
+            store
+                .count_by_status(ActivationStatus::Pending)
+                .await
+                .unwrap(),
+            1
         );
     }
 


### PR DESCRIPTION
ref STREAM-1276

## Why
Today we can only killswitch a task by name — all-or-nothing. To drop traffic for a single project mid-incident we either nuke the whole task or wait on app devs to add a `sentry.killswitches` definition (came out of INC-2274).

## What
`drop_task_killswitch` entries can now match on a task's arguments:

```yaml
drop_task_killswitch:
  - sentry.tasks.unmerge            # drop the whole task (as before)
  - name: sentry.tasks.unmerge      # or drop only when args match
    select_arg:   {0: 123}          # 1st positional arg == 123, OR
    select_kwarg: {project_id: 123} # kwarg project_id == 123
```

A rule drops the task if **any** condition matches. Enforced at ingest and in the upkeep DB-cleanup path. Matching reads the msgpack `parameters_bytes` (zstd-aware) and **fails open** on any decode error, so a changed task signature can't drop unrelated traffic. [Run book](https://www.notion.so/1b48b10e4b5d80a3911bc0b019ba73b5) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)