### PR TITLE
feat(taskbroker): Use Channels for Lazy Push Updates

### DIFF
--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -53,7 +53,16 @@ pub fn compute_claim_duration_ms(config: &Config) -> u64 {
 
     // In the worst case, the tasks in the push queue will take `QUERY_MS` time to update from claimed to processing
     // Since query timeouts aren't actually enforced right now, this is merely an approximation
-    let update_query_ms = rounds * QUERY_MS;
+    let update_query_ms = if config.push.update.batched {
+        let batch_length = config.push.update.batch.length.max(1) as u64;
+
+        // The lazy updater channel is one batch long. If it is full, the next task can
+        // wait behind the query currently in flight, the queued batch, and its own batch
+        let updater_batches = (batch_length + 1).div_ceil(batch_length) + 1;
+        updater_batches * QUERY_MS
+    } else {
+        rounds * QUERY_MS
+    };
 
     // Batched push updates can wait in the updater buffer until either the batch fills or the periodic flush runs
     let batch_delay_ms = if config.push.update.batched {

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -57,9 +57,9 @@ pub fn compute_claim_duration_ms(config: &Config) -> u64 {
         let batch_length = config.push.update.batch.length.max(1) as u64;
 
         // The lazy updater channel is one batch long. If it is full, the next task can
-        // wait behind the query currently in flight, the queued batch, and its own batch
-        let updater_batches = (batch_length + 1).div_ceil(batch_length) + 1;
-        updater_batches * QUERY_MS
+        // wait behind the query currently in flight and the queued batch
+        let queued_updates = batch_length + 1;
+        queued_updates * QUERY_MS
     } else {
         rounds * QUERY_MS
     };

--- a/src/push/updater.rs
+++ b/src/push/updater.rs
@@ -1,15 +1,14 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use chrono::{DateTime, Utc};
 use elegant_departure::get_shutdown_guard;
-use tokio::sync::{Mutex, MutexGuard, Notify, RwLock};
+use flume::{Receiver, Sender};
+use tokio::sync::Notify;
 use tonic::async_trait;
 use tracing::{error, info, warn};
 
 use crate::config::Config;
 use crate::store::traits::ActivationStore;
-use crate::timed;
 
 /// Represents an entity that can update tasks in some way. Meant to abstract away
 /// the update logic, which varies between delivery modes, batching configurations, and so on.
@@ -35,11 +34,11 @@ pub struct LazyUpdater {
     /// The activation store.
     store: Arc<dyn ActivationStore>,
 
-    /// Last time the buffer was flushed.
-    last_flush: Arc<RwLock<DateTime<Utc>>>,
+    /// Sent activation IDs that need to be updated.
+    sender: Sender<String>,
 
-    /// Sent activations that need to be updated.
-    buffer: Arc<Mutex<Vec<String>>>,
+    /// Receives activation IDs for the background updater loop.
+    receiver: Receiver<String>,
 
     /// Signals the background task to stop.
     stop: Notify,
@@ -47,52 +46,31 @@ pub struct LazyUpdater {
 
 impl LazyUpdater {
     pub fn new(config: Arc<Config>, store: Arc<dyn ActivationStore>) -> Self {
-        let buffer = Arc::new(Mutex::new(vec![]));
-        let last_flush = Arc::new(RwLock::new(Utc::now()));
+        let capacity = config
+            .push
+            .queue
+            .size
+            .max(config.push.update.batch.length)
+            .max(config.push.threads);
+        let (sender, receiver) = flume::bounded(capacity);
         let stop = Notify::new();
 
         Self {
             config,
             store,
-            buffer,
-            last_flush,
+            sender,
+            receiver,
             stop,
         }
     }
 
-    async fn lock_buffer(&self, operation: &'static str) -> MutexGuard<'_, Vec<String>> {
-        match self.buffer.try_lock() {
-            Ok(buffer) => {
-                metrics::counter!(
-                    "push.updater.buffer.lock",
-                    "operation" => operation,
-                    "result" => "uncontended"
-                )
-                .increment(1);
-
-                buffer
-            }
-
-            Err(_) => {
-                metrics::counter!(
-                    "push.updater.buffer.lock",
-                    "operation" => operation,
-                    "result" => "contended"
-                )
-                .increment(1);
-
-                timed!(
-                    self.buffer.lock(),
-                    "push.updater.buffer.lock.wait",
-                    "operation" => operation
-                )
-            }
-        }
-    }
-
     /// Flush buffered activations to the store. Empties the buffer on success, refills on failure.
-    async fn flush(&self, buffer: &mut MutexGuard<'_, Vec<String>>) -> Result<()> {
-        let ids: Vec<_> = buffer.drain(..).collect();
+    async fn flush(&self, buffer: &mut Vec<String>) -> Result<()> {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+
+        let ids = std::mem::take(buffer);
         let expected = ids.len() as u64;
 
         match self.store.mark_processing_batch(&ids).await {
@@ -106,10 +84,6 @@ impl LazyUpdater {
 
                 metrics::histogram!("push.updater.flush.expected").record(expected as f64);
                 metrics::histogram!("push.updater.flush.actual").record(actual as f64);
-
-                // Indicate that this is the last time we performed a periodic flush
-                let mut last_flush = self.last_flush.write().await;
-                *last_flush = Utc::now();
 
                 Ok(())
             }
@@ -132,6 +106,8 @@ impl Updater for LazyUpdater {
         // Flush every `interval` milliseconds
         let period = self.config.push.update.batch.interval;
         let mut interval = tokio::time::interval(period);
+        let batch_length = self.config.push.update.batch.length;
+        let mut buffer = Vec::with_capacity(batch_length);
 
         loop {
             tokio::select! {
@@ -140,19 +116,36 @@ impl Updater for LazyUpdater {
                     break;
                 }
 
-                _ = interval.tick(), if self.config.push.update.batched => {
-                    // Lock the ID buffer
-                    let mut buffer = self.lock_buffer("tick").await;
+                received = self.receiver.recv_async() => {
+                    match received {
+                        Ok(id) => {
+                            buffer.push(id);
+                            metrics::gauge!("push.updater.queue.depth").set(self.receiver.len() as f64);
 
-                    // Make sure we aren't flushing too soon
-                    let now = Utc::now().timestamp_millis();
-                    let elapsed = now - self.last_flush.read().await.timestamp_millis();
+                            if buffer.len() >= batch_length {
+                                match self.flush(&mut buffer).await {
+                                    Ok(_) => {
+                                        metrics::counter!("push.updater.flush", "reason" => "full", "result" => "ok")
+                                            .increment(1)
+                                    }
 
-                    if elapsed < (self.config.push.update.batch.interval.as_millis() as i64) {
-                        // Too soon!
-                        continue;
+                                    Err(e) => {
+                                        metrics::counter!("push.updater.flush", "reason" => "full", "result" => "error").increment(1);
+
+                                        error!(
+                                            error = ?e,
+                                            "Failed to flush claimed → processing updates (full buffer)"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+
+                        Err(_) => break,
                     }
+                }
 
+                _ = interval.tick(), if self.config.push.update.batched => {
                     match self.flush(&mut buffer).await {
                         Ok(_) => metrics::counter!("push.updater.flush", "reason" => "tick", "result" => "ok").increment(1),
 
@@ -169,8 +162,10 @@ impl Updater for LazyUpdater {
             }
         }
 
-        // Perform one last flush before exiting
-        let mut buffer = self.lock_buffer("exit").await;
+        // Drain all IDs that arrived before the updater stopped, then perform one last flush.
+        while let Ok(id) = self.receiver.try_recv() {
+            buffer.push(id);
+        }
 
         match self.flush(&mut buffer).await {
             Ok(_) => metrics::counter!("push.updater.flush", "reason" => "exit", "result" => "ok")
@@ -192,31 +187,8 @@ impl Updater for LazyUpdater {
     }
 
     async fn update(&self, id: &str) -> Result<()> {
-        // Lock the ID buffer
-        let mut buffer = self.lock_buffer("update").await;
-
-        if buffer.len() >= self.config.push.update.batch.length {
-            // Flush first
-            match self.flush(&mut buffer).await {
-                Ok(_) => {
-                    metrics::counter!("push.updater.flush", "reason" => "full", "result" => "ok")
-                        .increment(1)
-                }
-
-                Err(e) => {
-                    metrics::counter!("push.updater.flush", "reason" => "full", "result" => "error").increment(1);
-
-                    error!(
-                        error = ?e,
-                        "Failed to flush claimed → processing updates (full buffer)"
-                    );
-
-                    return Err(e);
-                }
-            }
-        }
-
-        buffer.push(id.to_string());
+        self.sender.send_async(id.to_string()).await?;
+        metrics::gauge!("push.updater.queue.depth").set(self.sender.len() as f64);
         Ok(())
     }
 

--- a/src/push/updater.rs
+++ b/src/push/updater.rs
@@ -126,6 +126,8 @@ impl Updater for LazyUpdater {
         let batch_length = self.config.push.update.batch.length;
 
         let mut interval = tokio::time::interval(period);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
         let mut buffer = Vec::with_capacity(batch_length);
 
         loop {
@@ -139,11 +141,20 @@ impl Updater for LazyUpdater {
                     match received {
                         Ok(id) => {
                             buffer.push(id);
-                            metrics::gauge!("push.updater.queue.depth").set(self.receiver.len() as f64);
+
+                            // Drain the entire queue
+                            while buffer.len() < batch_length {
+                                match self.receiver.try_recv() {
+                                    Ok(id) => buffer.push(id),
+                                    Err(_) => break
+                                };
+                            }
 
                             if buffer.len() >= batch_length {
                                 self.flush_with_reason(&mut buffer, "full").await;
                             }
+
+                            metrics::gauge!("push.updater.queue.depth").set(self.receiver.len() as f64);
                         }
 
                         Err(_) => break,

--- a/src/push/updater.rs
+++ b/src/push/updater.rs
@@ -46,13 +46,7 @@ pub struct LazyUpdater {
 
 impl LazyUpdater {
     pub fn new(config: Arc<Config>, store: Arc<dyn ActivationStore>) -> Self {
-        let capacity = config
-            .push
-            .queue
-            .size
-            .max(config.push.update.batch.length)
-            .max(config.push.threads);
-        let (sender, receiver) = flume::bounded(capacity);
+        let (sender, receiver) = flume::bounded(config.push.update.batch.length);
         let stop = Notify::new();
 
         Self {
@@ -95,6 +89,30 @@ impl LazyUpdater {
             }
         }
     }
+
+    async fn flush_with_reason(&self, buffer: &mut Vec<String>, reason: &'static str) -> bool {
+        match self.flush(buffer).await {
+            Ok(_) => {
+                metrics::counter!("push.updater.flush", "reason" => reason, "result" => "ok")
+                    .increment(1);
+
+                true
+            }
+
+            Err(e) => {
+                metrics::counter!("push.updater.flush", "reason" => reason, "result" => "error")
+                    .increment(1);
+
+                error!(
+                    error = ?e,
+                    reason,
+                    "Failed to flush claimed → processing updates"
+                );
+
+                false
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -105,8 +123,9 @@ impl Updater for LazyUpdater {
 
         // Flush every `interval` milliseconds
         let period = self.config.push.update.batch.interval;
-        let mut interval = tokio::time::interval(period);
         let batch_length = self.config.push.update.batch.length;
+
+        let mut interval = tokio::time::interval(period);
         let mut buffer = Vec::with_capacity(batch_length);
 
         loop {
@@ -116,28 +135,14 @@ impl Updater for LazyUpdater {
                     break;
                 }
 
-                received = self.receiver.recv_async() => {
+                received = self.receiver.recv_async(), if buffer.len() < batch_length => {
                     match received {
                         Ok(id) => {
                             buffer.push(id);
                             metrics::gauge!("push.updater.queue.depth").set(self.receiver.len() as f64);
 
                             if buffer.len() >= batch_length {
-                                match self.flush(&mut buffer).await {
-                                    Ok(_) => {
-                                        metrics::counter!("push.updater.flush", "reason" => "full", "result" => "ok")
-                                            .increment(1)
-                                    }
-
-                                    Err(e) => {
-                                        metrics::counter!("push.updater.flush", "reason" => "full", "result" => "error").increment(1);
-
-                                        error!(
-                                            error = ?e,
-                                            "Failed to flush claimed → processing updates (full buffer)"
-                                        );
-                                    }
-                                }
+                                self.flush_with_reason(&mut buffer, "full").await;
                             }
                         }
 
@@ -145,19 +150,8 @@ impl Updater for LazyUpdater {
                     }
                 }
 
-                _ = interval.tick(), if self.config.push.update.batched => {
-                    match self.flush(&mut buffer).await {
-                        Ok(_) => metrics::counter!("push.updater.flush", "reason" => "tick", "result" => "ok").increment(1),
-
-                        Err(e) => {
-                            metrics::counter!("push.updater.flush", "reason" => "tick", "result" => "error").increment(1);
-
-                            error!(
-                                error = ?e,
-                                "Failed to flush claimed → processing updates (tick)"
-                            );
-                        }
-                    }
+                _ = interval.tick() => {
+                    self.flush_with_reason(&mut buffer, "tick").await;
                 }
             }
         }
@@ -167,20 +161,7 @@ impl Updater for LazyUpdater {
             buffer.push(id);
         }
 
-        match self.flush(&mut buffer).await {
-            Ok(_) => metrics::counter!("push.updater.flush", "reason" => "exit", "result" => "ok")
-                .increment(1),
-
-            Err(e) => {
-                metrics::counter!("push.updater.flush", "reason" => "exit", "result" => "error")
-                    .increment(1);
-
-                error!(
-                    error = ?e,
-                    "Failed to flush claimed → processing updates (exit)"
-                );
-            }
-        }
+        self.flush_with_reason(&mut buffer, "exit").await;
 
         drop(guard);
         Ok(())


### PR DESCRIPTION
## Linear
Completes [STREAM-1661](https://linear.app/getsentry/issue/STREAM-1661/use-channels-for-lazy-push-updates-in-taskbroker)

## Description
Right now, the `LazyUpdater` flushes batches synchronously when they are full. This is bad when there are a lot of push threads and they are all trying to update activations at the same time -- push duration explodes.

By using channels under the hood, we can significantly reduce push duration (by several hundred times) without leaking any of that complexity outside the `LazyUpdater`.