### PR TITLE
fix(gocd): Use Only Active Deployments, Run Jobs in Parallel

### DIFF
--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -3,15 +3,17 @@
 eval "$(regions-project-env-vars --region="${SENTRY_REGION}")"
 /devinfra/scripts/get-cluster-credentials
 
-# We ignore StatefulSets as those NEVER run AlloyDB, and we only care about migrations for AlloyDB here
-deployments=$(kubectl get deployments -o name | awk -F/ '/task-.*-broker/ {print $2}')
+# Find all Deployments where the number of ready pods is greater than zero
+deployments=$(kubectl get deployments -A --no-headers | awk '$2 ~ /^task-.*-worker$/ && $5+0 > 0 {print $2}')
 
-for name in $deployments; do
-  LABEL_SELECTOR="app=$name"
+run_migrations() {
+  local name="$1"
+  local label_selector="app=$name"
+
   echo "Running migrations for $name..."
 
   if ! k8s-spawn-job \
-    --label-selector="${LABEL_SELECTOR}" \
+    --label-selector="${label_selector}" \
     --container-name="taskbroker" \
     --try-deployments-and-statefulsets \
     "${name}-migrations" \
@@ -19,11 +21,26 @@ for name in $deployments; do
     /opt/taskbroker \
     -- \
     --run migrations; then
-    echo "Migrations failed for $name, ignoring so the pipeline can continue"
-    continue
+    echo "Migrations failed for $name"
+    return 1
   fi
 
   echo "Done: $name"
+}
+
+pids=()
+
+for name in $deployments; do
+  run_migrations "$name" &
+  pids+=("$!")
 done
 
-exit 0
+status=0
+
+for pid in "${pids[@]}"; do
+  if ! wait "$pid"; then
+    status=1
+  fi
+done
+
+exit "$status"

--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -4,7 +4,7 @@ eval "$(regions-project-env-vars --region="${SENTRY_REGION}")"
 /devinfra/scripts/get-cluster-credentials
 
 # Find all Deployments where the number of ready pods is greater than zero
-deployments=$(kubectl get deployments -A --no-headers | awk '$2 ~ /^task-.*-worker$/ && $5+0 > 0 {print $2}')
+deployments=$(kubectl get deployments -A --no-headers | awk '$2 ~ /^task-.*-broker$/ && $5+0 > 0 {print $2}')
 
 run_migrations() {
   local name="$1"


### PR DESCRIPTION
## Linear
Refs [STREAM-1226](https://linear.app/getsentry/issue/STREAM-1226/fix-migration-step)

## Description
This PR does two things.

1. It prevents deployments with zero pods from being picked up as that makes `k8s-spawn-job` fail
2. It runs the migration jobs concurrently to speed things up, as migrations can take some time to run