### PR TITLE
fix(postgres): Skip Locks on Batch Push Update

### DIFF
--- a/src/store/adapters/postgres.rs
+++ b/src/store/adapters/postgres.rs
@@ -633,11 +633,17 @@ impl ActivationStore for PostgresStore {
                     .await?;
 
                 let result = sqlx::query(&format!(
-                    "UPDATE inflight_taskactivations SET
+                    "WITH selected AS (
+                        SELECT id FROM inflight_taskactivations
+                        WHERE id = $2 AND status = $3
+                        FOR UPDATE SKIP LOCKED
+                    )
+                    UPDATE inflight_taskactivations SET
                         status = $1,
                         processing_deadline = now() + (processing_deadline_duration * interval '1 second') + (interval '{grace_period} seconds'),
                         claim_expires_at = NULL
-                    WHERE id = $2 AND status = $3",
+                    FROM selected
+                    WHERE inflight_taskactivations.id = selected.id",
                 ))
                 .bind(ActivationStatus::Processing.to_string())
                 .bind(id)
@@ -681,11 +687,17 @@ impl ActivationStore for PostgresStore {
                     .await?;
 
                 let result = sqlx::query(&format!(
-                    "UPDATE inflight_taskactivations SET
+                    "WITH selected AS (
+                        SELECT id FROM inflight_taskactivations
+                        WHERE id = ANY($2) AND status = $3
+                        FOR UPDATE SKIP LOCKED
+                    )
+                    UPDATE inflight_taskactivations SET
                         status = $1,
                         processing_deadline = now() + (processing_deadline_duration * interval '1 second') + (interval '{grace_period} seconds'),
                         claim_expires_at = NULL
-                    WHERE id = ANY($2) AND status = $3",
+                    FROM selected
+                    WHERE inflight_taskactivations.id = selected.id",
                 ))
                 .bind(ActivationStatus::Processing.to_string())
                 .bind(ids)


### PR DESCRIPTION
For some workloads, we see a low rate of deadlock errors from Postgres. I looked into it and found that this is caused by push queries fighting delete queries for the same locks. The "push query" updates a batch of activations that have already been sent from "claimed" to "processing," while the delete query deletes a batch of successfully completed activations.

When the activations are sufficiently fast, they are completed around the same time as the push update batch is sent. As a result, they compete to lock the same rows.

I have found that this doesn't _significantly_ degrade performance, but it's worth fixing anyways. I have done that by changing the push update query to skip locked rows. This should be okay, and I don't think it will result in dropped data - if a record is already being deleted, there's no point in updating its status to "processing" anymore.