### PR TITLE
test(integration): Add postgres-backed push mode integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,3 +528,41 @@ jobs:
       - name: Run multi-topic integration test
         run: |
           make test-multi-topic
+
+  push-postgres-integration-test:
+    name: Push mode postgres integration test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+
+      - name: Install cmake
+        uses: lukka/get-cmake@28983e0d3955dba2bb0a6810caae0c6cf268ec0c # latest
+
+      - name: Install libcurl
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+        with:
+          key: ${{ github.job }}
+
+      - uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
+        with:
+          version: '0.8.2'
+          # we just cache the venv-dir directly in action-setup-venv
+          enable-cache: false
+
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
+        with:
+          cache-dependency-path: uv.lock
+          install-cmd: uv sync --frozen --only-dev --active
+
+      - name: Run push mode postgres integration test
+        run: |
+          make test-push-postgres

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,11 @@ test-failed-tasks: build reset-kafka ## Run the failed tasks integration test
 	rm -r integration_tests/.tests_output/test_failed_tasks
 .PHONY: test-failed-tasks
 
+test-push-postgres: build reset-kafka ## Run the postgres-backed push mode integration test
+	python -m pytest integration_tests/integration_tests/test_push_postgres.py -s
+	rm -r integration_tests/.tests_output/test_push_postgres
+.PHONY: test-push-postgres
+
 integration-test: test-rebalance test-worker-processing test-upkeep-retry test-upkeep-expiry test-upkeep-delay test-failed-tasks ## Run all integration tests
 .PHONY: integration-test
 

--- a/integration_tests/integration_tests/helpers.py
+++ b/integration_tests/integration_tests/helpers.py
@@ -2,11 +2,13 @@ import socket
 import sqlite3
 import subprocess
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
 import orjson
+import psycopg2
 from confluent_kafka import Consumer, KafkaException, Producer
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
@@ -212,6 +214,132 @@ def get_num_tasks_group_by_status(
     for task_count in rows:
         task_count_in_sqlite[task_count[0]] = task_count[1]
     return task_count_in_sqlite
+
+
+@dataclass
+class PostgresConfig:
+    """
+    Connection details for the postgres-backed activation store.
+
+    Defaults mirror the devservices shared-postgres container (reachable on the
+    host at 127.0.0.1:5432, postgres/password) and the Rust test conventions in
+    `src/test_utils.rs`. Each test should use a unique `database_name` so runs
+    don't collide; the taskbroker creates and migrates it on startup when
+    `run_migrations` is set in the store config.
+    """
+
+    database_name: str
+    host: str = "127.0.0.1"
+    port: int = 5432
+    username: str = "postgres"
+    password: str = "password"
+    default_database_name: str = "postgres"
+
+    def store_config(self) -> dict[str, Any]:
+        """
+        Build the `store` config block that selects the postgres adapter and
+        points it at this database (dumped into the taskbroker's yaml config).
+        """
+        return {
+            "adapter": "postgres",
+            "pg": {
+                "run_migrations": True,
+                "host": self.host,
+                "port": self.port,
+                "username": self.username,
+                "password": self.password,
+                "ddl_username": self.username,
+                "ddl_password": self.password,
+                "database_name": self.database_name,
+                "default_database_name": self.default_database_name,
+            },
+        }
+
+
+def unique_pg_database_name(prefix: str) -> str:
+    """A unique, valid postgres database identifier (ASCII alnum + underscore)."""
+    return f"{prefix}_{uuid4().hex}"
+
+
+def _pg_connect(pg: PostgresConfig, database: str) -> Any:
+    conn = psycopg2.connect(
+        host=pg.host,
+        port=pg.port,
+        user=pg.username,
+        password=pg.password,
+        dbname=database,
+    )
+    conn.autocommit = True
+    return conn
+
+
+def _pg_fetchall(pg: PostgresConfig, query: str, params: tuple[Any, ...] = ()) -> list[Any]:
+    """Run a read query against the test database and close the connection.
+
+    These helpers are polled frequently, so each opens and closes its own
+    connection to avoid leaking connections against postgres' connection cap.
+    """
+    conn = _pg_connect(pg, pg.database_name)
+    try:
+        cur = conn.cursor()
+        cur.execute(query, params)
+        rows = cur.fetchall()
+        cur.close()
+        return rows
+    finally:
+        conn.close()
+
+
+def get_num_tasks_in_postgres(pg: PostgresConfig) -> int:
+    rows = _pg_fetchall(pg, "SELECT count(*) FROM inflight_taskactivations;")
+    return int(rows[0][0])
+
+
+def get_num_tasks_in_postgres_by_status(pg: PostgresConfig, status: str) -> int:
+    """
+    Count activations with a given status. Note: the postgres store persists
+    the capitalized enum name (e.g. 'Pending', 'Claimed', 'Processing',
+    'Complete'), unlike the lowercase values used by the sqlite adapter.
+    """
+    rows = _pg_fetchall(
+        pg,
+        "SELECT count(*) FROM inflight_taskactivations WHERE status = %s;",
+        (status,),
+    )
+    return int(rows[0][0])
+
+
+def get_num_tasks_in_postgres_group_by_status(pg: PostgresConfig) -> dict[str, int]:
+    rows = _pg_fetchall(
+        pg, "SELECT status, count(id) FROM inflight_taskactivations GROUP BY status;"
+    )
+    return {row[0]: int(row[1]) for row in rows}
+
+
+def drop_postgres_db(pg: PostgresConfig) -> None:
+    """
+    Drop the test database. Connects to the default database, terminates any
+    lingering connections (the broker may not have fully torn down its pools),
+    then drops. Best-effort: swallows errors so cleanup never fails a test.
+    """
+    # Note: don't use `with conn:` here. psycopg2's connection context manager
+    # wraps the block in a transaction, and DROP DATABASE cannot run inside one.
+    conn = None
+    try:
+        conn = _pg_connect(pg, pg.default_database_name)  # autocommit=True
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            "WHERE datname = %s AND pid <> pg_backend_pid();",
+            (pg.database_name,),
+        )
+        cur.execute(f'DROP DATABASE IF EXISTS "{pg.database_name}";')
+        cur.close()
+    except Exception as e:
+        print(f"Failed to drop postgres db {pg.database_name}: {e}")
+    finally:
+        if conn is not None:
+            conn.close()
 
 
 def get_available_ports(count: int) -> list[int]:

