### PR TITLE
feat(taskworker): Add child fetch wait duration metric

### DIFF
--- a/clients/python/src/taskbroker_client/worker/workerchild.py
+++ b/clients/python/src/taskbroker_client/worker/workerchild.py
@@ -408,14 +408,32 @@ def child_process(
                     local_shutdown.set()
                     break
 
+            fetch_wait_start = time.monotonic()
             try:
                 inflight = child_tasks.get(timeout=1.0)
             except queue.Empty:
+                metrics.distribution(
+                    "taskworker.worker.child.fetch_wait_duration",
+                    time.monotonic() - fetch_wait_start,
+                    tags={
+                        "processing_pool": processing_pool_name,
+                        "outcome": "empty",
+                    },
+                )
                 metrics.incr(
                     "taskworker.worker.child_task_queue_empty",
                     tags={"processing_pool": processing_pool_name},
                 )
                 continue
+
+            metrics.distribution(
+                "taskworker.worker.child.fetch_wait_duration",
+                time.monotonic() - fetch_wait_start,
+                tags={
+                    "processing_pool": processing_pool_name,
+                    "outcome": "task",
+                },
+            )
 
             # Open the busy segment as soon as we have a task. The slot is now
             # unavailable for new work, whatever stage of handling it is in.


### PR DESCRIPTION
Description

Adds `taskworker.worker.child.fetch_wait_duration` distribution metric of how long each child blocks in `child_tasks.get()` waiting for work.

**Question we'd like to answer:**
When a child is idle, is it because the parent has nothing to give it, or because it can't get at work that's already sitting in the queue?

In `process-segments-push` (s4s2), children are idle ~55% of the time while `child_tasks.size` averages 8.97. A `get()` on a queue that deep should return in quickly. We can't currently tell which of those is wrong.

Existing metrics don't answer it. `child_task_queue_empty` only fires after a full 1s timeout, so it counts famines and misses the normal case. Occupancy gives the aggregate but not the shape, and the shape is what identifies the cause:

| Signature | Cause |
|---|---|
| Long waits while `child_tasks.size` > 0 | `_rlock` contention, children serializing on one queue lock |
| Long waits only while size == 0 | Supply-limited upstream of the parent |

That distinction decides how to update the autoscaling metric