### PR TITLE
fix(ci): Do not publish PR docker image on forks

### DIFF
--- a/.github/workflows/python-example-image.yml
+++ b/.github/workflows/python-example-image.yml
@@ -26,7 +26,7 @@ jobs:
           dockerfile_path: './clients/python/Dockerfile.example'
           dockerfile_context: './clients/python'
           ghcr: true
-          publish_on_pr: true
+          publish_on_pr: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           google_ar: false
           tag_nightly: false
           tag_latest: false


### PR DESCRIPTION
Right now CI fails with when PR has been created from a fork with this error:

```
  #21 ERROR: failed to push ghcr.io/getsentry/taskbroker-python-example:d7a8d7e7d88433686927fd661375e6f558ea1381: denied: installation not allowed to Write organization package
```

This change keeps publishing docker images for PRs getting opened from `getsentry/taskbroker` itself, while ignoring publishing on forks.