--- a/integration_tests/integration_tests/push_worker.py
+++ b/integration_tests/integration_tests/push_worker.py
@@ -1,0 +1,83 @@
+"""
+Minimal mock worker for push-mode integration tests.
+
+In push mode the taskbroker is the gRPC *client*: it claims activations from the
+store and pushes each one to a worker's `WorkerService.PushTask` endpoint (see
+`src/worker.rs`, `src/push/`). This module provides a lightweight gRPC *server*
+implementing that endpoint so tests can observe what the broker pushes.
+
+This is deliberately minimal (records pushed task ids, optionally fails) rather
+than reusing the production `PushTaskWorker` in `clients/python`, which spawns
+child processes and needs an app module — mirroring how `worker.py`'s
+`ConfigurableTaskWorker` is a lightweight mock of the pull-mode worker.
+"""
+
+import threading
+import time
+from concurrent import futures
+
+import grpc
+from sentry_protos.taskbroker.v1 import taskbroker_pb2_grpc
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import PushTaskRequest, PushTaskResponse
+
+
+class MockWorkerServicer(taskbroker_pb2_grpc.WorkerServiceServicer):
+    """
+    Records every activation id pushed by the broker. When `fail` is set, every
+    push is rejected so the broker exercises its revert-claimed-to-pending path.
+    """
+
+    def __init__(self, fail: bool = False, hang: float = 0.0) -> None:
+        self.fail = fail
+        # Seconds to block inside PushTask before responding. When larger than
+        # the broker's push.timeout, the push RPC times out on the broker side;
+        # this keeps the push pipeline saturated so claimed tasks pile up and
+        # are reverted by the upkeep claim-expiration path rather than the push
+        # thread.
+        self.hang = hang
+        self._lock = threading.Lock()
+        # All pushed ids in order (includes duplicates so tests can detect them).
+        self.pushed: list[str] = []
+
+    def PushTask(
+        self,
+        request: PushTaskRequest,
+        context: grpc.ServicerContext,
+    ) -> PushTaskResponse:
+        with self._lock:
+            self.pushed.append(request.task.id)
+
+        if self.hang:
+            time.sleep(self.hang)
+
+        if self.fail:
+            context.abort(grpc.StatusCode.UNAVAILABLE, "mock worker rejecting push")
+
+        return PushTaskResponse()
+
+    def pushed_ids(self) -> list[str]:
+        with self._lock:
+            return list(self.pushed)
+
+    def unique_pushed_ids(self) -> set[str]:
+        with self._lock:
+            return set(self.pushed)
+
+
+def start_mock_worker(
+    port: int, fail: bool = False, hang: float = 0.0
+) -> tuple[grpc.Server, MockWorkerServicer]:
+    """
+    Start a `WorkerService` gRPC server on `port` bound to localhost.
+
+    Returns the running server and its servicer; the caller is responsible for
+    `server.stop(grace)` when the test finishes. Bootstrap mirrors
+    `clients/python/src/taskbroker_client/worker/worker.py`.
+    """
+    servicer = MockWorkerServicer(fail=fail, hang=hang)
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=8))
+    taskbroker_pb2_grpc.add_WorkerServiceServicer_to_server(servicer, server)
+    server.add_insecure_port(f"127.0.0.1:{port}")
+    server.start()
+    print(f"[mock_worker] Listening on 127.0.0.1:{port} (fail={fail})")
+    return server, servicer

