### PR TITLE
feat(taskbroker-client): expose task enqueue producer future

### DIFF
--- a/clients/python/src/taskbroker_client/registry.py
+++ b/clients/python/src/taskbroker_client/registry.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 from collections.abc import Callable
 from concurrent import futures
-from typing import Any
+from typing import Any, cast
 
 import sentry_sdk
 from arroyo.backends.kafka import KafkaPayload
@@ -167,7 +167,9 @@ class TaskNamespace:
         else:
             self.metrics.incr("taskworker.registry.send_task.success", tags=tags)
 
-    def send_task(self, activation: TaskActivation, wait_for_delivery: bool = False) -> None:
+    def send_task(
+        self, activation: TaskActivation, wait_for_delivery: bool = False
+    ) -> ProducerFuture:
         topic = self.topic
 
         with sentry_sdk.start_span(
@@ -209,6 +211,8 @@ class TaskNamespace:
                 produce_future.result(timeout=10)
             except Exception:
                 logger.exception("Failed to wait for delivery")
+
+        return cast(ProducerFuture, produce_future)
 
     def _producer(self, topic: str) -> ProducerProtocol:
         if topic not in self._producers:

--- a/clients/python/src/taskbroker_client/task.py
+++ b/clients/python/src/taskbroker_client/task.py
@@ -27,7 +27,7 @@ from taskbroker_client.constants import (
 from taskbroker_client.retry import Retry
 
 if TYPE_CHECKING:
-    from taskbroker_client.registry import TaskNamespace
+    from taskbroker_client.registry import ProducerFuture, TaskNamespace
 
 
 ALWAYS_EAGER = False
@@ -150,6 +150,28 @@ class Task(Generic[P, R]):
         """
         self.apply_async(args=args, kwargs=kwargs)
 
+    def _create_activation_for_async_dispatch(
+        self,
+        args: Any | None = None,
+        kwargs: Any | None = None,
+        headers: MutableMapping[str, Any] | None = None,
+        expires: int | datetime.timedelta | None = None,
+        countdown: int | datetime.timedelta | None = None,
+    ) -> tuple[TaskActivation, Any, Any]:
+        if args is None:
+            args = []
+        if kwargs is None:
+            kwargs = {}
+
+        self._signal_send(task=self, args=args, kwargs=kwargs)
+
+        # Generate an activation even if we're in immediate mode to
+        # catch serialization errors in tests.
+        activation = self.create_activation(
+            args=args, kwargs=kwargs, headers=headers, expires=expires, countdown=countdown
+        )
+        return activation, args, kwargs
+
     def apply_async(
         self,
         args: Any | None = None,
@@ -165,16 +187,7 @@ class Task(Generic[P, R]):
         The provided parameters will be msgpack encoded and stored within
         a `TaskActivation` protobuf that is appended to kafka.
         """
-        if args is None:
-            args = []
-        if kwargs is None:
-            kwargs = {}
-
-        self._signal_send(task=self, args=args, kwargs=kwargs)
-
-        # Generate an activation even if we're in immediate mode to
-        # catch serialization errors in tests.
-        activation = self.create_activation(
+        activation, args, kwargs = self._create_activation_for_async_dispatch(
             args=args, kwargs=kwargs, headers=headers, expires=expires, countdown=countdown
         )
         if ALWAYS_EAGER:
@@ -184,6 +197,31 @@ class Task(Generic[P, R]):
                 activation,
                 wait_for_delivery=self.wait_for_delivery,
             )
+
+    def apply_async_with_future(
+        self,
+        args: Any | None = None,
+        kwargs: Any | None = None,
+        headers: MutableMapping[str, Any] | None = None,
+        expires: int | datetime.timedelta | None = None,
+        countdown: int | datetime.timedelta | None = None,
+        **options: Any,
+    ) -> ProducerFuture | None:
+        """
+        Schedule a task and return the producer future for callers that need to
+        wait on delivery alongside other Kafka produces.
+        """
+        activation, args, kwargs = self._create_activation_for_async_dispatch(
+            args=args, kwargs=kwargs, headers=headers, expires=expires, countdown=countdown
+        )
+        if ALWAYS_EAGER:
+            self._call_func(*args, **kwargs)
+            return None
+
+        return self._namespace.send_task(
+            activation,
+            wait_for_delivery=self.wait_for_delivery,
+        )
 
     def apply_async_testing(
         self,

--- a/clients/python/tests/test_registry.py
+++ b/clients/python/tests/test_registry.py
@@ -1,4 +1,5 @@
 from concurrent.futures import Future
+from typing import Any
 from unittest.mock import Mock
 
 import msgpack
@@ -141,7 +142,10 @@ def test_namespace_send_task_no_retry() -> None:
     mock_producer = Mock()
     namespace._producers["taskworker"] = mock_producer
 
-    namespace.send_task(activation)
+    ret_value: Future[Any] = Future()
+    mock_producer.produce.return_value = ret_value
+
+    assert namespace.send_task(activation) is ret_value
     assert mock_producer.produce.call_count == 1
 
     mock_call = mock_producer.produce.call_args

--- a/clients/python/tests/test_task.py
+++ b/clients/python/tests/test_task.py
@@ -1,6 +1,7 @@
 import contextlib
 import datetime
 from collections.abc import MutableMapping
+from concurrent.futures import Future
 from typing import Any
 from unittest.mock import patch
 
@@ -150,6 +151,26 @@ def test_delay_immediate_validate_activation(task_namespace: TaskNamespace) -> N
     assert len(calls) == 2
     assert calls[0] == {"mixed": None}
     assert calls[1] == {"mixed": "str"}
+
+
+def test_apply_async_with_future_returns_producer_future(task_namespace: TaskNamespace) -> None:
+    def test_func(*args: Any, **kwargs: Any) -> None:
+        pass
+
+    task = Task(
+        name="test.test_func",
+        func=test_func,
+        namespace=task_namespace,
+    )
+    producer_future: Future[Any] = Future()
+
+    with patch.object(task_namespace, "send_task", return_value=producer_future) as mock_send:
+        assert task.apply_async_with_future(args=["arg2"], kwargs={"org_id": 2}) is producer_future
+
+    assert mock_send.call_count == 1
+    activation = mock_send.call_args.args[0]
+    expected_params = {"args": ["arg2"], "kwargs": {"org_id": 2}}
+    assert msgpack.unpackb(activation.parameters_bytes, raw=False) == expected_params
 
 
 def test_should_retry(task_namespace: TaskNamespace) -> None:


### PR DESCRIPTION
Refs STREAM-1309

Modifies `TaskNamespace.send_task()` to return the existing producer future, and adds `Task.apply_async_with_future()` for dispatching a task and also returning that producer future.

This lets callers coordinate task enqueue delivery; in the case of the spans buffer enqueueing the process_segment task, it needs to know that the produce succeeded before calling `done_flush_segments`.