### PR TITLE
fix(gocd): Pass --config to migration job for use_yaml_config pools

### DIFF
--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -12,6 +12,15 @@ run_migrations() {
 
   echo "Running migrations for $name..."
 
+  local config_args=()
+  local config_path
+  config_path="$(kubectl get deployment "$name" \
+    -o jsonpath='{range .spec.template.spec.containers[?(@.name=="taskbroker")].args[*]}{.}{"\n"}{end}' \
+    | grep -A1 -x -- '--config' | tail -n1 || true)"
+  if [[ -n "${config_path}" ]]; then
+    config_args=(--config "${config_path}")
+  fi
+
   if ! k8s-spawn-job \
     --label-selector="${label_selector}" \
     --container-name="taskbroker" \
@@ -20,6 +29,7 @@ run_migrations() {
     "us-central1-docker.pkg.dev/sentryio/taskbroker/image:${GO_REVISION_TASKBROKER_REPO}" \
     /opt/taskbroker \
     -- \
+    "${config_args[@]}" \
     --run migrations; then
     echo "Migrations failed for $name"
     return 1

--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -12,14 +12,9 @@ run_migrations() {
 
   echo "Running migrations for $name..."
 
-  local config_args=()
-  local config_path
-  config_path="$(kubectl get deployment "$name" \
-    -o jsonpath='{range .spec.template.spec.containers[?(@.name=="taskbroker")].args[*]}{.}{"\n"}{end}' \
-    | grep -A1 -x -- '--config' | tail -n1 || true)"
-  if [[ -n "${config_path}" ]]; then
-    config_args=(--config "${config_path}")
-  fi
+  local broker_args=()
+  mapfile -t broker_args < <(kubectl get deployment "$name" \
+    -o jsonpath='{range .spec.template.spec.containers[?(@.name=="taskbroker")].args[*]}{.}{"\n"}{end}')
 
   if ! k8s-spawn-job \
     --label-selector="${label_selector}" \
@@ -29,7 +24,7 @@ run_migrations() {
     "us-central1-docker.pkg.dev/sentryio/taskbroker/image:${GO_REVISION_TASKBROKER_REPO}" \
     /opt/taskbroker \
     -- \
-    "${config_args[@]}" \
+    "${broker_args[@]}" \
     --run migrations; then
     echo "Migrations failed for $name"
     return 1

--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -12,9 +12,10 @@ run_migrations() {
 
   echo "Running migrations for $name..."
 
+  # Reuse the broker's own args.
   local broker_args=()
-  mapfile -t broker_args < <(kubectl get deployment "$name" \
-    -o jsonpath='{range .spec.template.spec.containers[?(@.name=="taskbroker")].args[*]}{.}{"\n"}{end}')
+  read -r -a broker_args < <(kubectl get deployment "$name" \
+    -o jsonpath='{.spec.template.spec.containers[?(@.name=="taskbroker")].args[*]}') || true
 
   if ! k8s-spawn-job \
     --label-selector="${label_selector}" \


### PR DESCRIPTION
Description:
The image pipeline's migration step fails for any use_yaml_config pool because the spawned migration job doesn't get the `--config flag`. This PR is responsible for adding it.

Context:
The `k8s-spawn-job` clones the live broker pod but replaces the container args without the `--config /config/config.yaml` flag the broker normally runs with. `use_yaml_config` pools keep their Kafka cluster address only in the mounted config.yaml, so without --config the binary parses env-only and dies at config load:

Error: missing field `address` for key "KAFKA_CLUSTERS.SMALL" in `TASKBROKER_` environment variable(s). See: https://deploy.getsentry.net/go/tab/build/detail/deploy-taskbroker-s4s2/195/run-migrations/2/run-migrations