--- a/integration_tests/integration_tests/test_push_postgres.py
+++ b/integration_tests/integration_tests/test_push_postgres.py
@@ -291,11 +291,16 @@ def test_push_postgres_failure_reverts_to_pending() -> None:
             ), f"no task should be lost: {counts}"
             time.sleep(0.5)
 
-        # Failed pushes revert claimed tasks back to pending, so at steady state
-        # nearly everything is pending (only the small in-flight set is claimed).
-        # push.threads(4) + queue.size(8) bounds the concurrently-claimed set.
+        # Failed pushes revert claimed tasks back to pending, so pending recovers.
+        # The pipeline never fully drains (fetch keeps claiming while pushes fail),
+        # so pending won't return to num_messages; assert it recovers to within the
+        # concurrently-claimed set instead. That set is bounded by a fetch batch
+        # (batch_length) plus what the push pool holds in flight (queue.size +
+        # threads), with headroom for a fresh batch overlapping the previous one.
+        max_in_flight = 32 + 8 + 4  # fetch.batch_length + push.queue.size + push.threads
         assert wait_until(
-            lambda: get_num_tasks_in_postgres_by_status(pg, "Pending") >= num_messages - 12,
+            lambda: get_num_tasks_in_postgres_by_status(pg, "Pending")
+            >= num_messages - max_in_flight,
             timeout=30,
         ), (
             "expected claimed tasks to revert back to pending, got "

--- a/integration_tests/integration_tests/test_push_postgres.py
+++ b/integration_tests/integration_tests/test_push_postgres.py
@@ -1,0 +1,397 @@
+"""
+Integration tests for postgres-backed *push* mode.
+
+Unlike every other integration test (which runs pull mode against SQLite), these
+launch a real taskbroker in push mode (`delivery_mode: push`) backed by the
+devservices postgres. In push mode the broker claims activations from postgres
+and pushes each to a worker's `WorkerService.PushTask` endpoint, so each test
+stands up a mock worker gRPC server (see push_worker.py) and points the broker's
+worker_map at it.
+
+Covered behaviors:
+- happy-path delivery: every task is pushed exactly once and marked processing;
+- push-failure revert: a rejecting worker causes claimed tasks to revert to pending;
+- claim-expiration / upkeep: a saturating worker leaves claimed tasks that upkeep
+  returns to pending.
+
+Requires devservices postgres up (127.0.0.1:5432, postgres/password) and kafka
+up (127.0.0.1:9092), which `make test-push-postgres` provisions.
+"""
+
+import re
+import signal
+import subprocess
+import time
+from typing import Any, Callable
+from uuid import uuid4
+
+import orjson
+import yaml
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
+    OnAttemptsExceeded,
+    RetryState,
+    TaskActivation,
+)
+
+from integration_tests.helpers import (
+    TASKBROKER_BIN,
+    TESTS_OUTPUT_ROOT,
+    PostgresConfig,
+    create_topic,
+    drop_postgres_db,
+    get_available_ports,
+    get_num_tasks_in_postgres,
+    get_num_tasks_in_postgres_by_status,
+    get_num_tasks_in_postgres_group_by_status,
+    send_custom_messages_to_topic,
+    unique_pg_database_name,
+)
+from integration_tests.push_worker import start_mock_worker
+
+# The application the broker routes on (activation.application) must match a
+# worker_map key. Generic helpers don't set application, so we build our own.
+APPLICATION = "sentry"
+
+
+def make_activations(num: int) -> list[TaskActivation]:
+    """Build `num` activations tagged with APPLICATION so the broker can route them."""
+    activations = []
+    for i in range(num):
+        activations.append(
+            TaskActivation(
+                id=uuid4().hex,
+                namespace="integration_tests",
+                taskname=f"integration_tests.say_hello_{i}",
+                parameters=orjson.dumps({"args": ["foobar"], "kwargs": {}}).decode("utf-8"),
+                retry_state=RetryState(
+                    attempts=0,
+                    max_attempts=1,
+                    on_attempts_exceeded=OnAttemptsExceeded.ON_ATTEMPTS_EXCEEDED_DISCARD,
+                ),
+                # seconds; large so the processing deadline never elapses mid-test
+                processing_deadline_duration=3000,
+                received_at=Timestamp(seconds=int(time.time())),
+                application=APPLICATION,
+            )
+        )
+    return activations
+
+
+def build_push_config(
+    *,
+    topic: str,
+    dlq_topic: str,
+    grpc_port: int,
+    worker_port: int,
+    pg: PostgresConfig,
+    fetch: dict[str, Any],
+    push: dict[str, Any],
+    log_filter: str = "info,librdkafka=warn,h2=off",
+) -> dict[str, Any]:
+    """Assemble the nested taskbroker yaml config for postgres-backed push mode."""
+    return {
+        "delivery_mode": "push",
+        "grpc_port": grpc_port,  # ConsumerService still starts but is unused in push mode
+        "log_filter": log_filter,
+        "kafka_auto_offset_reset": "earliest",
+        # kafka_deadletter_topic must be declared in kafka_topics under the new
+        # (kafka_clusters/kafka_topics) config format.
+        "kafka_deadletter_topic": dlq_topic,
+        "kafka_clusters": {"default": {"address": "127.0.0.1:9092"}},
+        "kafka_topics": {
+            topic: {"cluster": "default", "consumer_group": f"{topic}-grp"},
+            dlq_topic: {
+                "cluster": "default",
+                "consumer_group": f"{dlq_topic}-grp",
+                "produce_only": True,
+            },
+        },
+        "worker_map": {APPLICATION: f"http://127.0.0.1:{worker_port}"},
+        "fetch": fetch,
+        "push": push,
+        "store": pg.store_config(),
+    }
+
+
+def start_broker(config_path: str, log_path: str) -> "subprocess.Popen[bytes]":
+    log_file = open(log_path, "a")
+    process = subprocess.Popen(
+        [str(TASKBROKER_BIN), "-c", config_path],
+        stderr=subprocess.STDOUT,
+        stdout=log_file,
+    )
+    time.sleep(3)  # give the broker time to connect to the worker and start consuming
+    return process
+
+
+def stop_broker(process: "subprocess.Popen[bytes]") -> None:
+    process.send_signal(signal.SIGINT)
+    try:
+        assert process.wait(timeout=10) == 0
+    except Exception:
+        process.kill()
+        raise
+
+
+def wait_until(predicate: Callable[[], bool], timeout: float, interval: float = 0.5) -> bool:
+    """Poll `predicate` until it returns truthy or `timeout` seconds elapse."""
+    end = time.time() + timeout
+    while time.time() < end:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+def _setup_paths(name: str) -> tuple[str, str, int]:
+    out = TESTS_OUTPUT_ROOT / "test_push_postgres"
+    out.mkdir(parents=True, exist_ok=True)
+    curr = int(time.time())
+    config_path = str(out / f"config_{name}_{curr}.yml")
+    log_path = str(out / f"broker_{name}_{curr}.log")
+    return config_path, log_path, curr
+
+
+def test_push_postgres_happy_path() -> None:
+    """
+    Produce N tasks; a healthy mock worker accepts every push. Assert the broker
+    pushes each task exactly once (no duplicates) and marks them all processing
+    in postgres.
+    """
+    num_messages = 500
+    grpc_port, worker_port = get_available_ports(2)
+    config_path, log_path, curr = _setup_paths("happy")
+    topic = f"push-pg-happy-{curr}"
+    dlq_topic = f"push-pg-happy-dlq-{curr}"
+    pg = PostgresConfig(database_name=unique_pg_database_name("push_pg_happy"))
+
+    create_topic(topic, 1)
+    create_topic(dlq_topic, 1)
+
+    config = build_push_config(
+        topic=topic,
+        dlq_topic=dlq_topic,
+        grpc_port=grpc_port,
+        worker_port=worker_port,
+        pg=pg,
+        fetch={"threads": 1, "batch_length": 64, "backoff": "100ms"},
+        push={
+            "threads": 4,
+            "timeout": "30000ms",
+            "queue": {"size": 16, "timeout": "5000ms"},
+            "update": {"batched": False},
+        },
+    )
+    with open(config_path, "w") as f:
+        yaml.safe_dump(config, f)
+
+    activations = make_activations(num_messages)
+    produced_ids = {a.id for a in activations}
+    send_custom_messages_to_topic(topic, activations)
+
+    server, servicer = start_mock_worker(worker_port, fail=False)
+    process = None
+    try:
+        process = start_broker(config_path, log_path)
+
+        # All tasks should be pushed to the worker.
+        pushed_all = wait_until(
+            lambda: len(servicer.unique_pushed_ids()) >= num_messages, timeout=60
+        )
+        assert (
+            pushed_all
+        ), f"expected {num_messages} unique pushes, got {len(servicer.unique_pushed_ids())}"
+
+        # And each should be marked processing in postgres.
+        marked_processing = wait_until(
+            lambda: get_num_tasks_in_postgres_by_status(pg, "Processing") == num_messages,
+            timeout=30,
+        )
+        counts = get_num_tasks_in_postgres_group_by_status(pg)
+        assert marked_processing, f"expected {num_messages} processing, got {counts}"
+
+        # Exactly-once push: no task should have been pushed more than once.
+        assert servicer.unique_pushed_ids() == produced_ids
+        assert len(servicer.pushed_ids()) == num_messages, (
+            f"expected no duplicate pushes, got {len(servicer.pushed_ids())} for "
+            f"{num_messages} tasks"
+        )
+        assert get_num_tasks_in_postgres(pg) == num_messages
+    finally:
+        if process is not None:
+            stop_broker(process)
+        server.stop(0)
+        drop_postgres_db(pg)
+
+
+def test_push_postgres_failure_reverts_to_pending() -> None:
+    """
+    A worker that rejects every push. Assert the broker never marks anything
+    processing, loses no tasks, and reverts claimed tasks back to pending (the
+    push-thread revert path in src/push/thread.rs).
+    """
+    num_messages = 200
+    grpc_port, worker_port = get_available_ports(2)
+    config_path, log_path, curr = _setup_paths("failure")
+    topic = f"push-pg-failure-{curr}"
+    dlq_topic = f"push-pg-failure-dlq-{curr}"
+    pg = PostgresConfig(database_name=unique_pg_database_name("push_pg_failure"))
+
+    create_topic(topic, 1)
+    create_topic(dlq_topic, 1)
+
+    config = build_push_config(
+        topic=topic,
+        dlq_topic=dlq_topic,
+        grpc_port=grpc_port,
+        worker_port=worker_port,
+        pg=pg,
+        fetch={"threads": 1, "batch_length": 32, "backoff": "100ms"},
+        push={
+            "threads": 4,
+            "timeout": "5000ms",
+            "queue": {"size": 8, "timeout": "1000ms"},
+            "update": {"batched": False},
+        },
+    )
+    with open(config_path, "w") as f:
+        yaml.safe_dump(config, f)
+
+    activations = make_activations(num_messages)
+    send_custom_messages_to_topic(topic, activations)
+
+    server, servicer = start_mock_worker(worker_port, fail=True)
+    process = None
+    try:
+        process = start_broker(config_path, log_path)
+
+        # Wait for all tasks to land in postgres.
+        assert wait_until(
+            lambda: get_num_tasks_in_postgres(pg) == num_messages, timeout=60
+        ), f"expected {num_messages} tasks written, got {get_num_tasks_in_postgres(pg)}"
+
+        # The broker should actively push tasks to the (failing) worker. Because
+        # failed pushes revert to pending and get re-claimed, the same tasks are
+        # retried, so we assert the push path is exercised rather than requiring
+        # full unique coverage.
+        assert wait_until(
+            lambda: len(servicer.pushed_ids()) >= 20, timeout=60
+        ), f"expected the broker to attempt pushes, got {len(servicer.pushed_ids())}"
+
+        # Because every push fails, nothing is ever marked processing/complete and
+        # no task is lost. Sample the state over a short window to catch transient
+        # leaks.
+        for _ in range(10):
+            counts = get_num_tasks_in_postgres_group_by_status(pg)
+            assert counts.get("Processing", 0) == 0, f"nothing should be processing: {counts}"
+            assert counts.get("Complete", 0) == 0, f"nothing should complete: {counts}"
+            assert (
+                get_num_tasks_in_postgres(pg) == num_messages
+            ), f"no task should be lost: {counts}"
+            time.sleep(0.5)
+
+        # Failed pushes revert claimed tasks back to pending, so at steady state
+        # nearly everything is pending (only the small in-flight set is claimed).
+        # push.threads(4) + queue.size(8) bounds the concurrently-claimed set.
+        assert wait_until(
+            lambda: get_num_tasks_in_postgres_by_status(pg, "Pending") >= num_messages - 12,
+            timeout=30,
+        ), (
+            "expected claimed tasks to revert back to pending, got "
+            f"{get_num_tasks_in_postgres_group_by_status(pg)}"
+        )
+    finally:
+        if process is not None:
+            stop_broker(process)
+        server.stop(0)
+        drop_postgres_db(pg)
+
+
+def test_push_postgres_upkeep_reverts_expired_claims() -> None:
+    """
+    A worker that hangs on every push (longer than push.timeout). The push queue
+    stays saturated, so most claimed tasks are dropped from the pipeline and left
+    in 'Claimed'. Upkeep's claim-expiration path must return them to 'Pending'.
+
+    We assert the observable contract (nothing processing, no loss, pending
+    recovers) and confirm upkeep is the mechanism via its debug log signal.
+    """
+    num_messages = 200
+    grpc_port, worker_port = get_available_ports(2)
+    config_path, log_path, curr = _setup_paths("upkeep")
+    topic = f"push-pg-upkeep-{curr}"
+    dlq_topic = f"push-pg-upkeep-dlq-{curr}"
+    pg = PostgresConfig(database_name=unique_pg_database_name("push_pg_upkeep"))
+
+    create_topic(topic, 1)
+    create_topic(dlq_topic, 1)
+
+    # Small queue + single push thread + short push.timeout keeps the claim lease
+    # short (compute_claim_duration_ms), while the hanging worker keeps the queue
+    # full so fetch drops claimed tasks that only upkeep can revert.
+    config = build_push_config(
+        topic=topic,
+        dlq_topic=dlq_topic,
+        grpc_port=grpc_port,
+        worker_port=worker_port,
+        pg=pg,
+        fetch={"threads": 1, "batch_length": 10, "backoff": "100ms"},
+        push={
+            "threads": 1,
+            "timeout": "1000ms",
+            "queue": {"size": 1, "timeout": "200ms"},
+            "update": {"batched": False},
+        },
+        # Enable the upkeep debug log so we can confirm claim-expiration fired.
+        log_filter="info,librdkafka=warn,h2=off,taskbroker::upkeep=debug",
+    )
+    with open(config_path, "w") as f:
+        yaml.safe_dump(config, f)
+
+    activations = make_activations(num_messages)
+    send_custom_messages_to_topic(topic, activations)
+
+    # Hang longer than push.timeout (1s) and the claim lease so pushes time out
+    # and claimed tasks accumulate for upkeep to reclaim.
+    server, servicer = start_mock_worker(worker_port, hang=10.0)
+    process = None
+    try:
+        process = start_broker(config_path, log_path)
+
+        # Wait for all tasks to land in postgres.
+        assert wait_until(
+            lambda: get_num_tasks_in_postgres(pg) == num_messages, timeout=60
+        ), f"expected {num_messages} tasks written, got {get_num_tasks_in_postgres(pg)}"
+
+        # Tasks should get claimed as the fetch loop runs.
+        assert wait_until(
+            lambda: get_num_tasks_in_postgres_by_status(pg, "Claimed") > 0, timeout=30
+        ), "expected some tasks to be claimed"
+
+        # Upkeep should revert expired claims: confirm via its debug log signal.
+        # The upkeep debug line renders `..claim_expiration_reset=<n>..`; the log
+        # is ANSI-colored, so strip escapes before matching.
+        ansi = re.compile(r"\x1b\[[0-9;]*m")
+        reset = re.compile(r"claim_expiration_reset=(\d+)")
+
+        def upkeep_reset_seen() -> bool:
+            with open(log_path, "r") as f:
+                text = ansi.sub("", f.read())
+            return any(int(n) > 0 for n in reset.findall(text))
+
+        assert wait_until(upkeep_reset_seen, timeout=120), (
+            "expected upkeep to reset expired claims back to pending "
+            "(no claim_expiration_reset>0 in broker log)"
+        )
+
+        # Nothing should ever succeed (worker never acks) and nothing is lost.
+        counts = get_num_tasks_in_postgres_group_by_status(pg)
+        assert counts.get("Processing", 0) == 0, f"nothing should be processing: {counts}"
+        assert counts.get("Complete", 0) == 0, f"nothing should complete: {counts}"
+        assert get_num_tasks_in_postgres(pg) == num_messages, f"no task should be lost: {counts}"
+    finally:
+        if process is not None:
+            stop_broker(process)
+        server.stop(0)
+        drop_postgres_db(pg)

