### PR TITLE
chore: Pin rust to 1.96

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build image
 # Note that it is important which debian image is used, because not all of them have a
 # recent enough version of protobuf-compiler
-FROM rust:1-bookworm AS build
+FROM rust:1.96-bookworm AS build
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y cmake pkg-config libssl-dev librdkafka-dev protobuf-compiler


### PR DESCRIPTION
1.97 introduces a miscompilation: https://github.com/rust-lang/rust/issues/159035

independently of that though, we should pin our dependencies.