### PR TITLE
fix(python): Make worker occupancy time-weighted and warm-aware

### DIFF
--- a/clients/python/src/taskbroker_client/worker/worker.py
+++ b/clients/python/src/taskbroker_client/worker/worker.py
@@ -842,13 +842,16 @@ class TaskWorkerProcessingPool:
 
         bounded_busy = max(0, min(busy, self._concurrency))
         occupancy = bounded_busy / self._concurrency if self._concurrency else 0.0
-        self._metrics.gauge(
-            "taskworker.worker.occupancy",
-            occupancy,
-            tags=tags,
-        )
-        if self._prom is not None:
-            self._prom.occupancy.labels(processing_pool=self._processing_pool_name).set(occupancy)
+        if state_counts["running"] > 0:
+            self._metrics.gauge(
+                "taskworker.worker.occupancy",
+                occupancy,
+                tags=tags,
+            )
+            if self._prom is not None:
+                self._prom.occupancy.labels(processing_pool=self._processing_pool_name).set(
+                    occupancy
+                )
 
         # Emit number of children in each state
         for state, count in state_counts.items():

--- a/clients/python/src/taskbroker_client/worker/worker.py
+++ b/clients/python/src/taskbroker_client/worker/worker.py
@@ -156,7 +156,13 @@ class TrackedChild:
     process: BaseProcess
     state: ChildState
     release: Event
-    busy: bool = False
+    # Time-weighted busy tracking. `busy_since` is the monotonic timestamp of the
+    # currently-open busy segment (None while idle); `busy_accumulated` is the busy
+    # seconds banked since the last occupancy flush. Together they let us report the
+    # fraction of the interval a child spent executing, rather than a single
+    # instantaneous busy/idle sample.
+    busy_since: float | None = None
+    busy_accumulated: float = 0.0
 
 
 class PushTaskWorker:
@@ -787,6 +793,8 @@ class TaskWorkerProcessingPool:
         self._children: Dict[UUID, TrackedChild] = {}
         self._exiting_children: Deque[UUID] = deque()
         self._children_lock = threading.Lock()
+        # Start of the interval currently being accumulated for occupancy.
+        self._last_occupancy_flush_at = time.monotonic()
         self._shutdown_event = self._mp_context.Event()
         self._prometheus_port = prometheus_port
         self._prom: WorkerPrometheusMetrics | None = None
@@ -826,7 +834,7 @@ class TaskWorkerProcessingPool:
                 extra={"error": e, "processing_pool": self._processing_pool_name},
             )
 
-        # Count the number of children in each state and waiting for exit
+        now = time.monotonic()
         with self._children_lock:
             state_counts: dict[ChildState, int] = {
                 "pending": 0,
@@ -834,15 +842,25 @@ class TaskWorkerProcessingPool:
                 "exiting": 0,
             }
 
+            busy_time = 0.0
             for child in self._children.values():
                 state_counts[child.state] += 1
 
-            busy = sum(1 for child in self._children.values() if child.busy)
+                if child.busy_since is not None:
+                    child.busy_accumulated += now - child.busy_since
+                    child.busy_since = now
+                busy_time += child.busy_accumulated
+                child.busy_accumulated = 0.0
+
             exiting_children = len(self._exiting_children)
 
