### PR TITLE
feat: Add a flag to disable consuming from a topic

### DIFF
--- a/integration_tests/integration_tests/test_multi_topic.py
+++ b/integration_tests/integration_tests/test_multi_topic.py
@@ -131,3 +131,125 @@ def test_multi_topic_consumption() -> None:
             except Exception:
                 process.kill()
                 raise
+
+
+def test_multi_topic_consumption_with_one_disabled() -> None:
+    """
+    Verify that a single taskbroker configured (new `kafka_topics` format) with
+    two consumable topics but one disabled consumes from just one of its topics.
+
+    Each consumed topic gets its own rdkafka consumer (own group.id); both
+    pipelines write to the shared store. We produce N messages to each of two
+    topics and assert the broker ends up with N tasks in sqlite.
+    """
+    num_messages_per_topic = 1_000
+    num_partitions = 4
+    timeout = 60
+    curr_time = int(time.time())
+
+    topic_a = f"multitopic-a-{curr_time}"
+    topic_b = f"multitopic-b-{curr_time}"
+    retry_topic = f"multitopic-retry-{curr_time}"
+    dlq_topic = f"multitopic-dlq-{curr_time}"
+
+    # Pre-create the topics so the test exercises consumption, not topic
+    # creation. (create_missing_topics stays off.)
+    for topic in (topic_a, topic_b, retry_topic, dlq_topic):
+        create_topic(topic, num_partitions)
+
+    TEST_OUTPUT_PATH.mkdir(parents=True, exist_ok=True)
+    db_name = f"db_multi_topic_{curr_time}"
+    db_path = str(TEST_OUTPUT_PATH / f"{db_name}.sqlite")
+    config_filename = f"config_multi_topic_{curr_time}.yml"
+    grpc_port = get_available_ports(1)[0]
+
+    # New multi-topic config: two consumable topics + produce-only retry/dlq,
+    # all on a single cluster.
+    config_dict = {
+        "db_name": db_name,
+        "db_path": db_path,
+        "max_pending_count": 100_000,
+        "grpc_port": grpc_port,
+        "kafka_auto_offset_reset": "earliest",
+        "kafka_deadletter_topic": dlq_topic,
+        "kafka_retry_topic": retry_topic,
+        "kafka_clusters": {
+            "default": {"address": "127.0.0.1:9092"},
+        },
+        "kafka_topics": {
+            topic_a: {"cluster": "default", "consumer_group": f"{topic_a}-grp"},
+            topic_b: {
+                "cluster": "default",
+                "consumer_group": f"{topic_b}-grp",
+                "consumer_disabled": True,
+            },
+            retry_topic: {
+                "cluster": "default",
+                "consumer_group": f"{retry_topic}-grp",
+                "produce_only": True,
+            },
+            dlq_topic: {
+                "cluster": "default",
+                "consumer_group": f"{dlq_topic}-grp",
+                "produce_only": True,
+            },
+        },
+    }
+
+    config_path = str(TEST_OUTPUT_PATH / config_filename)
+    with open(config_path, "w") as f:
+        yaml.safe_dump(config_dict, f)
+
+    # A TaskbrokerConfig instance is only needed for the sqlite-counting helper,
+    # which reads db_name/db_path.
+    query_config = TaskbrokerConfig(
+        db_name=db_name,
+        db_path=db_path,
+        max_pending_count=100_000,
+        kafka_topic=topic_a,
+        kafka_deadletter_topic=dlq_topic,
+        kafka_consumer_group=f"{topic_a}-grp",
+        kafka_auto_offset_reset="earliest",
+        grpc_port=grpc_port,
+    )
+
+    log_path = str(TEST_OUTPUT_PATH / f"taskbroker_multi_topic_{curr_time}.log")
+    expected_total = num_messages_per_topic
+
+    send_generic_messages_to_topic(topic_a, num_messages_per_topic)
+    send_generic_messages_to_topic(topic_b, num_messages_per_topic)
+
+    process = None
+    try:
+        with open(log_path, "a") as log_file:
+            process = subprocess.Popen(
+                [str(TASKBROKER_BIN), "-c", config_path],
+                stderr=subprocess.STDOUT,
+                stdout=log_file,
+            )
+        time.sleep(3)  # give the broker time to start both consumers
+
+        written = 0
+        end = time.time() + timeout
+        while time.time() < end:
+            written = get_num_tasks_in_sqlite(query_config)
+            if written >= expected_total:
+                # Wait to ensure no unexpected messages are processed
+                time.sleep(3)
+                break
+            # the broker should still be alive while consuming
+            assert process.poll() is None, "taskbroker exited early"
+            time.sleep(1)
+
+        assert written == expected_total, (
+            f"expected {expected_total} tasks in sqlite "
+            f"({num_messages_per_topic} from one topic), got {written}"
+        )
+    finally:
+        if process is not None:
+            process.send_signal(signal.SIGINT)
+            try:
+                assert process.wait(timeout=10) == 0
+            except Exception:
+                process.kill()
+                raise

