### PR TITLE
chore(gocd): bump gocd-jsonnet to v3.0.7

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v3.0.4"
+      "version": "v3.0.7"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "7a25c44956933a57b5ca03beb3b70c470724c2c8",
-      "sum": "0S+eGE0WHdxJxKS/Bdga+NB+cB+ZBwF4LoehKv0azXc="
+      "version": "5eac1ffce92df58ea41712ad8c82f55aa628350f",
+      "sum": "V0sY265XbQP5OVTjn8s/ZQdyRQHzndWNJs+wY1zgr8M="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Bumps the `gocd-jsonnet` library from `v3.0.4` to `v3.0.7`.

- Updated `version` in `gocd/templates/jsonnetfile.json`
- Regenerated `gocd/templates/jsonnetfile.lock.json` via `jb update` (new commit hash + sum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)