### PR TITLE
fix(worker): keep pull worker healthy while queue is full

### DIFF
--- a/clients/python/src/taskbroker_client/worker/client.py
+++ b/clients/python/src/taskbroker_client/worker/client.py
@@ -328,6 +328,9 @@ class TaskbrokerClient:
             )
             self._timestamp_since_touch = cur_time
 
+    def emit_health_check(self) -> None:
+        self._emit_health_check()
+
     def _connect_to_host(self, host: str) -> ConsumerServiceStub:
         logger.info("taskworker.client.connect", extra={"host": host})
         channel = grpc.insecure_channel(host, options=self._grpc_options)

--- a/clients/python/src/taskbroker_client/worker/client.py
+++ b/clients/python/src/taskbroker_client/worker/client.py
@@ -309,7 +309,7 @@ class TaskbrokerClient:
         self._timestamp_since_touch_lock = threading.Lock()
         self._timestamp_since_touch = 0.0
 
-    def _emit_health_check(self) -> None:
+    def emit_health_check(self) -> None:
         if self._health_check_settings is None:
             return
 
@@ -327,9 +327,6 @@ class TaskbrokerClient:
                 tags={"processing_pool": self._processing_pool_name},
             )
             self._timestamp_since_touch = cur_time
-
-    def emit_health_check(self) -> None:
-        self._emit_health_check()
 
     def _connect_to_host(self, host: str) -> ConsumerServiceStub:
         logger.info("taskworker.client.connect", extra={"host": host})
@@ -406,7 +403,7 @@ class TaskbrokerClient:
         If a namespace is provided, only tasks for that namespace will be fetched.
         This will return None if there are no tasks to fetch.
         """
-        self._emit_health_check()
+        self.emit_health_check()
 
         request = GetTaskRequest(application=self._application, namespace=namespace)
         try:
@@ -458,7 +455,7 @@ class TaskbrokerClient:
 
         The return value is the next task that should be executed.
         """
-        self._emit_health_check()
+        self.emit_health_check()
         if fetch_next_task is not None:
             fetch_next_task.application = self._application
 

--- a/clients/python/src/taskbroker_client/worker/worker.py
+++ b/clients/python/src/taskbroker_client/worker/worker.py
@@ -656,6 +656,7 @@ class TaskWorker:
 
     def run_once(self) -> None:
         """Access point for tests to run a single worker loop"""
+        self.client.emit_health_check()
         self._add_task()
 
     def _add_task(self) -> bool:

--- a/clients/python/src/taskbroker_client/worker/worker.py
+++ b/clients/python/src/taskbroker_client/worker/worker.py
@@ -656,7 +656,6 @@ class TaskWorker:
 
     def run_once(self) -> None:
         """Access point for tests to run a single worker loop"""
-        self.client.emit_health_check()
         self._add_task()
 
     def _add_task(self) -> bool:
@@ -664,6 +663,7 @@ class TaskWorker:
         Add a task to child tasks queue. Returns False if no new task was fetched.
         """
         if self.worker_pool.is_worker_full():
+            self.client.emit_health_check()
             self._metrics.incr(
                 "taskworker.worker.add_tasks.child_tasks_full",
                 tags={"processing_pool": self._processing_pool_name},

--- a/clients/python/tests/worker/test_worker.py
+++ b/clients/python/tests/worker/test_worker.py
@@ -723,6 +723,35 @@ class TestTaskWorker(TestCase):
         self.assertEqual(taskworker._grpc_port, 50099)
 
 
+def test_pull_worker_health_check_touches_while_full(tmp_path: Path) -> None:
+    health_check_path = tmp_path / "health"
+    taskworker = TaskWorker(
+        app_module="examples.app:app",
+        broker_hosts=["127.0.0.1:50051"],
+        max_child_task_count=100,
+        process_type="fork",
+        health_check_file_path=str(health_check_path),
+        health_check_sec_per_touch=1,
+    )
+
+    with (
+        mock.patch.object(taskworker.worker_pool, "is_worker_full", return_value=True),
+        mock.patch.object(taskworker.client, "get_task") as mock_get_task,
+        mock.patch("taskbroker_client.worker.worker.time.sleep"),
+        mock.patch("taskbroker_client.worker.client.time") as mock_time,
+    ):
+        mock_time.time.return_value = 1
+        taskworker.run_once()
+        assert health_check_path.exists()
+
+        health_check_path.unlink()
+        mock_time.time.return_value = 3
+        taskworker.run_once()
+
+    assert health_check_path.exists()
+    mock_get_task.assert_not_called()
+
+
 def test_push_worker_health_check_touches_while_idle(tmp_path: Path) -> None:
     taskworker = PushTaskWorker(
         app_module="examples.app:app",


### PR DESCRIPTION
We have seen failed CI runs on [getsentry/self-hosted](https://github.com/getsentry/self-hosted) many times like this:
https://github.com/getsentry/self-hosted/actions/runs/31588205812/job/94086843852?pr=4462

Some have been related to `taskbroker` being unhealthy, the reason is `taskbroker` do not mark the service healthy when its queue is full, even though worker is ready and receive tasks, when it's get long, `taskbroker` becomes unhealthy, hence the flaky CI jobs in self-hosted, this may be the intended behaviour though, I'm not sure.

This PR changes the behaviour and updates healthcheck file whenever `worker` tries to receive a task even though queue is full.