### PR TITLE
feat(taskbroker): Print Redacted Config on Startup

### DIFF
--- a/src/config/batch.rs
+++ b/src/config/batch.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Validate)]
 pub struct BatchConfig {
     /// The maximum or desired length of a batch, depending on context.
     #[validate(range(min = 1))]

--- a/src/config/deprecated.rs
+++ b/src/config/deprecated.rs
@@ -62,7 +62,7 @@ macro_rules! map {
 
 pub(crate) use map;
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Default)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Default)]
 pub struct DeprecatedConfig {
     /// The topic to fetch task messages from.
     /// Deprecated: use kafka_topics instead. Mutually exclusive with the new

--- a/src/config/fetch.rs
+++ b/src/config/fetch.rs
@@ -6,7 +6,7 @@ use validator::Validate;
 use crate::config::validate;
 use crate::fetch::MAX_FETCH_THREADS;
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Validate)]
 pub struct FetchConfig {
     /// The number of concurrent fetch loops in push mode, which should be ≤ `MAX_FETCH_THREADS` and a power of two.
     #[validate(range(min = 1, max = MAX_FETCH_THREADS), custom(function = "validate::power_of_two"))]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -291,25 +291,33 @@ impl Default for Config {
 impl Config {
     pub fn dump_redacted_yaml(&self) -> Result<String> {
         let mut config = self.clone();
-        let redacted_value = String::from("******");
 
-        config.sentry_dsn = Some(redacted_value.clone());
+        let redacted_value = String::from("******");
+        let redact_optional = |value: &mut Option<String>| {
+            if let Some(value) = value.as_mut() {
+                *value = redacted_value.clone();
+            }
+        };
+
+        // Redact optional strings
+        redact_optional(&mut config.sentry_dsn);
+        redact_optional(&mut config.deprecated.kafka_sasl_password);
+        redact_optional(&mut config.deprecated.kafka_deadletter_sasl_password);
+        redact_optional(&mut config.deprecated.pg_password);
+        redact_optional(&mut config.deprecated.pg_ddl_password);
+
+        for cluster in config.kafka_clusters.values_mut() {
+            redact_optional(&mut cluster.sasl_password);
+        }
+
+        // Redact strings
         config
             .grpc_shared_secret
             .iter_mut()
             .for_each(|s| *s = redacted_value.clone());
 
-        config.deprecated.kafka_sasl_password = Some(redacted_value.clone());
-        config.deprecated.kafka_deadletter_sasl_password = Some(redacted_value.clone());
-        config.deprecated.pg_password = Some(redacted_value.clone());
-        config.deprecated.pg_ddl_password = Some(redacted_value.clone());
-
         config.store.pg.password = redacted_value.clone();
         config.store.pg.ddl_password = redacted_value.clone();
-
-        for cluster in config.kafka_clusters.values_mut() {
-            cluster.sasl_password = Some(redacted_value.clone());
-        }
 
         Ok(serde_yaml::to_string(&config)?)
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -49,7 +49,7 @@ pub enum DeliveryMode {
     Push,
 }
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Validate)]
 pub struct Config {
     /// Deprecated configuration options. Not meant to be used.
     #[serde(flatten)]
@@ -289,6 +289,31 @@ impl Default for Config {
 }
 
 impl Config {
+    pub fn dump_redacted_yaml(&self) -> Result<String> {
+        let mut config = self.clone();
+        let redacted_value = String::from("******");
+
+        config.sentry_dsn = Some(redacted_value.clone());
+        config
+            .grpc_shared_secret
+            .iter_mut()
+            .for_each(|s| *s = redacted_value.clone());
+
+        config.deprecated.kafka_sasl_password = Some(redacted_value.clone());
+        config.deprecated.kafka_deadletter_sasl_password = Some(redacted_value.clone());
+        config.deprecated.pg_password = Some(redacted_value.clone());
+        config.deprecated.pg_ddl_password = Some(redacted_value.clone());
+
+        config.store.pg.password = redacted_value.clone();
+        config.store.pg.ddl_password = redacted_value.clone();
+
+        for cluster in config.kafka_clusters.values_mut() {
+            cluster.sasl_password = Some(redacted_value.clone());
+        }
+
+        Ok(serde_yaml::to_string(&config)?)
+    }
+
     /// Build a config instance from defaults, env vars, file + CLI options
     pub fn from_args(args: &Args) -> Result<Self> {
         let mut builder = Figment::from(Config::default());

--- a/src/config/push.rs
+++ b/src/config/push.rs
@@ -6,7 +6,7 @@ use validator::Validate;
 use crate::config::batch::BatchConfig;
 use crate::config::validate;
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Validate)]
 pub struct PushQueueConfig {
     /// The size of the push queue.
     #[validate(range(min = 1))]
@@ -27,7 +27,7 @@ impl Default for PushQueueConfig {
     }
 }
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Validate)]
 pub struct PushUpdateConfig {
     // Update claimed → processing updates in batches?
     pub batched: bool,
@@ -50,7 +50,7 @@ impl Default for PushUpdateConfig {
     }
 }
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize, Validate)]
 pub struct PushConfig {
     /// The number of concurrent push threads to run.
     #[validate(range(min = 1))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,8 @@ async fn main() -> Result<(), Error> {
     logging::init(logging::LoggingConfig::from_config(&config));
     metrics::init(metrics::MetricsConfig::from_config(&config));
 
+    info!(config = config.dump_redacted_yaml()?, "Configuration");
+
     if args.run == Run::Migrations {
         return config.store.adapter.migrate(&config).await;
     }


### PR DESCRIPTION
## Linear
Refs [STREAM-1278](https://linear.app/getsentry/issue/STREAM-1278/move-taskbroker-config-to-yaml)

## Description
As we transition from environment variables to YAML for configuration, we might make mistakes. Printing the redacted configuration on startup will help us debug these mistakes when they happen.