### PR TITLE
fix(ci): Fix build_context arg

### DIFF
--- a/.github/workflows/python-example-image.yml
+++ b/.github/workflows/python-example-image.yml
@@ -24,7 +24,7 @@ jobs:
           image_name: 'taskbroker-python-example'
           platforms: linux/amd64
           dockerfile_path: './clients/python/Dockerfile.example'
-          dockerfile_context: './clients/python'
+          build_context: './clients/python'
           ghcr: true
           publish_on_pr: true
           google_ar: false


### PR DESCRIPTION
https://github.com/getsentry/taskbroker/actions/runs/31592976952/job/94485841860?pr=779#step:3:1
```
Warning: Unexpected input(s) 'dockerfile_context', valid inputs are ['image_name', 'dockerfile_path', 'build_context', 'build_target', 'build_args', 'ghcr', 'ghcr_image_name', 'publish_on_pr', 'google_ar', 'google_ar_image_name', 'tags', 'tag_prefix', 'tag_suffix', 'google_workload_identity_provider', 'google_service_account', 'platforms', 'outputs', 'tag_latest', 'tag_nightly']
```

There is no `dockerfile_context` in https://github.com/getsentry/action-build-and-push-images/blob/main/action.yml#L15, it gets ignored and by default build_context is `.` and does not build `./clients/python` which is intended.

https://github.com/getsentry/taskbroker/actions/runs/31592976952/job/94485841860?pr=779#step:3:13
```
    build_context: .
```