### PR TITLE
fix(ci): skip upstream-only workflow operations on forks

### DIFF
--- a/.github/workflows/fast-revert.yml
+++ b/.github/workflows/fast-revert.yml
@@ -14,7 +14,8 @@ jobs:
   revert:
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'workflow_dispatch' || github.event.label.name == 'Trigger: Revert'
+      github.repository == 'getsentry/taskbroker' &&
+      (github.event_name == 'workflow_dispatch' || github.event.label.name == 'Trigger: Revert')
     steps:
       - name: Get auth token
         id: token

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -28,7 +28,7 @@ jobs:
           platforms: linux/${{ matrix.platform }}
           dockerfile_path: './Dockerfile'
           build_args: TASKBROKER_GIT_REVISION=${{ github.sha }}
-          ghcr: true
+          ghcr: ${{ github.repository == 'getsentry/taskbroker' }}
           tag_suffix: -${{ matrix.platform }}
           publish_on_pr: ${{ github.event.pull_request.author_association == 'OWNER' || github.event.pull_request.author_association == 'MEMBER' }}
           google_ar: false
@@ -38,7 +38,7 @@ jobs:
   assemble-taskbroker-image:
     runs-on: ubuntu-latest
     needs: [build]
-    if: ${{ (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) && github.event_name != 'pull_request' }}
+    if: ${{ github.repository == 'getsentry/taskbroker' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) && github.event_name != 'pull_request' }}
     permissions:
       contents: read
       packages: write
@@ -62,7 +62,7 @@ jobs:
 
   build-production:
     runs-on: ubuntu-24.04
-    if: github.ref_name == github.event.repository.default_branch
+    if: ${{ github.repository == 'getsentry/taskbroker' && github.ref_name == github.event.repository.default_branch }}
     name: Build and push production images to ${{ matrix.registry }} registry
     strategy:
       matrix:
@@ -93,6 +93,7 @@ jobs:
           google_service_account: gha-taskbroker-push@sac-prod-sa.iam.gserviceaccount.com
 
   self-hosted-end-to-end:
+    if: ${{ github.repository == 'getsentry/taskbroker' }}
     needs: [assemble-taskbroker-image]
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/python-example-image.yml
+++ b/.github/workflows/python-example-image.yml
@@ -25,7 +25,7 @@ jobs:
           platforms: linux/amd64
           dockerfile_path: './clients/python/Dockerfile.example'
           build_context: './clients/python'
-          ghcr: true
+          ghcr: ${{ github.repository == 'getsentry/taskbroker' }}
           publish_on_pr: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           google_ar: false
           tag_nightly: false

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ github.repository == 'getsentry/taskbroker' }}
     runs-on: ubuntu-latest
     steps:
       - name: Get auth token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ github.repository == 'getsentry/taskbroker' }}
     runs-on: ubuntu-latest
     name: "Release a new taskbroker version"
     steps:


### PR DESCRIPTION
I faced [this](https://github.com/aminvakil/taskbroker/actions/runs/31728694656) after rebasing main and pushing to my own fork, so opened this.

~Please tell me if "privileged" is not a good term here and I should change my PR title.~

Changed.