### PR TITLE
fix: Repair migration config-repo parse and pass --config for yaml pools

### DIFF
--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# IMPORTANT: this script is inlined into the GoCD pipeline definition via
-# importstr, and GoCD runs parameter substitution over it. A literal hash that
-# is not in the first column breaks the config-repo parse, silently freezing the
-# pipeline on its last good render.
-
 eval "$(regions-project-env-vars --region="${SENTRY_REGION}")"
 /devinfra/scripts/get-cluster-credentials
 
@@ -17,7 +12,6 @@ run_migrations() {
 
   echo "Running migrations for $name..."
 
-# Reuse the broker's own args
   local broker_args=()
   read -r -a broker_args < <(kubectl get deployment "$name" -o json \
     | jq -r '.spec.template.spec.containers[] | select(.name == "taskbroker") | .args // [] | join(" ")')

--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+# IMPORTANT: this script is inlined into the GoCD pipeline definition via
+# importstr, and GoCD runs parameter substitution over it. A literal hash that
+# is not in the first column breaks the config-repo parse, silently freezing the
+# pipeline on its last good render. So keep every comment in column 1, and avoid
+# any mid-line hash (for example, bash array-length syntax on a variable).
+
 eval "$(regions-project-env-vars --region="${SENTRY_REGION}")"
 /devinfra/scripts/get-cluster-credentials
-
-# DEBUG (temporary): make k8s-spawn-job pprint the spawned pod spec.
-export DEBUG=1
 
 # Find all Deployments where the number of ready pods is greater than zero
 deployments=$(kubectl get deployments -A --no-headers | awk '$2 ~ /^task-.*-broker$/ && $5+0 > 0 {print $2}')
@@ -15,24 +18,10 @@ run_migrations() {
 
   echo "Running migrations for $name..."
 
-  # ---- DEBUG (temporary): find where --config is lost. Remove after diagnosing. ----
-  echo "DEBUG[$name]: kubectl client => $(kubectl version --client 2>&1 | head -1)"
-  echo "DEBUG[$name]: context namespace => [$(kubectl config view --minify -o jsonpath='{..namespace}' 2>&1)]"
-  echo "DEBUG[$name]: deployment lookup (default ns) => $(kubectl get deployment "$name" -o name 2>&1)"
-  echo "DEBUG[$name]: live container command/args/mounts (jq) =>"
-  kubectl get deployment "$name" -o json 2>/dev/null \
-    | jq -c '.spec.template.spec.containers[] | select(.name == "taskbroker") | {command, args, mounts: [.volumeMounts[]?.mountPath]}' 2>&1 \
-    | sed "s/^/DEBUG[$name]:   /"
-  echo "DEBUG[$name]: argsA filter-jsonpath  => [$(kubectl get deployment "$name" -o jsonpath='{.spec.template.spec.containers[?(@.name=="taskbroker")].args[*]}' 2>&1)]"
-  echo "DEBUG[$name]: argsB nofilter-jsonpath => [$(kubectl get deployment "$name" -o jsonpath='{.spec.template.spec.containers[*].args[*]}' 2>&1)]"
-  echo "DEBUG[$name]: argsC jq               => [$(kubectl get deployment "$name" -o json 2>/dev/null | jq -r '.spec.template.spec.containers[] | select(.name == "taskbroker") | .args // [] | join(" ")' 2>&1)]"
-  # ---- end DEBUG ----
-
-  # Reuse the broker's own args.
+# Reuse the broker's own args
   local broker_args=()
-  read -r -a broker_args < <(kubectl get deployment "$name" \
-    -o jsonpath='{.spec.template.spec.containers[?(@.name=="taskbroker")].args[*]}') || true
-  echo "DEBUG[$name]: broker_args count=${#broker_args[@]} => ${broker_args[*]}"
+  read -r -a broker_args < <(kubectl get deployment "$name" -o json \
+    | jq -r '.spec.template.spec.containers[] | select(.name == "taskbroker") | .args // [] | join(" ")')
 
   if ! k8s-spawn-job \
     --label-selector="${label_selector}" \

--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -3,8 +3,7 @@
 # IMPORTANT: this script is inlined into the GoCD pipeline definition via
 # importstr, and GoCD runs parameter substitution over it. A literal hash that
 # is not in the first column breaks the config-repo parse, silently freezing the
-# pipeline on its last good render. So keep every comment in column 1, and avoid
-# any mid-line hash (for example, bash array-length syntax on a variable).
+# pipeline on its last good render.
 
 eval "$(regions-project-env-vars --region="${SENTRY_REGION}")"
 /devinfra/scripts/get-cluster-credentials


### PR DESCRIPTION
The taskbroker config-repo parse has been failing since #753, freezing the deploy-taskbroker-s4s2 pipeline on an old render that runs migrations without --config. This PR makes the migration script GoCD-parseable again and reliably passes --config to use_yaml_config pools.