### PR TITLE
ref(o11y): Remove custom origin in the streaming trace lifecycle

### DIFF
--- a/clients/python/src/taskbroker_client/sdk.py
+++ b/clients/python/src/taskbroker_client/sdk.py
@@ -28,7 +28,6 @@ def start_transaction(
                 name=name,
                 attributes={
                     "sentry.op": op,
-                    "sentry.origin": origin,
                     **attributes,
                 },
             )
@@ -68,7 +67,6 @@ def start_span(
                 name=name,
                 attributes={
                     "sentry.op": op,
-                    "sentry.origin": origin,
                     **attributes,
                 },
             )


### PR DESCRIPTION
Span description inference based on the span's name is only applied if `origin: manual`.
Stop setting the `sentry.origin` attribute. Taskworker spans can be identified by `messaging.system: taskworker`. 