### PR TITLE
chore: migrate fast revert to GitHub app token action

### DIFF
--- a/.github/workflows/fast-revert.yml
+++ b/.github/workflows/fast-revert.yml
@@ -20,8 +20,8 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.GETSENTRY_FAST_REVERT_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.GETSENTRY_FAST_REVERT_BOT_PRIVATE_KEY }}
+          client-id: ${{ vars.FAST_REVERT_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FAST_REVERT_PRIVATE_KEY }}
 
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:

--- a/.github/workflows/fast-revert.yml
+++ b/.github/workflows/fast-revert.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: Get auth token
         id: token
-        uses: getsentry/action-github-app-token@v3.0.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app_id: ${{ vars.FAST_REVERT_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FAST_REVERT_PRIVATE_KEY }}
+          client-id: ${{ vars.GETSENTRY_FAST_REVERT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.GETSENTRY_FAST_REVERT_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:


### PR DESCRIPTION
Update fast-revert workflow to use the official actions/create-github-app-token action with the shared fast-revert bot credentials.

---

## Related PRs (migration off `getsentry/action-github-app-token`)

Tracking issue: https://github.com/getsentry/action-github-app-token/issues/104

- [getsentry/devinfra-coder-infra#111](https://github.com/getsentry/devinfra-coder-infra/pull/111)
- [getsentry/devinfra-deployment-service#945](https://github.com/getsentry/devinfra-deployment-service/pull/945)
- [getsentry/eng-pipes#1046](https://github.com/getsentry/eng-pipes/pull/1046)
- [getsentry/getsentry#21704](https://github.com/getsentry/getsentry/pull/21704)
- [getsentry/getsentry#22098](https://github.com/getsentry/getsentry/pull/22098)
- [getsentry/ops#23138](https://github.com/getsentry/ops/pull/23138)
- [getsentry/ops#23656](https://github.com/getsentry/ops/pull/23656)
- [getsentry/ops-sandbox#18](https://github.com/getsentry/ops-sandbox/pull/18)
- [getsentry/scm-platform#134](https://github.com/getsentry/scm-platform/pull/134)
- [getsentry/security-socket-firewall#26](https://github.com/getsentry/security-socket-firewall/pull/26)
- [getsentry/seer#7963](https://github.com/getsentry/seer/pull/7963)
- [getsentry/seer#8334](https://github.com/getsentry/seer/pull/8334)
- [getsentry/self-hosted#4497](https://github.com/getsentry/self-hosted/pull/4497)
- [getsentry/sentry#123034](https://github.com/getsentry/sentry/pull/123034)
- [getsentry/sentry#125064](https://github.com/getsentry/sentry/pull/125064)
- [getsentry/sentry-docs#19537](https://github.com/getsentry/sentry-docs/pull/19537)
- [getsentry/sentry-informer#366](https://github.com/getsentry/sentry-informer/pull/366)
- [getsentry/sentry-kafka-schemas#503](https://github.com/getsentry/sentry-kafka-schemas/pull/503)
- [getsentry/sentry-options-automator#9457](https://github.com/getsentry/sentry-options-automator/pull/9457)
- [getsentry/sentry-options-automator#9824](https://github.com/getsentry/sentry-options-automator/pull/9824)
- [getsentry/service-registry#152](https://github.com/getsentry/service-registry/pull/152)
- [getsentry/snuba#8417](https://github.com/getsentry/snuba/pull/8417)
- [getsentry/snuba#8487](https://github.com/getsentry/snuba/pull/8487)
- [getsentry/static-sites#4822](https://github.com/getsentry/static-sites/pull/4822)
- [getsentry/super-big-consumers#536](https://github.com/getsentry/super-big-consumers/pull/536)
- [getsentry/taskbroker#789](https://github.com/getsentry/taskbroker/pull/789)
- [getsentry/terraform-modules#911](https://github.com/getsentry/terraform-modules/pull/911)
- [getsentry/uptime-checker#513](https://github.com/getsentry/uptime-checker/pull/513)
- [getsentry/uptime-checker#517](https://github.com/getsentry/uptime-checker/pull/517)
