### PR TITLE
test: Initialize SDK in relevant tests

### DIFF
--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -35,18 +35,12 @@ def sentry_init(request: FixtureRequest) -> Generator[Callable[..., None], None,
         client = sentry_sdk.Client(*a, **kw)
         sentry_sdk.get_global_scope().set_client(client)
 
-    if request.node.get_closest_marker("forked"):
-        # Do not run isolation if the test is already running in
-        # ultimate isolation (seems to be required for celery tests that
-        # fork)
+    old_client = sentry_sdk.get_global_scope().client
+    try:
+        sentry_sdk.get_current_scope().set_client(None)
         yield inner
-    else:
-        old_client = sentry_sdk.get_global_scope().client
-        try:
-            sentry_sdk.get_current_scope().set_client(None)
-            yield inner
-        finally:
-            sentry_sdk.get_global_scope().set_client(old_client)
+    finally:
+        sentry_sdk.get_global_scope().set_client(old_client)
 
 
 class TestTransport(Transport):

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -29,12 +29,9 @@ def freeze_time(t: str | datetime | None = None) -> time_machine.travel:
 
 @pytest.fixture
 def sentry_init() -> Generator[Callable[..., None], None, None]:
-    clients = []
-
     def inner(*a: Any, **kw: Any) -> None:
         kw.setdefault("transport", TestTransport())
         client = sentry_sdk.Client(*a, **kw)
-        clients.append(client)
         sentry_sdk.get_global_scope().set_client(client)
 
     old_client = sentry_sdk.get_global_scope().client
@@ -42,8 +39,6 @@ def sentry_init() -> Generator[Callable[..., None], None, None]:
         sentry_sdk.get_current_scope().set_client(None)
         yield inner
     finally:
-        for client in clients:
-            client.close()
         sentry_sdk.get_global_scope().set_client(old_client)
 
 

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -46,9 +46,6 @@ def sentry_init() -> Generator[Callable[..., None], None, None]:
 
 
 class TestTransport(Transport):
-    def __init__(self) -> None:
-        Transport.__init__(self)
-
     def capture_envelope(self, _: Envelope) -> None:
         """No-op capture_envelope for tests"""
         pass

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -6,7 +6,6 @@ import pytest
 import sentry_sdk
 import time_machine
 from arroyo.backends.kafka import KafkaProducer
-from pytest import FixtureRequest
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.transport import Transport
 
@@ -29,7 +28,7 @@ def freeze_time(t: str | datetime | None = None) -> time_machine.travel:
 
 
 @pytest.fixture
-def sentry_init(request: FixtureRequest) -> Generator[Callable[..., None], None, None]:
+def sentry_init() -> Generator[Callable[..., None], None, None]:
     def inner(*a: Any, **kw: Any) -> None:
         kw.setdefault("transport", TestTransport())
         client = sentry_sdk.Client(*a, **kw)

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -40,6 +40,9 @@ def sentry_init(request: FixtureRequest) -> Generator[Callable[..., None], None,
         sentry_sdk.get_current_scope().set_client(None)
         yield inner
     finally:
+        current = sentry_sdk.get_global_scope().client
+        if current is not None:
+            current.close()
         sentry_sdk.get_global_scope().set_client(old_client)
 
 

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -29,9 +29,12 @@ def freeze_time(t: str | datetime | None = None) -> time_machine.travel:
 
 @pytest.fixture
 def sentry_init() -> Generator[Callable[..., None], None, None]:
+    clients = []
+
     def inner(*a: Any, **kw: Any) -> None:
         kw.setdefault("transport", TestTransport())
         client = sentry_sdk.Client(*a, **kw)
+        clients.append(client)
         sentry_sdk.get_global_scope().set_client(client)
 
     old_client = sentry_sdk.get_global_scope().client
@@ -39,6 +42,8 @@ def sentry_init() -> Generator[Callable[..., None], None, None]:
         sentry_sdk.get_current_scope().set_client(None)
         yield inner
     finally:
+        for client in clients:
+            client.close()
         sentry_sdk.get_global_scope().set_client(old_client)
 
 

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -1,7 +1,14 @@
+from collections.abc import Callable, Generator
 from datetime import UTC, datetime
+from typing import Any
 
+import pytest
+import sentry_sdk
 import time_machine
 from arroyo.backends.kafka import KafkaProducer
+from pytest import FixtureRequest
+from sentry_sdk.envelope import Envelope
+from sentry_sdk.transport import Transport
 
 from taskbroker_client.types import AtMostOnceStore
 
@@ -19,6 +26,36 @@ def freeze_time(t: str | datetime | None = None) -> time_machine.travel:
     if t is None:
         t = datetime.now(UTC)
     return time_machine.travel(t, tick=False)
+
+
+@pytest.fixture
+def sentry_init(request: FixtureRequest) -> Generator[Callable[..., None], None, None]:
+    def inner(*a: Any, **kw: Any) -> None:
+        kw.setdefault("transport", TestTransport())
+        client = sentry_sdk.Client(*a, **kw)
+        sentry_sdk.get_global_scope().set_client(client)
+
+    if request.node.get_closest_marker("forked"):
+        # Do not run isolation if the test is already running in
+        # ultimate isolation (seems to be required for celery tests that
+        # fork)
+        yield inner
+    else:
+        old_client = sentry_sdk.get_global_scope().client
+        try:
+            sentry_sdk.get_current_scope().set_client(None)
+            yield inner
+        finally:
+            sentry_sdk.get_global_scope().set_client(old_client)
+
+
+class TestTransport(Transport):
+    def __init__(self) -> None:
+        Transport.__init__(self)
+
+    def capture_envelope(self, _: Envelope) -> None:
+        """No-op capture_envelope for tests"""
+        pass
 
 
 class StubAtMostOnce(AtMostOnceStore):

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -29,9 +29,12 @@ def freeze_time(t: str | datetime | None = None) -> time_machine.travel:
 
 @pytest.fixture
 def sentry_init() -> Generator[Callable[..., None], None, None]:
+    clients = []
+
     def inner(*a: Any, **kw: Any) -> None:
         kw.setdefault("transport", TestTransport())
         client = sentry_sdk.Client(*a, **kw)
+        clients.append(client)
         sentry_sdk.get_global_scope().set_client(client)
 
     old_client = sentry_sdk.get_global_scope().client
@@ -39,9 +42,8 @@ def sentry_init() -> Generator[Callable[..., None], None, None]:
         sentry_sdk.get_current_scope().set_client(None)
         yield inner
     finally:
-        current = sentry_sdk.get_global_scope().client
-        if current is not None:
-            current.close()
+        for client in clients:
+            client.close()
         sentry_sdk.get_global_scope().set_client(old_client)
 
 

--- a/clients/python/tests/test_task.py
+++ b/clients/python/tests/test_task.py
@@ -2,7 +2,7 @@ import contextlib
 import datetime
 from collections.abc import MutableMapping
 from concurrent.futures import Future
-from typing import Any
+from typing import Any, Callable
 from unittest.mock import patch
 
 import msgpack
@@ -297,7 +297,11 @@ def test_create_activation_parameters(task_namespace: TaskNamespace) -> None:
     assert activation.parameters == ""
 
 
-def test_create_activation_tracing(task_namespace: TaskNamespace) -> None:
+def test_create_activation_tracing(
+    sentry_init: Callable[..., None], task_namespace: TaskNamespace
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     @task_namespace.register(name="test.parameters")
     def with_parameters(one: str, two: int, org_id: int) -> None:
         raise NotImplementedError
@@ -310,7 +314,11 @@ def test_create_activation_tracing(task_namespace: TaskNamespace) -> None:
     assert "baggage" in headers
 
 
-def test_create_activation_tracing_headers(task_namespace: TaskNamespace) -> None:
+def test_create_activation_tracing_headers(
+    sentry_init: Callable[..., None], task_namespace: TaskNamespace
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     @task_namespace.register(name="test.parameters")
     def with_parameters(one: str, two: int, org_id: int) -> None:
         raise NotImplementedError
@@ -326,7 +334,11 @@ def test_create_activation_tracing_headers(task_namespace: TaskNamespace) -> Non
     assert headers["key"] == "value"
 
 
-def test_create_activation_tracing_disable(task_namespace: TaskNamespace) -> None:
+def test_create_activation_tracing_disable(
+    sentry_init: Callable[..., None], task_namespace: TaskNamespace
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     @task_namespace.register(name="test.parameters")
     def with_parameters(one: str, two: int, org_id: int) -> None:
         raise NotImplementedError

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -2360,6 +2360,8 @@ def test_child_process_uses_configured_future_checking_frequency(
         idle_sleeps.append(seconds)
         real_sleep(seconds)
 
+    import examples.tasks  # noqa: F401  — ensure sleep ref is bound before patching
+
     # time.sleep is only used by the idle branch of check_task_future_completion
     # inside workerchild, so every recorded call comes from that loop. The task's
     # own sleep uses a separate `from time import sleep` import in examples.tasks.

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -1023,7 +1023,8 @@ class TestWorkerServicer(TestCase):
 
 @mock.patch("taskbroker_client.worker.workerchild.capture_checkin")
 def test_child_process_complete(
-    sentry_init: Callable[..., None], mock_capture_checkin: mock.MagicMock
+    mock_capture_checkin: mock.MagicMock,
+    sentry_init: Callable[..., None],
 ) -> None:
     sentry_init(traces_sample_rate=1.0)
 
@@ -1116,8 +1117,8 @@ def test_child_process_emits_running_message(sentry_init: Callable[..., None]) -
 
 @mock.patch("taskbroker_client.worker.workerchild.capture_checkin")
 def test_child_process_emits_exiting_once_and_continues_until_release(
-    sentry_init: Callable[..., None],
     mock_capture_checkin: mock.MagicMock,
+    sentry_init: Callable[..., None],
 ) -> None:
     sentry_init(traces_sample_rate=1.0)
 
@@ -1282,7 +1283,9 @@ def test_child_process_retry_task(sentry_init: Callable[..., None]) -> None:
 @mock.patch("taskbroker_client.worker.workerchild.logger")
 @mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
 def test_child_process_retry_task_max_attempts(
-    sentry_init: Callable[..., None], mock_capture: mock.Mock, mock_logger: mock.Mock
+    mock_capture: mock.Mock,
+    mock_logger: mock.Mock,
+    sentry_init: Callable[..., None],
 ) -> None:
     sentry_init(traces_sample_rate=1.0)
 
@@ -1461,7 +1464,8 @@ def test_child_process_at_most_once(sentry_init: Callable[..., None]) -> None:
 
 @mock.patch("taskbroker_client.worker.workerchild.capture_checkin")
 def test_child_process_record_checkin(
-    sentry_init: Callable[..., None], mock_capture_checkin: mock.Mock
+    mock_capture_checkin: mock.Mock,
+    sentry_init: Callable[..., None],
 ) -> None:
     sentry_init(traces_sample_rate=1.0)
 
@@ -1530,7 +1534,8 @@ def test_child_process_pass_headers(sentry_init: Callable[..., None]) -> None:
 
 @mock.patch("taskbroker_client.worker.workerchild.logger")
 def test_child_process_terminate_task(
-    sentry_init: Callable[..., None], mock_logger: mock.Mock
+    mock_logger: mock.Mock,
+    sentry_init: Callable[..., None],
 ) -> None:
     sentry_init(traces_sample_rate=1.0)
 
@@ -1581,7 +1586,8 @@ def test_child_process_terminate_task(
 
 @mock.patch("taskbroker_client.worker.workerchild.capture_checkin")
 def test_child_process_decompression(
-    sentry_init: Callable[..., None], mock_capture_checkin: mock.MagicMock
+    mock_capture_checkin: mock.MagicMock,
+    sentry_init: Callable[..., None],
 ) -> None:
     sentry_init(traces_sample_rate=1.0)
 
@@ -1670,7 +1676,8 @@ def test_child_process_context_hooks(sentry_init: Callable[..., None]) -> None:
 
 @mock.patch("taskbroker_client.worker.workerchild.logger")
 def test_child_process_silenced_timeout(
-    sentry_init: Callable[..., None], mock_logger: mock.Mock
+    mock_logger: mock.Mock,
+    sentry_init: Callable[..., None],
 ) -> None:
     sentry_init(traces_sample_rate=1.0)
 
@@ -1705,7 +1712,8 @@ def test_child_process_silenced_timeout(
 
 @mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
 def test_child_process_silenced_exception_with_retries(
-    sentry_init: Callable[..., None], mock_capture: mock.Mock
+    mock_capture: mock.Mock,
+    sentry_init: Callable[..., None],
 ) -> None:
     sentry_init(traces_sample_rate=1.0)
 
@@ -1737,7 +1745,8 @@ def test_child_process_silenced_exception_with_retries(
 
 @mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
 def test_child_process_expected_ignored_exception_max_attempts(
-    sentry_init: Callable[..., None], mock_capture: mock.Mock
+    mock_capture: mock.Mock,
+    sentry_init: Callable[..., None],
 ) -> None:
     sentry_init(traces_sample_rate=1.0)
 
@@ -1770,7 +1779,9 @@ def test_child_process_expected_ignored_exception_max_attempts(
 @mock.patch("taskbroker_client.worker.workerchild.logger")
 @mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
 def test_child_process_silenced_exception_max_attempts(
-    sentry_init: Callable[..., None], mock_capture: mock.Mock, mock_logger: mock.Mock
+    mock_capture: mock.Mock,
+    mock_logger: mock.Mock,
+    sentry_init: Callable[..., None],
 ) -> None:
     """Silenced exceptions do not raise on retry exhaustion."""
     sentry_init(traces_sample_rate=1.0)
@@ -1827,7 +1838,8 @@ def test_child_process_silenced_exception_max_attempts(
 
 @mock.patch("taskbroker_client.worker.workerchild.logger")
 def test_child_process_retry_on_deadline_exceeded(
-    sentry_init: Callable[..., None], mock_logger: mock.Mock
+    mock_logger: mock.Mock,
+    sentry_init: Callable[..., None],
 ) -> None:
     sentry_init(traces_sample_rate=1.0)
 
@@ -1864,7 +1876,8 @@ def test_child_process_retry_on_deadline_exceeded(
 
 @mock.patch("taskbroker_client.worker.workerchild.logger")
 def test_child_process_general_exception_logs_task_failed(
-    sentry_init: Callable[..., None], mock_logger: mock.Mock
+    mock_logger: mock.Mock,
+    sentry_init: Callable[..., None],
 ) -> None:
     """A non-retriable Exception emits taskworker.task.failed with all fields."""
     sentry_init(traces_sample_rate=1.0)
@@ -1904,8 +1917,8 @@ def test_child_process_general_exception_logs_task_failed(
 
 @mock.patch("taskbroker_client.worker.workerchild.logger")
 def test_child_process_silenced_exception_does_not_log_task_failed(
-    sentry_init: Callable[..., None],
     mock_logger: mock.Mock,
+    sentry_init: Callable[..., None],
 ) -> None:
     """When err is in silenced_exceptions, taskworker.task.failed is NOT logged.
     Preserves the silencing semantics added in #608."""

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -2326,11 +2326,9 @@ def test_child_process_clears_pending_futures_when_task_fails(
 
 
 def test_child_process_uses_configured_future_checking_frequency(
-    sentry_init: Callable[..., None], clear_pending_futures: None, restore_signal_handlers: None
+    clear_pending_futures: None, restore_signal_handlers: None
 ) -> None:
     """The idle future-checking loop polls on the configured interval."""
-    sentry_init(traces_sample_rate=1.0)
-
     # A task that runs long enough for the idle future-checking loop to poll a
     # few times before max_task_count triggers shutdown.
     slow_task = InflightTaskActivation(

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -2326,9 +2326,14 @@ def test_child_process_clears_pending_futures_when_task_fails(
 
 
 def test_child_process_uses_configured_future_checking_frequency(
-    clear_pending_futures: None, restore_signal_handlers: None
+    sentry_init: Callable[..., None], clear_pending_futures: None, restore_signal_handlers: None
 ) -> None:
     """The idle future-checking loop polls on the configured interval."""
+    sentry_init(
+        traces_sample_rate=1.0,
+        enable_backpressure_handling=False,  # To avoid time.sleep which the test patches.
+    )
+
     # A task that runs long enough for the idle future-checking loop to poll a
     # few times before max_task_count triggers shutdown.
     slow_task = InflightTaskActivation(

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -1022,7 +1022,11 @@ class TestWorkerServicer(TestCase):
 
 
 @mock.patch("taskbroker_client.worker.workerchild.capture_checkin")
-def test_child_process_complete(mock_capture_checkin: mock.MagicMock) -> None:
+def test_child_process_complete(
+    sentry_init: Callable[..., None], mock_capture_checkin: mock.MagicMock
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1047,7 +1051,11 @@ def test_child_process_complete(mock_capture_checkin: mock.MagicMock) -> None:
     assert mock_capture_checkin.call_count == 0
 
 
-def test_child_process_canary_task(capsys: pytest.CaptureFixture[str]) -> None:
+def test_child_process_canary_task(
+    sentry_init: Callable[..., None], capsys: pytest.CaptureFixture[str]
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1073,7 +1081,9 @@ def test_child_process_canary_task(capsys: pytest.CaptureFixture[str]) -> None:
     assert capsys.readouterr().out == "Done running canary task!\n"
 
 
-def test_child_process_emits_running_message() -> None:
+def test_child_process_emits_running_message(sentry_init: Callable[..., None]) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1106,8 +1116,11 @@ def test_child_process_emits_running_message() -> None:
 
 @mock.patch("taskbroker_client.worker.workerchild.capture_checkin")
 def test_child_process_emits_exiting_once_and_continues_until_release(
+    sentry_init: Callable[..., None],
     mock_capture_checkin: mock.MagicMock,
 ) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     shutdown = Event()
     ctx = get_context("fork")
     child_id = uuid4()
@@ -1167,7 +1180,9 @@ def test_child_process_emits_exiting_once_and_continues_until_release(
     assert mock_capture_checkin.call_count == 0
 
 
-def test_child_process_emits_busy_and_idle_messages() -> None:
+def test_child_process_emits_busy_and_idle_messages(sentry_init: Callable[..., None]) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1199,7 +1214,9 @@ def test_child_process_emits_busy_and_idle_messages() -> None:
     assert processed.get(timeout=1).task_id == SIMPLE_TASK.activation.id
 
 
-def test_child_process_remove_start_time_kwargs() -> None:
+def test_child_process_remove_start_time_kwargs(sentry_init: Callable[..., None]) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     activation = InflightTaskActivation(
         host="localhost:50051",
         receive_timestamp=0,
@@ -1236,7 +1253,9 @@ def test_child_process_remove_start_time_kwargs() -> None:
     assert result.status == TASK_ACTIVATION_STATUS_COMPLETE
 
 
-def test_child_process_retry_task() -> None:
+def test_child_process_retry_task(sentry_init: Callable[..., None]) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1263,8 +1282,10 @@ def test_child_process_retry_task() -> None:
 @mock.patch("taskbroker_client.worker.workerchild.logger")
 @mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
 def test_child_process_retry_task_max_attempts(
-    mock_capture: mock.Mock, mock_logger: mock.Mock
+    sentry_init: Callable[..., None], mock_capture: mock.Mock, mock_logger: mock.Mock
 ) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     # Create an activation that is on its final attempt and
     # will raise an error again.
     activation = InflightTaskActivation(
@@ -1324,7 +1345,9 @@ def test_child_process_retry_task_max_attempts(
     assert extra["retry_max_attempts"] == 3
 
 
-def test_child_process_failure_task() -> None:
+def test_child_process_failure_task(sentry_init: Callable[..., None]) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1348,7 +1371,9 @@ def test_child_process_failure_task() -> None:
     assert result.status == TASK_ACTIVATION_STATUS_FAILURE
 
 
-def test_child_process_shutdown() -> None:
+def test_child_process_shutdown(sentry_init: Callable[..., None]) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1372,7 +1397,9 @@ def test_child_process_shutdown() -> None:
     assert processed.qsize() == 0
 
 
-def test_child_process_unknown_task() -> None:
+def test_child_process_unknown_task(sentry_init: Callable[..., None]) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1400,7 +1427,9 @@ def test_child_process_unknown_task() -> None:
     assert result.status == TASK_ACTIVATION_STATUS_COMPLETE
 
 
-def test_child_process_at_most_once() -> None:
+def test_child_process_at_most_once(sentry_init: Callable[..., None]) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1431,7 +1460,11 @@ def test_child_process_at_most_once() -> None:
 
 
 @mock.patch("taskbroker_client.worker.workerchild.capture_checkin")
-def test_child_process_record_checkin(mock_capture_checkin: mock.Mock) -> None:
+def test_child_process_record_checkin(
+    sentry_init: Callable[..., None], mock_capture_checkin: mock.Mock
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1463,8 +1496,10 @@ def test_child_process_record_checkin(mock_capture_checkin: mock.Mock) -> None:
     )
 
 
-def test_child_process_pass_headers() -> None:
+def test_child_process_pass_headers(sentry_init: Callable[..., None]) -> None:
     """Task with pass_headers=True receives headers from the activation."""
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1494,7 +1529,11 @@ def test_child_process_pass_headers() -> None:
 
 
 @mock.patch("taskbroker_client.worker.workerchild.logger")
-def test_child_process_terminate_task(mock_logger: mock.Mock) -> None:
+def test_child_process_terminate_task(
+    sentry_init: Callable[..., None], mock_logger: mock.Mock
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1541,7 +1580,10 @@ def test_child_process_terminate_task(mock_logger: mock.Mock) -> None:
 
 
 @mock.patch("taskbroker_client.worker.workerchild.capture_checkin")
-def test_child_process_decompression(mock_capture_checkin: mock.MagicMock) -> None:
+def test_child_process_decompression(
+    sentry_init: Callable[..., None], mock_capture_checkin: mock.MagicMock
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
 
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
@@ -1567,8 +1609,10 @@ def test_child_process_decompression(mock_capture_checkin: mock.MagicMock) -> No
     assert mock_capture_checkin.call_count == 0
 
 
-def test_child_process_context_hooks() -> None:
+def test_child_process_context_hooks(sentry_init: Callable[..., None]) -> None:
     """Context hooks' on_execute is called with activation headers during task execution."""
+    sentry_init(traces_sample_rate=1.0)
+
     executed_headers: list[dict[str, str]] = []
 
     class RecordingHook:
@@ -1625,7 +1669,11 @@ def test_child_process_context_hooks() -> None:
 
 
 @mock.patch("taskbroker_client.worker.workerchild.logger")
-def test_child_process_silenced_timeout(mock_logger: mock.Mock) -> None:
+def test_child_process_silenced_timeout(
+    sentry_init: Callable[..., None], mock_logger: mock.Mock
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1656,7 +1704,11 @@ def test_child_process_silenced_timeout(mock_logger: mock.Mock) -> None:
 
 
 @mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
-def test_child_process_silenced_exception_with_retries(mock_capture: mock.Mock) -> None:
+def test_child_process_silenced_exception_with_retries(
+    sentry_init: Callable[..., None], mock_capture: mock.Mock
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1684,7 +1736,11 @@ def test_child_process_silenced_exception_with_retries(mock_capture: mock.Mock) 
 
 
 @mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
-def test_child_process_expected_ignored_exception_max_attempts(mock_capture: mock.Mock) -> None:
+def test_child_process_expected_ignored_exception_max_attempts(
+    sentry_init: Callable[..., None], mock_capture: mock.Mock
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1714,9 +1770,11 @@ def test_child_process_expected_ignored_exception_max_attempts(mock_capture: moc
 @mock.patch("taskbroker_client.worker.workerchild.logger")
 @mock.patch("taskbroker_client.worker.workerchild.sentry_sdk.capture_exception")
 def test_child_process_silenced_exception_max_attempts(
-    mock_capture: mock.Mock, mock_logger: mock.Mock
+    sentry_init: Callable[..., None], mock_capture: mock.Mock, mock_logger: mock.Mock
 ) -> None:
     """Silenced exceptions do not raise on retry exhaustion."""
+    sentry_init(traces_sample_rate=1.0)
+
     activation = InflightTaskActivation(
         host="localhost:50051",
         receive_timestamp=0,
@@ -1768,7 +1826,11 @@ def test_child_process_silenced_exception_max_attempts(
 
 
 @mock.patch("taskbroker_client.worker.workerchild.logger")
-def test_child_process_retry_on_deadline_exceeded(mock_logger: mock.Mock) -> None:
+def test_child_process_retry_on_deadline_exceeded(
+    sentry_init: Callable[..., None], mock_logger: mock.Mock
+) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1801,8 +1863,12 @@ def test_child_process_retry_on_deadline_exceeded(mock_logger: mock.Mock) -> Non
 
 
 @mock.patch("taskbroker_client.worker.workerchild.logger")
-def test_child_process_general_exception_logs_task_failed(mock_logger: mock.Mock) -> None:
+def test_child_process_general_exception_logs_task_failed(
+    sentry_init: Callable[..., None], mock_logger: mock.Mock
+) -> None:
     """A non-retriable Exception emits taskworker.task.failed with all fields."""
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1838,10 +1904,13 @@ def test_child_process_general_exception_logs_task_failed(mock_logger: mock.Mock
 
 @mock.patch("taskbroker_client.worker.workerchild.logger")
 def test_child_process_silenced_exception_does_not_log_task_failed(
+    sentry_init: Callable[..., None],
     mock_logger: mock.Mock,
 ) -> None:
     """When err is in silenced_exceptions, taskworker.task.failed is NOT logged.
     Preserves the silencing semantics added in #608."""
+    sentry_init(traces_sample_rate=1.0)
+
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
@@ -1936,10 +2005,13 @@ def _producing_task(task_id: str = "task-with-futures") -> InflightTaskActivatio
 
 @pytest.mark.parametrize("producer_cls", _PRODUCER_CLASSES)
 def test_child_process_tracks_producer_futures(
+    sentry_init: Callable[..., None],
     producer_cls: type,
     clear_pending_futures: None,
     restore_signal_handlers: None,
 ) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     task = _producing_task()
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
@@ -1974,10 +2046,13 @@ def test_child_process_tracks_producer_futures(
 
 @pytest.mark.parametrize("producer_cls", _PRODUCER_CLASSES)
 def test_child_process_holds_result_until_futures_done(
+    sentry_init: Callable[..., None],
     producer_cls: type,
     clear_pending_futures: None,
     restore_signal_handlers: None,
 ) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     task = _producing_task()
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
@@ -2029,10 +2104,13 @@ def test_child_process_holds_result_until_futures_done(
 
 @pytest.mark.parametrize("producer_cls", _PRODUCER_CLASSES)
 def test_child_process_skip_awaiting_futures_places_result_immediately(
+    sentry_init: Callable[..., None],
     producer_cls: type,
     clear_pending_futures: None,
     restore_signal_handlers: None,
 ) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     task = _producing_task()
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
@@ -2091,10 +2169,13 @@ def test_child_process_skip_awaiting_futures_places_result_immediately(
 
 @pytest.mark.parametrize("producer_cls", _PRODUCER_CLASSES)
 def test_child_process_drains_pending_futures_on_sigterm(
+    sentry_init: Callable[..., None],
     producer_cls: type,
     clear_pending_futures: None,
     restore_signal_handlers: None,
 ) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     task = _producing_task()
     todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
@@ -2139,10 +2220,13 @@ def test_child_process_drains_pending_futures_on_sigterm(
 
 @pytest.mark.parametrize("producer_cls", _PRODUCER_CLASSES)
 def test_child_process_retries_on_failed_future(
+    sentry_init: Callable[..., None],
     producer_cls: type,
     clear_pending_futures: None,
     restore_signal_handlers: None,
 ) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     retriable_task = InflightTaskActivation(
         host="localhost:50051",
         receive_timestamp=0,
@@ -2189,10 +2273,13 @@ def test_child_process_retries_on_failed_future(
 
 @pytest.mark.parametrize("pending_registry", _PENDING_REGISTRIES)
 def test_child_process_clears_pending_futures_when_task_fails(
+    sentry_init: Callable[..., None],
     pending_registry: Any,
     clear_pending_futures: None,
     restore_signal_handlers: None,
 ) -> None:
+    sentry_init(traces_sample_rate=1.0)
+
     leftover_future: Future[BrokerValue[KafkaPayload]] = Future()
     leftover_future.set_result(_make_broker_value())
     pending_registry["test.producer"].append(leftover_future)
@@ -2226,9 +2313,11 @@ def test_child_process_clears_pending_futures_when_task_fails(
 
 
 def test_child_process_uses_configured_future_checking_frequency(
-    clear_pending_futures: None, restore_signal_handlers: None
+    sentry_init: Callable[..., None], clear_pending_futures: None, restore_signal_handlers: None
 ) -> None:
     """The idle future-checking loop polls on the configured interval."""
+    sentry_init(traces_sample_rate=1.0)
+
     # A task that runs long enough for the idle future-checking loop to poll a
     # few times before max_task_count triggers shutdown.
     slow_task = InflightTaskActivation(

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -2360,7 +2360,7 @@ def test_child_process_uses_configured_future_checking_frequency(
         idle_sleeps.append(seconds)
         real_sleep(seconds)
 
-    import examples.tasks  # noqa: F401  — ensure sleep ref is bound before patching
+    import examples.tasks  # noqa: F401; Ensure time.sleep reference is set before patching.
 
     # time.sleep is only used by the idle branch of check_task_future_completion
     # inside workerchild, so every recorded call comes from that loop. The task's


### PR DESCRIPTION
Initialize the SDK with a mock transport in tests in which `_execute_activation` or `create_activation` is called, since the functions rely on tracing functions. The SDK was previously uninitialized in tests.
The initialization fixture is adapted from https://github.com/getsentry/sentry-python.

This allows us to exercise options that change the tracing behavior in tests. The tests are parametrized on the trace lifecycle in a follow up PR (https://github.com/getsentry/taskbroker/pull/757).