### PR TITLE
feat(taskbroker): Add Tokio worker-thread utilization metric

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,9 @@
+[build]
+# Exposes Tokio's per-worker runtime metrics (worker_total_busy_duration,
+# worker_local_queue_depth, etc.) via `Handle::metrics()`. These are gated
+# behind the `tokio_unstable` cfg.
+rustflags = ["--cfg", "tokio_unstable"]
+
 [env]
 # Workaround for https://github.com/confluentinc/librdkafka/pull/5012
 CMAKE_POLICY_VERSION_MINIMUM = "3.10"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,9 @@
 # worker_local_queue_depth, etc.) via `Handle::metrics()`. These are gated
 # behind the `tokio_unstable` cfg.
 rustflags = ["--cfg", "tokio_unstable"]
+# Doc-tests are compiled by rustdoc, which reads rustdocflags rather than
+# rustflags; without this they'd miss the cfg above and hit our compile_error!.
+rustdocflags = ["--cfg", "tokio_unstable"]
 
 [env]
 # Workaround for https://github.com/confluentinc/librdkafka/pull/5012

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches: ["main"]
 
 env:
-  RUSTFLAGS: -Dwarnings
+  RUSTFLAGS: -Dwarnings --cfg tokio_unstable
 
 jobs:
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2024"
 [profile.release]
 debug = 1
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+
 [dependencies]
 anyhow = "1.0.92"
 async-backtrace = "0.2"
@@ -43,14 +46,20 @@ sentry = { version = "0.41.0", default-features = false, features = [
     "transport",
     # additional features
     "tracing",
-    "logs"
+    "logs",
 ] }
 sentry_protos = "0.22.0"
 serde = "1.0.214"
 serde_bytes = "0.11"
 serde_yaml = "0.9.34"
 sha2 = "0.10.8"
-sqlx = { version = "0.8.6", features = ["sqlite", "runtime-tokio", "tls-rustls-ring-webpki", "chrono", "postgres"] }
+sqlx = { version = "0.8.6", features = [
+    "sqlite",
+    "runtime-tokio",
+    "tls-rustls-ring-webpki",
+    "chrono",
+    "postgres",
+] }
 tokio = { version = "1.43.1", features = ["full"] }
 tokio-stream = { version = "0.1.16", features = ["full"] }
 tokio-util = "0.7.12"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY ./Cargo.lock ./Cargo.lock
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./migrations ./migrations
 COPY ./benches ./benches
