### PR TITLE
debug(gocd): Instrument migration job to find why --config is dropped

### DIFF
--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -3,6 +3,9 @@
 eval "$(regions-project-env-vars --region="${SENTRY_REGION}")"
 /devinfra/scripts/get-cluster-credentials
 
+# DEBUG (temporary): make k8s-spawn-job pprint the spawned pod spec.
+export DEBUG=1
+
 # Find all Deployments where the number of ready pods is greater than zero
 deployments=$(kubectl get deployments -A --no-headers | awk '$2 ~ /^task-.*-broker$/ && $5+0 > 0 {print $2}')
 
@@ -12,10 +15,24 @@ run_migrations() {
 
   echo "Running migrations for $name..."
 
+  # ---- DEBUG (temporary): find where --config is lost. Remove after diagnosing. ----
+  echo "DEBUG[$name]: kubectl client => $(kubectl version --client 2>&1 | head -1)"
+  echo "DEBUG[$name]: context namespace => [$(kubectl config view --minify -o jsonpath='{..namespace}' 2>&1)]"
+  echo "DEBUG[$name]: deployment lookup (default ns) => $(kubectl get deployment "$name" -o name 2>&1)"
+  echo "DEBUG[$name]: live container command/args/mounts (jq) =>"
+  kubectl get deployment "$name" -o json 2>/dev/null \
+    | jq -c '.spec.template.spec.containers[] | select(.name == "taskbroker") | {command, args, mounts: [.volumeMounts[]?.mountPath]}' 2>&1 \
+    | sed "s/^/DEBUG[$name]:   /"
+  echo "DEBUG[$name]: argsA filter-jsonpath  => [$(kubectl get deployment "$name" -o jsonpath='{.spec.template.spec.containers[?(@.name=="taskbroker")].args[*]}' 2>&1)]"
+  echo "DEBUG[$name]: argsB nofilter-jsonpath => [$(kubectl get deployment "$name" -o jsonpath='{.spec.template.spec.containers[*].args[*]}' 2>&1)]"
+  echo "DEBUG[$name]: argsC jq               => [$(kubectl get deployment "$name" -o json 2>/dev/null | jq -r '.spec.template.spec.containers[] | select(.name == "taskbroker") | .args // [] | join(" ")' 2>&1)]"
+  # ---- end DEBUG ----
+
   # Reuse the broker's own args.
   local broker_args=()
   read -r -a broker_args < <(kubectl get deployment "$name" \
     -o jsonpath='{.spec.template.spec.containers[?(@.name=="taskbroker")].args[*]}') || true
+  echo "DEBUG[$name]: broker_args count=${#broker_args[@]} => ${broker_args[*]}"
 
   if ! k8s-spawn-job \
     --label-selector="${label_selector}" \


### PR DESCRIPTION
The image pipeline's run-migrations step fails for use_yaml_config pools (e.g. ingest-push) with:
```
Error: missing field `address` for key "KAFKA_CLUSTERS.SMALL" in `TASKBROKER_` environment variable(s)
```

#753 tried to fix this by reading the broker's args off the live deployment and passing --config through to the spawned migration job, but the migration still fails identically. This adds logging to confirm that before committing to a fix.