--- a/src/config/kafka.rs
+++ b/src/config/kafka.rs
@@ -14,6 +14,10 @@ pub struct TopicConfig {
     /// Defaults to false, meaning the topic is consumed.
     #[serde(default)]
     pub produce_only: bool,
+    /// If true, this topic is disabled for consumption.
+    /// Defaults to false, meaning the topic is consumed.
+    #[serde(default)]
+    pub consumer_disabled: bool,
     /// Raw mode settings. If set, this topic uses raw mode.
     #[serde(default)]
     pub raw: Option<RawModeConfig>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -564,6 +564,7 @@ impl Config {
                     cluster: DEFAULT_CLUSTER.to_owned(),
                     consumer_group: consumer_group.clone(),
                     produce_only: false,
+                    consumer_disabled: false,
                     raw: raw_config,
                     session_timeout_ms: None,
                     auto_commit_interval_ms: None,
@@ -581,6 +582,7 @@ impl Config {
                     cluster: DEADLETTER_CLUSTER.to_owned(),
                     consumer_group: consumer_group.clone(),
                     produce_only: true,
+                    consumer_disabled: false,
                     raw: None,
                     session_timeout_ms: None,
                     auto_commit_interval_ms: None,
@@ -612,6 +614,7 @@ impl Config {
                         cluster: DEADLETTER_CLUSTER.to_owned(),
                         consumer_group,
                         produce_only: true,
+                        consumer_disabled: false,
                         raw: None,
                         session_timeout_ms: None,
                         auto_commit_interval_ms: None,
@@ -1407,6 +1410,7 @@ kafka_topics:
       application: profiles
       taskname: profiles.process
       processing_deadline_duration: 30
+    consumer_disabled: true
   profiles-retry:
     cluster: profiles-cluster
     consumer_group: taskbroker-profiles-retry
@@ -1435,6 +1439,7 @@ kafka_clusters:
             assert_eq!(profiles.cluster, "profiles-cluster");
             assert_eq!(profiles.consumer_group, "taskbroker-profiles");
             assert!(!profiles.produce_only);
+            assert!(profiles.consumer_disabled);
             assert_eq!(
                 profiles.raw,
                 Some(RawModeConfig {

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -57,7 +57,7 @@ pub async fn start_no_consume_mode(
                 metadata = Some(md);
                 break;
             }
-            Err(KafkaError::MessageConsumption(RDKafkaErrorCode::BrokerTransportFailure)) => {
+            Err(KafkaError::MetadataFetch(RDKafkaErrorCode::BrokerTransportFailure)) => {
                 error!("Failed to connect to broker, retrying...");
                 retries += 1;
                 continue;

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -11,6 +11,7 @@ use rdkafka::consumer::stream_consumer::StreamPartitionQueue;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext, Rebalance, StreamConsumer};
 use rdkafka::error::{KafkaError, KafkaResult};
 use rdkafka::message::{BorrowedMessage, OwnedMessage};
+use rdkafka::metadata::Metadata;
 use rdkafka::types::RDKafkaErrorCode;
 use rdkafka::{ClientConfig, ClientContext, Message, Offset, TopicPartitionList};
 
@@ -30,6 +31,62 @@ use tracing::{debug, error, info, instrument, warn};
 
 use crate::store::traits::ActivationStore;
 use crate::store::types::TopicPartition;
+
+pub async fn start_no_consume_mode(
+    topics: &[&str],
+    kafka_client_config: &ClientConfig,
+) -> Result<(), Error> {
+    let topics_tag = topics.join(",");
+    let (event_sender, _) = unbounded_channel();
+    let context = KafkaContext::new(event_sender.clone(), topics_tag.clone());
+    let consumer: Arc<StreamConsumer<KafkaContext>> = Arc::new(
+        kafka_client_config
+            .create_with_context(context)
+            .expect("Consumer creation failed"),
+    );
+
+    // Validates: broker reachability, SASL/SSL auth handshake,
+    // topic existence, and partition count — no group join.
+    // Retry on transient errors like broker transport failure.
+    let topic = topics[0];
+    let mut retries = 0;
+    let mut metadata = None;
+    while retries < 3 {
+        match consumer.fetch_metadata(Some(topic), Duration::from_secs(10)) {
+            Ok(md) => {
+                metadata = Some(md);
+                break;
+            }
+            Err(KafkaError::MessageConsumption(RDKafkaErrorCode::BrokerTransportFailure)) => {
+                error!("Failed to connect to broker, retrying...");
+                retries += 1;
+                continue;
+            }
+            Err(e) => {
+                return Err(anyhow!("failed to fetch metadata: {e:?}"));
+            }
+        };
+    }
+
+    if metadata.is_none() {
+        return Err(anyhow!("failed to fetch metadata after 3 retries"));
+    }
+
+    let md = metadata.unwrap();
+    let topic_md = md
+        .topics()
+        .iter()
+        .find(|t| t.name() == topic)
+        .ok_or_else(|| anyhow!("topic {topic} not found"))?;
+
+    if let Some(err) = topic_md.error() {
+        return Err(anyhow!("topic {topic} error: {err:?}"));
+    }
+    info!("Topic {topic} configuration validated");
+    let guard = elegant_departure::get_shutdown_guard();
+    guard.wait().await;
+    Ok(())
+}
 
 pub async fn start_consumer(
     topics: &[&str],

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -11,7 +11,6 @@ use rdkafka::consumer::stream_consumer::StreamPartitionQueue;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext, Rebalance, StreamConsumer};
 use rdkafka::error::{KafkaError, KafkaResult};
 use rdkafka::message::{BorrowedMessage, OwnedMessage};
-use rdkafka::metadata::Metadata;
 use rdkafka::types::RDKafkaErrorCode;
 use rdkafka::{ClientConfig, ClientContext, Message, Offset, TopicPartitionList};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use taskbroker::grpc::server::{TaskbrokerServer, flush_updates};
 use taskbroker::kafka::activation_batcher::{ActivationBatcher, ActivationBatcherConfig};
 use taskbroker::kafka::activation_writer::{ActivationWriter, ActivationWriterConfig};
 use taskbroker::kafka::admin::create_missing_topics;
-use taskbroker::kafka::consumer::start_consumer;
+use taskbroker::kafka::consumer::{start_consumer, start_no_consume_mode};
 use taskbroker::kafka::deserialize::{self, DeserializeConfig};
 use taskbroker::kafka::os_stream_writer::{OsStream, OsStreamWriter};
 use taskbroker::metrics;
@@ -162,19 +162,31 @@ async fn main() -> Result<(), Error> {
     // Consumer(s) from kafka. Each consumed topic gets its own consumer (own
     // group.id and cluster), so we spawn one consumer task per consumable topic,
     // all sharing the one activation store.
-    let consumer_topics: Vec<String> = config
+    let consumer_topics: Vec<(String, bool)> = config
         .consumable_topics()
         .expect("invalid config: no consumable topic")
         .into_iter()
-        .map(|(name, _)| name.to_owned())
+        .map(|(name, cfg)| (name.to_owned(), cfg.consumer_disabled))
         .collect();
 
     let mut consumer_tasks: Vec<(String, JoinHandle<Result<(), Error>>)> = Vec::new();
-    for topic in consumer_topics {
+    for (topic, consumer_disabled) in consumer_topics {
         let consumer_store = store.clone();
         let consumer_config = config.clone();
         let runtime_config_manager = runtime_config_manager.clone();
         let task_topic = topic.clone();
+
+        if consumer_disabled {
+            let handle = taskbroker::tokio::spawn(async move {
+                start_no_consume_mode(
+                    &[task_topic.as_str()],
+                    &consumer_config.kafka_consumer_config_for(&task_topic),
+                )
+                .await
+            });
+            consumer_tasks.push((topic, handle));
+            continue;
+        }
 
         let handle = taskbroker::tokio::spawn(async move {
             // The consumer has an internal thread that listens for cancellations, so it doesn't need


### PR DESCRIPTION
When creating new pools, it is beneficial to have the pool be created but not actually consume from the topic(s) it is configured to handle. This allows initial testing and also ensuring the pool is fully warmed up. To that end, provide a flag that will validate that the kafka settings are correct, but won't subscribe to the topic and consume messages.