+COPY ./.cargo ./.cargo
 
 # Build dependencies in a way they can be cached
 RUN cargo build --release

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -150,6 +150,11 @@ pub struct Config {
     /// (reclaiming free pages) are executed
     pub maintenance_task_interval_ms: u64,
 
+    /// The frequency (in milliseconds) at which Tokio runtime metrics
+    /// (worker-thread utilization, queue depths) are sampled and emitted.
+    #[validate(range(min = 1))]
+    pub runtime_metrics_interval_ms: u64,
+
     /// The maximum number of seconds a task can be delayed until.
     /// Tasks delayed greater than this duration are capped.
     pub max_delayed_task_allowed_sec: u64,
@@ -268,6 +273,7 @@ impl Default for Config {
             health_check_killswitched: false,
             upkeep_deadline_reset_skip_after_startup_sec: 60,
             maintenance_task_interval_ms: 6000,
+            runtime_metrics_interval_ms: 5000,
             max_delayed_task_allowed_sec: 3600,
             max_message_size: 5000000,
             grpc_max_message_size: 52 * 1024 * 1024, // 52MB

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -150,10 +150,12 @@ pub struct Config {
     /// (reclaiming free pages) are executed
     pub maintenance_task_interval_ms: u64,
 
-    /// The frequency (in milliseconds) at which Tokio runtime metrics
-    /// (worker-thread utilization, queue depths) are sampled and emitted.
-    #[validate(range(min = 1))]
-    pub runtime_metrics_interval_ms: u64,
+    /// The frequency at which Tokio runtime metrics (worker-thread
+    /// utilization, queue depths) are sampled and emitted, e.g. `"1s"` or
+    /// `"500ms"`.
+    #[serde(with = "crate::serde::duration")]
+    #[validate(custom(function = "validate::nonzero_duration"))]
+    pub runtime_metrics_interval: Duration,
 
     /// The maximum number of seconds a task can be delayed until.
     /// Tasks delayed greater than this duration are capped.
@@ -273,7 +275,7 @@ impl Default for Config {
             health_check_killswitched: false,
             upkeep_deadline_reset_skip_after_startup_sec: 60,
             maintenance_task_interval_ms: 6000,
-            runtime_metrics_interval_ms: 5000,
+            runtime_metrics_interval: Duration::from_secs(1),
             max_delayed_task_allowed_sec: 3600,
             max_message_size: 5000000,
             grpc_max_message_size: 52 * 1024 * 1024, // 52MB

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod logging;
 pub mod metrics;
 pub mod push;
 pub mod runtime_config;
+pub mod runtime_metrics;
 pub mod serde;
 pub mod store;
 pub mod test_utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ async fn main() -> Result<(), Error> {
     // Tokio runtime metrics sampler: emits per-broker worker-thread utilization
     // and queue-depth gauges.
     let runtime_metrics_task = taskbroker::tokio::spawn(taskbroker::runtime_metrics::run(
-        Duration::from_millis(config.runtime_metrics_interval_ms),
+        config.runtime_metrics_interval,
     ));
 
     // Consumer(s) from kafka. Each consumed topic gets its own consumer (own

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,12 @@ async fn main() -> Result<(), Error> {
         }
     });
 
+    // Tokio runtime metrics sampler: emits per-broker worker-thread utilization
+    // and queue-depth gauges.
+    let runtime_metrics_task = taskbroker::tokio::spawn(taskbroker::runtime_metrics::run(
+        Duration::from_millis(config.runtime_metrics_interval_ms),
+    ));
+
     // Consumer(s) from kafka. Each consumed topic gets its own consumer (own
     // group.id and cluster), so we spawn one consumer task per consumable topic,
     // all sharing the one activation store.
@@ -378,7 +384,11 @@ async fn main() -> Result<(), Error> {
         .on_signal(SignalKind::hangup())
         .on_signal(SignalKind::quit())
         .on_completion(log_task_completion("upkeep_task", upkeep_task))
-        .on_completion(log_task_completion("maintenance_task", maintenance_task));
+        .on_completion(log_task_completion("maintenance_task", maintenance_task))
+        .on_completion(log_task_completion(
+            "runtime_metrics_task",
+            runtime_metrics_task,
+        ));
 
     for (topic, handle) in consumer_tasks {
         departure =

--- a/src/runtime_metrics.rs
+++ b/src/runtime_metrics.rs
@@ -1,20 +1,38 @@
-use std::time::Duration;
+//! Per-broker Tokio runtime metrics.
+//!
+//! Emits gauges describing how busy the shared Tokio worker pool is, the most
+//! important being `runtime.worker_utilization`: the mean fraction of worker
+//! threads that were actively executing tasks over the last sampling window.
+//!
+//! Tokio exposes `worker_total_busy_duration` as a **monotonic cumulative counter** per worker,
+//! not an instantaneous rate. A single reading is meaningless on its own; to derive
+//! a utilization ratio we remember the previous cumulative total (and when it was taken) and divide
+//! the delta over the window by that window's maximum possible busy time
+//! (`elapsed * num_workers`). [`WorkerBusySampler`] owns that state.
 
-use tokio::runtime::Handle;
+use std::time::{Duration, Instant};
+
+use tokio::runtime::{Handle, RuntimeMetrics};
 use tokio::time::{self, MissedTickBehavior};
+
+#[cfg(not(tokio_unstable))]
+compile_error!(
+    "taskbroker's runtime metrics require the Tokio unstable API; build with \
+     `--cfg tokio_unstable` (see .cargo/config.toml) or set \
+     RUSTFLAGS=\"--cfg tokio_unstable\""
+);
 
 /// Computes the mean worker-thread busy ratio in `[0.0, 1.0]`.
 ///
-/// `busy_delta_secs` is the total busy time accrued across all worker threads
-/// since the previous sample; dividing by `elapsed_secs * num_workers` (the
-/// maximum possible busy time for the whole pool over that window) yields the
-/// fraction of the pool that was busy.
-#[cfg(tokio_unstable)]
-fn utilization_ratio(busy_delta_secs: f64, elapsed_secs: f64, num_workers: usize) -> f64 {
+/// `busy_secs` is the total busy time accrued across all worker threads over
+/// the window; dividing by `elapsed_secs * num_workers` (the maximum possible
+/// busy time for the whole pool over that window) yields the fraction of the
+/// pool that was busy.
+fn utilization_ratio(busy_secs: f64, elapsed_secs: f64, num_workers: usize) -> f64 {
     if elapsed_secs <= 0.0 || num_workers == 0 {
         return 0.0;
     }
-    (busy_delta_secs / (elapsed_secs * num_workers as f64)).clamp(0.0, 1.0)
+    (busy_secs / (elapsed_secs * num_workers as f64)).clamp(0.0, 1.0)
 }
 
 /// Samples the current Tokio runtime's metrics every `interval` and emits them
@@ -26,34 +44,22 @@ pub async fn run(interval: Duration) -> anyhow::Result<()> {
     let mut timer = time::interval(interval);
     timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-    #[cfg(not(tokio_unstable))]
-    tracing::warn!(
-        "Tokio worker utilization metric unavailable: built without `--cfg tokio_unstable`; \
-         emitting stable runtime counts only"
-    );
-
-    #[cfg(tokio_unstable)]
-    let mut sampler = unstable::WorkerBusySampler::new(&runtime_metrics);
+    let mut sampler = WorkerBusySampler::new(&runtime_metrics);
 
     loop {
         tokio::select! {
             _ = timer.tick() => {
-                // Stable metrics (available regardless of `tokio_unstable`).
                 metrics::gauge!("runtime.num_workers")
                     .set(runtime_metrics.num_workers() as f64);
                 metrics::gauge!("runtime.num_alive_tasks")
                     .set(runtime_metrics.num_alive_tasks() as f64);
 
-                // Detailed per-worker metrics (require `tokio_unstable`).
-                #[cfg(tokio_unstable)]
-                {
-                    let sample = sampler.sample(&runtime_metrics);
-                    metrics::gauge!("runtime.worker_utilization").set(sample.utilization);
-                    metrics::gauge!("runtime.global_queue_depth")
-                        .set(sample.global_queue_depth as f64);
-                    metrics::gauge!("runtime.worker_local_queue_depth")
-                        .set(sample.local_queue_depth as f64);
-                }
+                let sample = sampler.sample(&runtime_metrics);
+                metrics::gauge!("runtime.worker_utilization").set(sample.utilization);
+                metrics::gauge!("runtime.global_queue_depth")
+                    .set(sample.global_queue_depth as f64);
+                metrics::gauge!("runtime.worker_local_queue_depth")
+                    .set(sample.local_queue_depth as f64);
             }
             _ = guard.wait() => break,
         }
@@ -62,76 +68,70 @@ pub async fn run(interval: Duration) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(tokio_unstable)]
-mod unstable {
-    use std::time::Instant;
+/// A single sampling result derived from the runtime's per-worker metrics.
+struct Sample {
+    /// Mean worker-thread busy ratio in `[0.0, 1.0]`.
+    utilization: f64,
+    /// Number of tasks queued in the runtime's global (injection) queue.
+    global_queue_depth: usize,
+    /// Total tasks queued across every worker's local run queue.
+    local_queue_depth: usize,
+}
 
-    use tokio::runtime::RuntimeMetrics;
+/// Holds the state needed to turn Tokio's monotonic `worker_total_busy_duration`
+/// counter into a per-window utilization ratio: the previous cumulative busy
+/// total and the instant it was read.
+struct WorkerBusySampler {
+    prev_busy_secs: f64,
+    last_sample: Instant,
+}
 
-    use super::utilization_ratio;
-
-    /// A single sampling result derived from the runtime's per-worker metrics.
-    pub struct Sample {
-        /// Mean worker-thread busy ratio in `[0.0, 1.0]`.
-        pub utilization: f64,
-        /// Number of tasks queued in the runtime's global (injection) queue.
-        pub global_queue_depth: usize,
-        /// Total tasks queued across all workers' local run queues.
-        pub local_queue_depth: usize,
-    }
-
-    /// Tracks the cumulative worker busy duration between samples so that
-    /// utilization can be computed from the delta over the sampling window.
-    pub struct WorkerBusySampler {
-        prev_busy_secs: f64,
-        last_sample: Instant,
-    }
-
-    impl WorkerBusySampler {
-        pub fn new(runtime_metrics: &RuntimeMetrics) -> Self {
-            Self {
-                prev_busy_secs: total_busy_secs(runtime_metrics),
-                last_sample: Instant::now(),
-            }
-        }
-
-        pub fn sample(&mut self, runtime_metrics: &RuntimeMetrics) -> Sample {
-            let now = Instant::now();
-            let busy_secs = total_busy_secs(runtime_metrics);
-            let elapsed_secs = now.duration_since(self.last_sample).as_secs_f64();
-            // `worker_total_busy_duration` is monotonic, but guard against clock
-            // effects / worker count changes producing a negative delta.
-            let busy_delta_secs = (busy_secs - self.prev_busy_secs).max(0.0);
-
-            self.prev_busy_secs = busy_secs;
-            self.last_sample = now;
-
-            let num_workers = runtime_metrics.num_workers();
-            let local_queue_depth = (0..num_workers)
-                .map(|worker| runtime_metrics.worker_local_queue_depth(worker))
-                .sum();
-
-            Sample {
-                utilization: utilization_ratio(busy_delta_secs, elapsed_secs, num_workers),
-                global_queue_depth: runtime_metrics.global_queue_depth(),
-                local_queue_depth,
-            }
+impl WorkerBusySampler {
+    fn new(runtime_metrics: &RuntimeMetrics) -> Self {
+        Self {
+            prev_busy_secs: total_busy_secs(runtime_metrics),
+            last_sample: Instant::now(),
         }
     }
 
-    /// Sums `worker_total_busy_duration` across every worker thread, in seconds.
-    fn total_busy_secs(runtime_metrics: &RuntimeMetrics) -> f64 {
-        (0..runtime_metrics.num_workers())
-            .map(|worker| {
-                runtime_metrics
-                    .worker_total_busy_duration(worker)
-                    .as_secs_f64()
-            })
-            .sum()
+    fn sample(&mut self, runtime_metrics: &RuntimeMetrics) -> Sample {
+        let now = Instant::now();
+        let cumulative_busy_secs = total_busy_secs(runtime_metrics);
+        let elapsed_secs = now.duration_since(self.last_sample).as_secs_f64();
+        // The counter is monotonic, but clamp to guard against clock effects or
+        // a changing worker count producing a negative delta.
+        let busy_delta_secs = (cumulative_busy_secs - self.prev_busy_secs).max(0.0);
+
+        self.prev_busy_secs = cumulative_busy_secs;
+        self.last_sample = now;
+
+        let num_workers = runtime_metrics.num_workers();
+        let local_queue_depth = (0..num_workers)
+            .map(|worker| runtime_metrics.worker_local_queue_depth(worker))
+            .sum();
+
+        Sample {
+            utilization: utilization_ratio(busy_delta_secs, elapsed_secs, num_workers),
+            global_queue_depth: runtime_metrics.global_queue_depth(),
+            local_queue_depth,
+        }
     }
 }
 
-#[cfg(all(test, tokio_unstable))]
+/// Sums each worker's cumulative `worker_total_busy_duration` (a monotonic
+/// counter of time spent executing tasks, never idle/parked) into a single
+/// pool-wide total, in seconds.
+fn total_busy_secs(runtime_metrics: &RuntimeMetrics) -> f64 {
+    (0..runtime_metrics.num_workers())
+        .map(|worker| {
+            runtime_metrics
+                .worker_total_busy_duration(worker)
+                .as_secs_f64()
+        })
+        .sum()
+}
+
+#[cfg(test)]
 mod tests {
     use super::utilization_ratio;
 

--- a/src/runtime_metrics.rs
+++ b/src/runtime_metrics.rs
@@ -1,0 +1,170 @@
+use std::time::Duration;
+
+use tokio::runtime::Handle;
+use tokio::time::{self, MissedTickBehavior};
+
+/// Computes the mean worker-thread busy ratio in `[0.0, 1.0]`.
+///
+/// `busy_delta_secs` is the total busy time accrued across all worker threads
+/// since the previous sample; dividing by `elapsed_secs * num_workers` (the
+/// maximum possible busy time for the whole pool over that window) yields the
+/// fraction of the pool that was busy.
+#[cfg(tokio_unstable)]
+fn utilization_ratio(busy_delta_secs: f64, elapsed_secs: f64, num_workers: usize) -> f64 {
+    if elapsed_secs <= 0.0 || num_workers == 0 {
+        return 0.0;
+    }
+    (busy_delta_secs / (elapsed_secs * num_workers as f64)).clamp(0.0, 1.0)
+}
+
+/// Samples the current Tokio runtime's metrics every `interval` and emits them
+/// to statsd until a shutdown signal is received.
+pub async fn run(interval: Duration) -> anyhow::Result<()> {
+    let guard = elegant_departure::get_shutdown_guard().shutdown_on_drop();
+    let runtime_metrics = Handle::current().metrics();
+
+    let mut timer = time::interval(interval);
+    timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    #[cfg(not(tokio_unstable))]
+    tracing::warn!(
+        "Tokio worker utilization metric unavailable: built without `--cfg tokio_unstable`; \
+         emitting stable runtime counts only"
+    );
+
+    #[cfg(tokio_unstable)]
+    let mut sampler = unstable::WorkerBusySampler::new(&runtime_metrics);
+
+    loop {
+        tokio::select! {
+            _ = timer.tick() => {
+                // Stable metrics (available regardless of `tokio_unstable`).
+                metrics::gauge!("runtime.num_workers")
+                    .set(runtime_metrics.num_workers() as f64);
+                metrics::gauge!("runtime.num_alive_tasks")
+                    .set(runtime_metrics.num_alive_tasks() as f64);
+
+                // Detailed per-worker metrics (require `tokio_unstable`).
+                #[cfg(tokio_unstable)]
+                {
+                    let sample = sampler.sample(&runtime_metrics);
+                    metrics::gauge!("runtime.worker_utilization").set(sample.utilization);
+                    metrics::gauge!("runtime.global_queue_depth")
+                        .set(sample.global_queue_depth as f64);
+                    metrics::gauge!("runtime.worker_local_queue_depth")
+                        .set(sample.local_queue_depth as f64);
+                }
+            }
+            _ = guard.wait() => break,
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(tokio_unstable)]
+mod unstable {
+    use std::time::Instant;
+
+    use tokio::runtime::RuntimeMetrics;
+
+    use super::utilization_ratio;
+
+    /// A single sampling result derived from the runtime's per-worker metrics.
+    pub struct Sample {
+        /// Mean worker-thread busy ratio in `[0.0, 1.0]`.
+        pub utilization: f64,
+        /// Number of tasks queued in the runtime's global (injection) queue.
+        pub global_queue_depth: usize,
+        /// Total tasks queued across all workers' local run queues.
+        pub local_queue_depth: usize,
+    }
+
+    /// Tracks the cumulative worker busy duration between samples so that
+    /// utilization can be computed from the delta over the sampling window.
+    pub struct WorkerBusySampler {
+        prev_busy_secs: f64,
+        last_sample: Instant,
+    }
+
+    impl WorkerBusySampler {
+        pub fn new(runtime_metrics: &RuntimeMetrics) -> Self {
+            Self {
+                prev_busy_secs: total_busy_secs(runtime_metrics),
+                last_sample: Instant::now(),
+            }
+        }
+
+        pub fn sample(&mut self, runtime_metrics: &RuntimeMetrics) -> Sample {
+            let now = Instant::now();
+            let busy_secs = total_busy_secs(runtime_metrics);
+            let elapsed_secs = now.duration_since(self.last_sample).as_secs_f64();
+            // `worker_total_busy_duration` is monotonic, but guard against clock
+            // effects / worker count changes producing a negative delta.
+            let busy_delta_secs = (busy_secs - self.prev_busy_secs).max(0.0);
+
+            self.prev_busy_secs = busy_secs;
+            self.last_sample = now;
+
+            let num_workers = runtime_metrics.num_workers();
+            let local_queue_depth = (0..num_workers)
+                .map(|worker| runtime_metrics.worker_local_queue_depth(worker))
+                .sum();
+
+            Sample {
+                utilization: utilization_ratio(busy_delta_secs, elapsed_secs, num_workers),
+                global_queue_depth: runtime_metrics.global_queue_depth(),
+                local_queue_depth,
+            }
+        }
+    }
+
+    /// Sums `worker_total_busy_duration` across every worker thread, in seconds.
+    fn total_busy_secs(runtime_metrics: &RuntimeMetrics) -> f64 {
+        (0..runtime_metrics.num_workers())
+            .map(|worker| {
+                runtime_metrics
+                    .worker_total_busy_duration(worker)
+                    .as_secs_f64()
+            })
+            .sum()
+    }
+}
+
+#[cfg(all(test, tokio_unstable))]
+mod tests {
+    use super::utilization_ratio;
+
+    #[test]
+    fn utilization_is_busy_over_capacity() {
+        // 4 workers, 2s window => 8s of capacity. 4s busy => 50% utilization.
+        assert_eq!(utilization_ratio(4.0, 2.0, 4), 0.5);
+    }
+
+    #[test]
+    fn utilization_fully_busy() {
+        // Every worker busy the whole window => 100%.
+        assert_eq!(utilization_ratio(16.0, 2.0, 8), 1.0);
+    }
+
+    #[test]
+    fn utilization_clamps_above_one() {
+        // Rounding/measurement skew can push busy slightly over capacity.
+        assert_eq!(utilization_ratio(9.0, 2.0, 4), 1.0);
+    }
+
+    #[test]
+    fn utilization_handles_zero_elapsed() {
+        assert_eq!(utilization_ratio(1.0, 0.0, 4), 0.0);
+    }
+
+    #[test]
+    fn utilization_handles_zero_workers() {
+        assert_eq!(utilization_ratio(1.0, 2.0, 0), 0.0);
+    }
+
+    #[test]
+    fn utilization_idle() {
+        assert_eq!(utilization_ratio(0.0, 2.0, 4), 0.0);
+    }
+}


### PR DESCRIPTION
## Summary

Refs: STREAM-1672.

Adds per-broker Tokio runtime metrics so operators can see how much of the worker-thread pool is actually busy, rather than inferring it from CPU.

Context: in the s4s2 process-segments-push investigation the broker was starved on Tokio worker threads while CPU sat < 1 core, because the push workload is I/O-bound. We currently have no way to see this. This exposes utilization (how much of the pool is in use), not just saturation.

Prior art: Relay emits the same family of Tokio runtime metrics via `tokio::runtime::RuntimeMetrics`.

## Changes
Adds a lightweight sampler that reads `Handle::current().metrics()` on an interval and emits:

| Metric | Type | Meaning |
|---|---|---|
| `runtime.worker_utilization` | gauge (0–1) | mean worker-thread busy ratio (the primary signal) |
| `runtime.global_queue_depth` | gauge | tasks in the runtime's global (injection) queue |
| `runtime.worker_local_queue_depth` | gauge | tasks summed across workers' local run queues |
| `runtime.num_workers` | gauge | worker-thread count |
| `runtime.num_alive_tasks` | gauge | live tasks in the runtime |

This change requires the `tokio_unstable` config. The per-worker fields are only exposed under `--cfg tokio_unstable`, so this PR enables it. It's a compile-time flag which shouldn't have runtime overhead as Tokio collects these counters regardless. It is also the same approach Relay runs
in production.