### PR TITLE
doc(taskbroker_client): better docstring for apply_async_with_future

### DIFF
--- a/clients/python/src/taskbroker_client/task.py
+++ b/clients/python/src/taskbroker_client/task.py
@@ -212,7 +212,9 @@ class Task(Generic[P, R]):
 
         This does not wait for delivery. Callers that need delivery confirmation
         must wait on the returned future themselves. Callers that do not need the
-        future should use apply_async().
+        future should use apply_async(). Ignoring the returned future does not
+        cancel or prevent the produce; the task activation has already been
+        handed to the producer.
         """
         activation, args, kwargs = self._create_activation_for_async_dispatch(
             args=args, kwargs=kwargs, headers=headers, expires=expires, countdown=countdown

--- a/clients/python/src/taskbroker_client/task.py
+++ b/clients/python/src/taskbroker_client/task.py
@@ -208,8 +208,11 @@ class Task(Generic[P, R]):
         **options: Any,
     ) -> ProducerFuture | None:
         """
-        Schedule a task and return the producer future for callers that need to
-        wait on delivery alongside other Kafka produces.
+        Schedule a task and return the producer future.
+
+        This does not wait for delivery. Callers that need delivery confirmation
+        must wait on the returned future themselves. Callers that do not need the
+        future should use apply_async().
         """
         activation, args, kwargs = self._create_activation_for_async_dispatch(
             args=args, kwargs=kwargs, headers=headers, expires=expires, countdown=countdown


### PR DESCRIPTION
Refs STREAM-1309

We should clarify that `apply_async_with_future` does not wait on delivery but only returns the future, and callers must wait on the future themselves if they need delivery confirmation. 

Also clarifies that if we ignore the future return value, the produce still happens in the background.