--- a/integration_tests/pyproject.toml
+++ b/integration_tests/pyproject.toml
@@ -15,6 +15,7 @@ dev = [
     "grpcio>=1.67.0",
     "orjson>=3.10.10",
     "protobuf>=5.28.3",
+    "psycopg2-binary>=2.9",
     "pyyaml>=6.0.2",
     "sentry-protos>=0.15.0",
     "flake8>=7.3.0",
@@ -56,6 +57,7 @@ disallow_untyped_defs = true
 [[tool.mypy.overrides]]
 module = [
     "confluent_kafka.*",
+    "psycopg2.*",
 ]
 ignore_missing_imports = true
 # end: missing 3rd party stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dev = [
     "grpcio>=1.67.0",
     "orjson>=3.10.10",
     "protobuf>=5.28.3",
+    "psycopg2-binary>=2.9",
     "pyyaml>=6.0.2",
     "sentry-protos>=0.22.1",
     "flake8>=7.3.0",
@@ -57,6 +58,7 @@ module = [
     "redis.*",
     "rediscluster.*",
     "confluent_kafka.*",
+    "psycopg2.*",
     "msgpack",
 ]
 ignore_missing_imports = true

--- a/uv.lock
+++ b/uv.lock
@@ -501,6 +501,28 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg2-binary"
+version = "2.9.10"
+source = { registry = "https://pypi.devinfra.sentry.io/simple" }
+wheels = [
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:04392983d0bb89a8717772a193cfaac58871321e3ec69514e1c4e0d4957b5aff" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:1a6784f0ce3fec4edc64e985865c17778514325074adf5ad8f80636cd029ef7c" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5f86c56eeb91dc3135b3fd8a95dc7ae14c538a2f3ad77a19645cf55bab1799c" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:512d29bb12608891e349af6a0cccedce51677725a921c07dba6342beaf576f9a" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:880845dfe1f85d9d5f7c412efea7a08946a46894537e4e5d091732eb1d34d9a0" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9440fa522a79356aaa482aa4ba500b65f28e5d0e63b801abf6aa152a29bd842a" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3923c1d9870c49a2d44f795df0c889a22380d36ef92440ff618ec315757e539" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cd9b4f2cfab88ed4a9106192de509464b75a906462fb846b936eabe45c2063e" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:26540d4a9a4e2b096f1ff9cce51253d0504dca5a85872c7f7be23be5a53eb18d" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e217ce4d37667df0bc1c397fdcd8de5e81018ef305aed9415c3b093faaeb10fb" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:245159e7ab20a71d989da00f280ca57da7641fa2cdcf71749c193cea540a74f7" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8608c078134f0b3cbd9f89b34bd60a943b23fd33cc5f065e8d5f840061bd0673" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ce313780d0c3f165f37b759873128abc950136b18d73dad7d56a4ec2e6a30491" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp314-cp314-manylinux_2_31_aarch64.whl", hash = "sha256:3393e93c4923aceea70524588ce683387ac882d5827086d44960e84612746d90" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/psycopg2_binary-2.9.10-cp314-cp314-manylinux_2_31_x86_64.whl", hash = "sha256:957d8df3b59e1662d1c74b5e0e76b58fbeeddab5713dae0db9bbc3a36e4b003b" },
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
@@ -740,6 +762,7 @@ dev = [
     { name = "orjson", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pre-commit", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "psycopg2-binary", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "sentry-devenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -762,6 +785,7 @@ dev = [
     { name = "orjson", specifier = ">=3.10.10" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "protobuf", specifier = ">=5.28.3" },
+    { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "sentry-devenv", specifier = ">=1.22.2" },
@@ -871,6 +895,7 @@ dev = [
     { name = "orjson", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pre-commit", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "psycopg2-binary", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "sentry-devenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -893,6 +918,7 @@ dev = [
     { name = "orjson", specifier = ">=3.10.10" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "protobuf", specifier = ">=5.28.3" },
+    { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "sentry-devenv", specifier = ">=1.22.2" },


### PR DESCRIPTION
## Summary

Adds integration test coverage for **postgres-backed push mode**. Every existing integration test runs pull mode against SQLite, so the push pipeline (the broker claims activations from the store and pushes them to worker gRPC endpoints) had no end-to-end coverage. This suite launches a real `taskbroker` binary in push mode backed by the devservices postgres.

Most of the existing Python integration-test infrastructure is reused (broker subprocess lifecycle, config-as-YAML, kafka helpers, `get_available_ports`, Makefile/CI per-test job structure). Postgres was already a devservices dependency, and the broker self-provisions the DB + runs migrations on startup, so no external DB setup is needed.

## What's new

- **`push_worker.py`** — a minimal `MockWorkerServicer` gRPC server implementing `WorkerService.PushTask`. This is the key new piece: in push mode the broker is the gRPC *client*, whereas the existing `worker.py` is a pull-mode client. The mock records pushed activation IDs and can be told to `fail` (abort) or `hang`.
- **`helpers.py`** — `PostgresConfig` dataclass (with `.store_config()`) plus `get_num_tasks_in_postgres[_by_status/_group_by_status]`, `drop_postgres_db`, and `unique_pg_database_name`, mirroring the existing sqlite helpers. Uses `psycopg2-binary`.
- **`test_push_postgres.py`** — three tests:
  - **happy-path**: healthy worker → every task pushed exactly once and marked `Processing` in postgres.
  - **push-failure revert**: rejecting worker → nothing marked processing, no tasks lost, claimed tasks revert to pending (push-thread revert path).
  - **claim-expiration / upkeep**: hanging worker saturates the push queue → claimed tasks are stranded and upkeep reverts them to pending (verified via the `claim_expiration_reset` upkeep log signal).
- **`Makefile` + CI** — a `test-push-postgres` target and a matching `push-postgres-integration-test` job (copied from the multi-topic job).

## Notes

- Uses `psycopg2-binary` rather than `psycopg` (v3) because the devinfra package index doesn't have v3.
- A few things surfaced while writing these that are worth knowing: the new config format requires the deadletter topic to be declared in `kafka_topics`, and the postgres store persists **capitalized** status enum names (`Pending`/`Claimed`/`Processing`) unlike sqlite's lowercase.
- Following the `test-multi-topic` precedent, the new target is a standalone CI job and is **not** added to the `integration-test` aggregate.

## Test plan

- `make test-push-postgres` (or `uv run --active python -m pytest integration_tests/integration_tests/test_push_postgres.py`) — all 3 tests pass locally (~105s) against devservices kafka + postgres.
- `black`, `isort`, `flake8`, and `mypy` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