-        bounded_busy = max(0, min(busy, self._concurrency))
-        occupancy = bounded_busy / self._concurrency if self._concurrency else 0.0
-        if state_counts["running"] > 0:
+        elapsed = now - self._last_occupancy_flush_at
+        self._last_occupancy_flush_at = now
+
+        running_count = state_counts["running"]
+        if running_count > 0 and elapsed > 0:
+            occupancy = busy_time / (elapsed * running_count)
+            occupancy = max(0.0, min(occupancy, 1.0))
             self._metrics.gauge(
                 "taskworker.worker.occupancy",
                 occupancy,
@@ -852,6 +870,12 @@ class TaskWorkerProcessingPool:
                 self._prom.occupancy.labels(processing_pool=self._processing_pool_name).set(
                     occupancy
                 )
+
+        self._metrics.gauge(
+            "taskworker.worker.concurrency",
+            float(self._concurrency),
+            tags=tags,
+        )
 
         # Emit number of children in each state
         for state, count in state_counts.items():
@@ -1020,13 +1044,19 @@ class TaskWorkerProcessingPool:
                         elif message.event == "exiting":
                             self._exiting_children.append(message.child_id)
 
-                        # This child is executing a task
+                        # This child started executing a task: open a busy segment.
+                        # Guard against duplicate "busy" so we don't lose the
+                        # original start time.
                         elif message.event == "busy":
-                            child.busy = True
+                            if child.busy_since is None:
+                                child.busy_since = time.monotonic()
 
-                        # This child isn't doing anything right now
+                        # This child finished a task: close the open busy segment
+                        # and bank the elapsed time. Guard against a stray "idle".
                         elif message.event == "idle":
-                            child.busy = False
+                            if child.busy_since is not None:
+                                child.busy_accumulated += time.monotonic() - child.busy_since
+                                child.busy_since = None
 
                     while True:
                         # Compute how many children are still running

--- a/clients/python/src/taskbroker_client/worker/worker.py
+++ b/clients/python/src/taskbroker_client/worker/worker.py
@@ -160,6 +160,40 @@ class TrackedChild:
     busy_since: float | None = None  # monotonic timestamp of the currently-open busy segment
     busy_accumulated: float = 0.0  # the busy seconds banked since the last occupancy flush
 
+    def mark_busy(self, now: float) -> None:
+        """Open a busy segment when the child starts a task.
+
+        `busy`/`idle` strictly alternate per child today, so a segment should
+        never already be open; the guard is defensive and keeps the original
+        start time if that invariant ever drifts.
+        """
+        if self.busy_since is None:
+            self.busy_since = now
+
+    def mark_idle(self, now: float) -> None:
+        """Close the open busy segment and bank its elapsed seconds.
+
+        Guarded so an unexpected `idle` with no open segment is a no-op rather
+        than a crash.
+        """
+        if self.busy_since is not None:
+            self.busy_accumulated += now - self.busy_since
+            self.busy_since = None
+
+    def drain_busy(self, now: float) -> float:
+        """Return busy seconds since the last drain and reset the counter.
+
+        Any segment still open is folded in up to `now` and left open (its
+        start advanced to `now`) so a task spanning multiple intervals keeps
+        contributing to each one.
+        """
+        if self.busy_since is not None:
+            self.busy_accumulated += now - self.busy_since
+            self.busy_since = now
+        banked = self.busy_accumulated
+        self.busy_accumulated = 0.0
+        return banked
+
 
 class PushTaskWorker:
     _mp_context: ForkContext | SpawnContext | ForkServerContext
@@ -841,12 +875,7 @@ class TaskWorkerProcessingPool:
             busy_time = 0.0
             for child in self._children.values():
                 state_counts[child.state] += 1
-
-                if child.busy_since is not None:
-                    child.busy_accumulated += now - child.busy_since
-                    child.busy_since = now
-                busy_time += child.busy_accumulated
-                child.busy_accumulated = 0.0
+                busy_time += child.drain_busy(now)
 
             exiting_children = len(self._exiting_children)
 
@@ -856,7 +885,7 @@ class TaskWorkerProcessingPool:
         running_count = state_counts["running"]
         if running_count > 0 and elapsed > 0:
             occupancy = busy_time / (elapsed * running_count)
-            occupancy = max(0.0, min(occupancy, 1.0))
+            occupancy = min(occupancy, 1.0)
             self._metrics.gauge(
                 "taskworker.worker.occupancy",
                 occupancy,
@@ -1041,18 +1070,13 @@ class TaskWorkerProcessingPool:
                             self._exiting_children.append(message.child_id)
 
                         # This child started executing a task: open a busy segment.
-                        # Guard against duplicate "busy" so we don't lose the
-                        # original start time.
                         elif message.event == "busy":
-                            if child.busy_since is None:
-                                child.busy_since = time.monotonic()
+                            child.mark_busy(time.monotonic())
 
                         # This child finished a task: close the open busy segment
-                        # and bank the elapsed time. Guard against a stray "idle".
+                        # and bank the elapsed time.
                         elif message.event == "idle":
-                            if child.busy_since is not None:
-                                child.busy_accumulated += time.monotonic() - child.busy_since
-                                child.busy_since = None
+                            child.mark_idle(time.monotonic())
 
                     while True:
                         # Compute how many children are still running

--- a/clients/python/src/taskbroker_client/worker/worker.py
+++ b/clients/python/src/taskbroker_client/worker/worker.py
@@ -156,13 +156,9 @@ class TrackedChild:
     process: BaseProcess
     state: ChildState
     release: Event
-    # Time-weighted busy tracking. `busy_since` is the monotonic timestamp of the
-    # currently-open busy segment (None while idle); `busy_accumulated` is the busy
-    # seconds banked since the last occupancy flush. Together they let us report the
-    # fraction of the interval a child spent executing, rather than a single
-    # instantaneous busy/idle sample.
-    busy_since: float | None = None
-    busy_accumulated: float = 0.0
+    # Time-weighted busy tracking
+    busy_since: float | None = None  # monotonic timestamp of the currently-open busy segment
+    busy_accumulated: float = 0.0  # the busy seconds banked since the last occupancy flush
 
 
 class PushTaskWorker:
@@ -793,7 +789,6 @@ class TaskWorkerProcessingPool:
         self._children: Dict[UUID, TrackedChild] = {}
         self._exiting_children: Deque[UUID] = deque()
         self._children_lock = threading.Lock()
-        # Start of the interval currently being accumulated for occupancy.
         self._last_occupancy_flush_at = time.monotonic()
         self._shutdown_event = self._mp_context.Event()
         self._prometheus_port = prometheus_port
@@ -834,6 +829,7 @@ class TaskWorkerProcessingPool:
                 extra={"error": e, "processing_pool": self._processing_pool_name},
             )
 
+        # Calculate time-weighted occupancy.
         now = time.monotonic()
         with self._children_lock:
             state_counts: dict[ChildState, int] = {

--- a/clients/python/src/taskbroker_client/worker/worker.py
+++ b/clients/python/src/taskbroker_client/worker/worker.py
@@ -863,9 +863,8 @@ class TaskWorkerProcessingPool:
                 extra={"error": e, "processing_pool": self._processing_pool_name},
             )
 
-        # Calculate time-weighted occupancy.
-        now = time.monotonic()
         with self._children_lock:
+            now = time.monotonic()
             state_counts: dict[ChildState, int] = {
                 "pending": 0,
                 "running": 0,

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -871,12 +871,18 @@ def test_start_does_not_serve_when_shutdown_during_warmup() -> None:
     fake_server.wait_for_termination.assert_not_called()
 
 
-def _make_tracked_child(state: str, busy: bool) -> TrackedChild:
+def _make_tracked_child(
+    state: str,
+    *,
+    busy_since: float | None = None,
+    busy_accumulated: float = 0.0,
+) -> TrackedChild:
     return TrackedChild(
         process=mock.Mock(),
         state=state,  # type: ignore[arg-type]
         release=mock.Mock(),
-        busy=busy,
+        busy_since=busy_since,
+        busy_accumulated=busy_accumulated,
     )
 
 
@@ -890,8 +896,8 @@ def test_emit_periodic_metrics_skips_occupancy_during_warmup() -> None:
 
     # A freshly started pod has only pending children; none are consuming yet.
     with pool._children_lock:
-        pool._children[uuid4()] = _make_tracked_child("pending", busy=False)
-        pool._children[uuid4()] = _make_tracked_child("pending", busy=False)
+        pool._children[uuid4()] = _make_tracked_child("pending")
+        pool._children[uuid4()] = _make_tracked_child("pending")
 
     pool._emit_periodic_metrics()
 
@@ -900,25 +906,110 @@ def test_emit_periodic_metrics_skips_occupancy_during_warmup() -> None:
     assert _gauge_calls(pool._metrics, "taskworker.worker.occupancy") == []
     # Other gauges still fire so warmup stays observable.
     assert _gauge_calls(pool._metrics, "taskworker.worker.children")
+    # Concurrency is static and emitted even before any child is warm.
+    concurrency_calls = _gauge_calls(pool._metrics, "taskworker.worker.concurrency")
+    assert len(concurrency_calls) == 1
+    assert concurrency_calls[0].args[1] == pytest.approx(4.0)
 
 
-def test_emit_periodic_metrics_reports_occupancy_once_warm() -> None:
-    pool = _make_result_thread_pool(_SendResultCapture(), concurrency=4)
+def test_emit_periodic_metrics_time_weights_busy_over_the_interval() -> None:
+    # Worked example: interval [10.0, 11.0], 3 running children.
+    #   A: 0.19s banked, idle at flush
+    #   B: 0.30s banked + open segment since 10.70 -> +0.30 across the boundary
+    #   C: 0.45s banked, idle at flush
+    # busy_time = 0.19 + 0.60 + 0.45 = 1.24 -> occupancy = 1.24 / (1.0 * 3)
+    pool = _make_result_thread_pool(_SendResultCapture(), concurrency=8)
     pool._metrics = mock.Mock()
+    pool._last_occupancy_flush_at = 10.0
 
+    child_b = uuid4()
     with pool._children_lock:
-        pool._children[uuid4()] = _make_tracked_child("running", busy=True)
-        pool._children[uuid4()] = _make_tracked_child("running", busy=True)
-        pool._children[uuid4()] = _make_tracked_child("running", busy=False)
-        # A still-warming child does not block reporting for the warm ones.
-        pool._children[uuid4()] = _make_tracked_child("pending", busy=False)
+        pool._children[uuid4()] = _make_tracked_child("running", busy_accumulated=0.19)
+        pool._children[child_b] = _make_tracked_child(
+            "running", busy_accumulated=0.30, busy_since=10.70
+        )
+        pool._children[uuid4()] = _make_tracked_child("running", busy_accumulated=0.45)
 
-    pool._emit_periodic_metrics()
+    with mock.patch("taskbroker_client.worker.worker.time.monotonic", return_value=11.0):
+        pool._emit_periodic_metrics()
 
     occupancy_calls = _gauge_calls(pool._metrics, "taskworker.worker.occupancy")
     assert len(occupancy_calls) == 1
-    # 2 busy children over the configured concurrency of 4.
-    assert occupancy_calls[0].args[1] == pytest.approx(0.5)
+    assert occupancy_calls[0].args[1] == pytest.approx(1.24 / 3)
+
+    # The open segment is carried into the next interval; banks are drained.
+    assert pool._children[child_b].busy_since == pytest.approx(11.0)
+    for child in pool._children.values():
+        assert child.busy_accumulated == 0.0
+    assert pool._last_occupancy_flush_at == pytest.approx(11.0)
+
+
+def test_emit_periodic_metrics_divides_by_running_children() -> None:
+    # Two children busy for the whole 1s interval, one idle, one still warming.
+    pool = _make_result_thread_pool(_SendResultCapture(), concurrency=8)
+    pool._metrics = mock.Mock()
+    pool._last_occupancy_flush_at = 10.0
+
+    with pool._children_lock:
+        pool._children[uuid4()] = _make_tracked_child("running", busy_accumulated=1.0)
+        pool._children[uuid4()] = _make_tracked_child("running", busy_accumulated=1.0)
+        pool._children[uuid4()] = _make_tracked_child("running", busy_accumulated=0.0)
+        # Excluded from both numerator and denominator.
+        pool._children[uuid4()] = _make_tracked_child("pending")
+
+    with mock.patch("taskbroker_client.worker.worker.time.monotonic", return_value=11.0):
+        pool._emit_periodic_metrics()
+
+    occupancy_calls = _gauge_calls(pool._metrics, "taskworker.worker.occupancy")
+    assert len(occupancy_calls) == 1
+    # 2 busy-child-seconds over 3 running slots for a 1s interval.
+    assert occupancy_calls[0].args[1] == pytest.approx(2 / 3)
+
+
+def test_emit_periodic_metrics_clamps_occupancy_to_one() -> None:
+    # A draining child can still be mid-task, so busy-time can exceed the running
+    # capacity for the interval; occupancy must clamp to 1.0.
+    pool = _make_result_thread_pool(_SendResultCapture(), concurrency=4)
+    pool._metrics = mock.Mock()
+    pool._last_occupancy_flush_at = 10.0
+
+    with pool._children_lock:
+        pool._children[uuid4()] = _make_tracked_child("running", busy_accumulated=1.0)
+        pool._children[uuid4()] = _make_tracked_child("exiting", busy_accumulated=1.0)
+
+    with mock.patch("taskbroker_client.worker.worker.time.monotonic", return_value=11.0):
+        pool._emit_periodic_metrics()
+
+    occupancy_calls = _gauge_calls(pool._metrics, "taskworker.worker.occupancy")
+    assert len(occupancy_calls) == 1
+    assert occupancy_calls[0].args[1] == pytest.approx(1.0)
+
+
+def test_spawn_children_tracks_busy_and_idle_transitions() -> None:
+    fake_context = _FakeContext()
+    pool = _make_fake_context_pool(fake_context, concurrency=1)
+
+    pool.start_spawn_children_thread()
+    try:
+        _wait_for(lambda: len(fake_context.processes) == 1)
+        messages = fake_context.queues[-1]
+        child_id = fake_context.processes[0].args[0]
+
+        messages.put(ChildMessage(child_id, "running"))
+        _wait_for(lambda: pool.ready_count == 1)
+
+        # "busy" opens a segment.
+        messages.put(ChildMessage(child_id, "busy"))
+        _wait_for(lambda: pool._children[child_id].busy_since is not None)
+
+        # "idle" closes it and banks a positive amount of busy-time.
+        messages.put(ChildMessage(child_id, "idle"))
+        _wait_for(
+            lambda: pool._children[child_id].busy_since is None
+            and pool._children[child_id].busy_accumulated > 0
+        )
+    finally:
+        pool.shutdown()
 
 
 def test_spawn_children_counts_pending_children_toward_concurrency() -> None:

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -47,6 +47,7 @@ from taskbroker_client.worker.worker import (
     PushTaskWorker,
     TaskWorker,
     TaskWorkerProcessingPool,
+    TrackedChild,
     WorkerServicer,
 )
 from taskbroker_client.worker.workerchild import ChildMessage
@@ -868,6 +869,56 @@ def test_start_does_not_serve_when_shutdown_during_warmup() -> None:
     assert serving_calls == []
     # We never reached server.wait_for_termination() (returned before it).
     fake_server.wait_for_termination.assert_not_called()
+
+
+def _make_tracked_child(state: str, busy: bool) -> TrackedChild:
+    return TrackedChild(
+        process=mock.Mock(),
+        state=state,  # type: ignore[arg-type]
+        release=mock.Mock(),
+        busy=busy,
+    )
+
+
+def _gauge_calls(metrics: mock.Mock, name: str) -> list[Any]:
+    return [c for c in metrics.gauge.call_args_list if c.args[0] == name]
+
+
+def test_emit_periodic_metrics_skips_occupancy_during_warmup() -> None:
+    pool = _make_result_thread_pool(_SendResultCapture(), concurrency=4)
+    pool._metrics = mock.Mock()
+
+    # A freshly started pod has only pending children; none are consuming yet.
+    with pool._children_lock:
+        pool._children[uuid4()] = _make_tracked_child("pending", busy=False)
+        pool._children[uuid4()] = _make_tracked_child("pending", busy=False)
+
+    pool._emit_periodic_metrics()
+
+    # Occupancy must not be emitted while warming up, otherwise fresh pods
+    # publish misleading zeros that drag down the fleet-wide average.
+    assert _gauge_calls(pool._metrics, "taskworker.worker.occupancy") == []
+    # Other gauges still fire so warmup stays observable.
+    assert _gauge_calls(pool._metrics, "taskworker.worker.children")
+
+
+def test_emit_periodic_metrics_reports_occupancy_once_warm() -> None:
+    pool = _make_result_thread_pool(_SendResultCapture(), concurrency=4)
+    pool._metrics = mock.Mock()
+
+    with pool._children_lock:
+        pool._children[uuid4()] = _make_tracked_child("running", busy=True)
+        pool._children[uuid4()] = _make_tracked_child("running", busy=True)
+        pool._children[uuid4()] = _make_tracked_child("running", busy=False)
+        # A still-warming child does not block reporting for the warm ones.
+        pool._children[uuid4()] = _make_tracked_child("pending", busy=False)
+
+    pool._emit_periodic_metrics()
+
+    occupancy_calls = _gauge_calls(pool._metrics, "taskworker.worker.occupancy")
+    assert len(occupancy_calls) == 1
+    # 2 busy children over the configured concurrency of 4.
+    assert occupancy_calls[0].args[1] == pytest.approx(0.5)
 
 
 def test_spawn_children_counts_pending_children_toward_concurrency() -> None:


### PR DESCRIPTION
Refs: STREAM-1680

The `taskworker.worker.occupancy` under-reported real utilization, especially during rollouts, it stayed low even when workers were saturated and a large backlog was draining.

Changes:
1. Time-weighted busy threads: Started tracking busy time  instead of a boolean.  Each flush sums busy-seconds per child, closing any open segment at the interval boundary and reopening it, so tasks longer than the interval keep contributing. Occupancy is now `busy_time / (elapsed * running_children)`, the time-weighted average of concurrently-busy children over available capacity.
2. Warm-gated emission: Occupancy is only emitted once at least one child is `running`, so warming pods no longer publish zeros when warming.
3. running denominator: Divides by warmed-up children rather than target concurrency.

Testing
- Unit tests, see `test_worker.py`.
- Verified locally end-to-end: broker + push worker with `--prometheus-port`. Test produced `examples` task load and scraped `taskworker_worker_occupancy`. Occupancy tracks expected fractions.

